### PR TITLE
docs: adopt marketplace-centric distribution strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ properly structured extensions that follow best practices.
 ## 30-Second Demo
 
 ```bash
-# Install the plugin
-/plugin install oakensoul/aida-core-plugin
+# Add AIDA marketplace (one-time setup)
+/plugin marketplace add oakensoul/aida-marketplace
+
+# Install the core plugin
+/plugin install core@aida
 
 # Configure AIDA (auto-detects your environment)
 /aida config
@@ -49,19 +52,25 @@ properly structured extensions that follow best practices.
 
 ## Quick Start
 
-### Step 1: Install
+### Step 1: Add Marketplace
 
 ```bash
-/plugin install oakensoul/aida-core-plugin
+/plugin marketplace add oakensoul/aida-marketplace
 ```
 
-### Step 2: Configure
+### Step 2: Install
+
+```bash
+/plugin install core@aida
+```
+
+### Step 3: Configure
 
 ```bash
 /aida config
 ```
 
-### Step 3: Verify
+### Step 4: Verify
 
 ```bash
 /aida status

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -19,13 +19,21 @@ Before installing AIDA, ensure you have:
 
 ## Installation
 
-### Step 1: Install the Plugin
+### Step 1: Add AIDA Marketplace
 
 ```bash
-/plugin install oakensoul/aida-core-plugin
+/plugin marketplace add oakensoul/aida-marketplace
 ```
 
-### Step 2: Run Initial Setup
+This is a one-time setup that adds the AIDA plugin registry to your Claude Code.
+
+### Step 2: Install Core Plugin
+
+```bash
+/plugin install core@aida
+```
+
+### Step 3: Run Initial Setup
 
 ```bash
 /aida config

--- a/docs/USER_GUIDE_INSTALL.md
+++ b/docs/USER_GUIDE_INSTALL.md
@@ -83,18 +83,36 @@ git --version
 
 ## Installation Steps
 
-### Step 1: Install the Plugin
+### Step 1: Add AIDA Marketplace
 
-Open Claude Code and install the plugin:
+Open Claude Code and add the AIDA marketplace (one-time setup):
 
 ```bash
-/plugin install oakensoul/aida-core-plugin
+/plugin marketplace add oakensoul/aida-marketplace
 ```
 
 **Expected output:**
 
 ```text
-Installing plugin from oakensoul/aida-core-plugin...
+Adding marketplace oakensoul/aida-marketplace...
+✓ Fetched marketplace registry
+✓ Added marketplace "aida"
+
+Available plugins: core
+```
+
+### Step 2: Install Core Plugin
+
+Install the core AIDA plugin:
+
+```bash
+/plugin install core@aida
+```
+
+**Expected output:**
+
+```text
+Installing plugin core@aida...
 ✓ Downloaded plugin files
 ✓ Verified plugin structure
 ✓ Installed aida-core
@@ -105,7 +123,7 @@ Run /aida config to set up your personal preferences.
 
 **Time required**: ~30 seconds
 
-### Step 2: Run Installation Wizard
+### Step 3: Run Installation Wizard
 
 Launch the installation wizard:
 

--- a/docs/architecture/adr/008-marketplace-centric-distribution.md
+++ b/docs/architecture/adr/008-marketplace-centric-distribution.md
@@ -1,0 +1,334 @@
+---
+type: adr
+title: "ADR-008: Marketplace-Centric Distribution"
+status: accepted
+date: "2025-01-21"
+deciders:
+  - "@oakensoul"
+---
+
+# ADR-008: Marketplace-Centric Distribution
+
+## Context
+
+AIDA plugins need a distribution strategy that addresses:
+
+- How users discover and install plugins
+- How plugin versions are managed
+- Where feedback and issues are centralized
+- How plugins relate to each other (dependencies, compatibility)
+
+Distribution options:
+
+1. **Direct GitHub**: Users install from individual GitHub repos
+2. **Marketplace-Centric**: Central registry with short names and versioning
+3. **Package Manager**: Publish to npm, PyPI, or similar
+4. **Hybrid**: Support multiple installation methods
+
+## Decision
+
+Use a **Marketplace-Centric** distribution model where:
+
+1. **`aida-marketplace`** is the central registry for all AIDA plugins
+2. Users install plugins using short names: `/plugin install core@aida`
+3. All feedback/issues go to the `aida-marketplace` repository
+4. Plugin repos contain source code; marketplace provides discovery and versioning
+
+### Installation Flow
+
+```bash
+# One-time: Add the AIDA marketplace
+/plugin marketplace add oakensoul/aida-marketplace
+
+# Install plugins by short name
+/plugin install core@aida
+```
+
+### Naming Convention
+
+| Component                    | Name                           |
+| ---------------------------- | ------------------------------ |
+| Marketplace repo             | `oakensoul/aida-marketplace`   |
+| Marketplace name             | `aida`                         |
+| Core plugin (in marketplace) | `core`                         |
+| Core plugin repo             | `oakensoul/aida-core-plugin`   |
+| Install command              | `/plugin install core@aida`    |
+
+## Rationale
+
+### Why Marketplace-Centric?
+
+#### 1. Discoverability
+
+- Single place to find all AIDA plugins
+- Curated list with descriptions and tags
+- Future: Search, categories, popularity metrics
+
+#### 2. Simplified Installation
+
+- Short, memorable names: `core@aida` vs `oakensoul/aida-core-plugin`
+- Consistent pattern for all plugins
+- No need to remember GitHub paths
+
+#### 3. Centralized Versioning
+
+- Marketplace tracks compatible versions
+- Can enforce version constraints between plugins
+- Single source of truth for "latest stable"
+
+#### 4. Unified Feedback
+
+- All issues in one repository
+- Cross-plugin issues easier to track
+- Community builds in one place
+- Maintainer doesn't need to monitor multiple repos
+
+#### 5. Built-in Claude Support
+
+- Marketplace can include CLAUDE.md with plugin-specific instructions
+- Consistent onboarding experience
+- Plugin-specific context automatically loaded
+
+#### 6. Future Extensibility
+
+- Plugin dependencies
+- Compatibility matrices
+- Automated testing across plugin combinations
+- Community contributions
+
+### Why Not Direct GitHub?
+
+**Against:**
+
+- Verbose installation: `/plugin install oakensoul/aida-core-plugin`
+- No central discovery
+- Version management per-repo
+- Issues scattered across repos
+- No namespace/branding
+
+**When to Use:**
+
+- Development/testing: Install from local path or branch
+- Fallback: If marketplace is unavailable
+
+### Why Not Package Managers (npm, PyPI)?
+
+**Against:**
+
+- AIDA plugins are Claude Code extensions, not traditional packages
+- Would require separate tooling
+- Doesn't integrate with Claude Code's plugin system
+- Overkill for markdown/config files
+
+## Consequences
+
+### Positive
+
+- Simpler user experience with short names
+- Central place for discovery and feedback
+- Consistent versioning across plugins
+- Clear branding (`@aida` namespace)
+- Easier to maintain (single issues repo)
+- Built-in onboarding via marketplace CLAUDE.md
+
+### Negative
+
+- Extra step: Must add marketplace first
+- Marketplace repo must be maintained
+- Version sync between marketplace.json and plugin repos
+- Single point of failure (if marketplace repo is down)
+
+### Mitigation
+
+**Extra Step:**
+
+- Document clearly in all plugin READMEs
+- One-time setup, then forgotten
+- Could automate in future
+
+**Maintenance Burden:**
+
+- Automated version checking (GitHub Actions)
+- Clear contribution guidelines
+- Semantic versioning for compatibility
+
+**Version Sync:**
+
+- CI to validate marketplace.json versions match plugin repos
+- Release automation to update marketplace on plugin release
+
+**Single Point of Failure:**
+
+- Direct GitHub install as documented fallback
+- Marketplace is just a JSON file, very stable
+
+## Implementation
+
+### Marketplace Structure
+
+```text
+aida-marketplace/
+├── .claude-plugin/
+│   └── marketplace.json    # Plugin registry
+├── README.md               # User-facing docs
+├── CLAUDE.md               # Claude context for marketplace
+└── docs/
+    └── ...                 # Plugin documentation
+```
+
+### marketplace.json Format
+
+```json
+{
+  "name": "aida",
+  "description": "AIDA plugins for Claude Code",
+  "owner": {
+    "name": "oakensoul",
+    "email": "...",
+    "url": "https://github.com/oakensoul"
+  },
+  "plugins": [
+    {
+      "name": "core",
+      "source": {
+        "type": "github",
+        "repo": "oakensoul/aida-core-plugin"
+      },
+      "description": "Core AIDA functionality",
+      "version": "0.5.0",
+      "tags": ["core", "essential"]
+    }
+  ]
+}
+```
+
+### Plugin Repo Requirements
+
+Each plugin repo must have:
+
+- `.claude-plugin/plugin.json` - Plugin manifest
+- `README.md` - Documentation
+- `CLAUDE.md` - Claude context (optional but recommended)
+
+### Feedback Flow
+
+All user feedback goes to `oakensoul/aida-marketplace`:
+
+- Bug reports
+- Feature requests
+- General feedback
+- Cross-plugin issues
+
+Individual plugin repos are for:
+
+- Source code
+- Plugin-specific development
+- Releases/tags
+
+## Alternatives Considered
+
+### Alternative 1: Direct GitHub Only
+
+**Approach:** Users install directly from GitHub repos
+
+**Pros:**
+
+- Simpler architecture (no marketplace)
+- One less repo to maintain
+
+**Cons:**
+
+- Poor discoverability
+- Verbose install commands
+- No central versioning
+- Scattered issues
+
+**Verdict:** Doesn't scale, poor UX
+
+### Alternative 2: Hybrid (Marketplace + Direct)
+
+**Approach:** Support both equally
+
+**Pros:**
+
+- Flexibility for users
+- Fallback options
+
+**Cons:**
+
+- Documentation complexity
+- Two "blessed" paths confuse users
+- Version drift between methods
+
+**Verdict:** Marketplace primary, direct as undocumented fallback only
+
+### Alternative 3: Monorepo
+
+**Approach:** All plugins in one repository
+
+**Pros:**
+
+- Single repo to manage
+- Atomic cross-plugin changes
+- Simpler versioning
+
+**Cons:**
+
+- Doesn't scale with many plugins
+- All-or-nothing releases
+- Large repo size
+- Harder for community contributions
+
+**Verdict:** Separate repos with marketplace registry is more flexible
+
+## Related Decisions
+
+- [ADR-001: Skills-First Architecture](001-skills-first-architecture.md)
+- [ADR-005: Local-First Storage](005-local-first-storage.md)
+- [ADR-006: gh CLI for Feedback](006-gh-cli-feedback.md)
+
+## Future Considerations
+
+### Plugin Dependencies
+
+Marketplace could track dependencies:
+
+```json
+{
+  "name": "workflows",
+  "requires": ["core@>=0.5.0"]
+}
+```
+
+### Compatibility Matrix
+
+Track which plugin versions work together:
+
+```json
+{
+  "compatibility": {
+    "core@0.5.x": ["workflows@0.2.x"]
+  }
+}
+```
+
+### Community Plugins
+
+Allow third-party plugins in marketplace:
+
+- Submission process
+- Review/approval workflow
+- Verified publisher badges
+
+### Automated Releases
+
+GitHub Actions to:
+
+- Bump marketplace.json when plugin releases
+- Validate version compatibility
+- Run cross-plugin tests
+
+---
+
+**Decision Record:** @oakensoul, 2025-01-21
+**Status:** Accepted

--- a/docs/architecture/c4/container-diagram.md
+++ b/docs/architecture/c4/container-diagram.md
@@ -623,7 +623,11 @@ Exit with appropriate code
 ### Installation
 
 ```bash
-/plugin install oakensoul/aida-core-plugin
+# Add AIDA marketplace (one-time)
+/plugin marketplace add oakensoul/aida-marketplace
+
+# Install core plugin
+/plugin install core@aida
 ```
 
 ### Updates


### PR DESCRIPTION
## Summary

- Add ADR-008 documenting marketplace-centric distribution for AIDA plugins
- Update all installation docs to use `/plugin install core@aida` pattern
- Establishes `aida-marketplace` as the canonical installation source

## Changes

### New ADR-008: Marketplace-Centric Distribution
Documents the decision to use marketplace-centric distribution with:
- Central registry at `oakensoul/aida-marketplace`
- Short plugin names (`core@aida` instead of `oakensoul/aida-core-plugin`)
- Centralized feedback/issues in marketplace repo

### Updated Installation Flow
All docs now show:
```bash
# One-time setup
/plugin marketplace add oakensoul/aida-marketplace

# Install plugin
/plugin install core@aida
```

## Files Changed
- `docs/architecture/adr/008-marketplace-centric-distribution.md` (new)
- `README.md` - Updated demo and quick start
- `docs/GETTING_STARTED.md` - Updated installation steps
- `docs/USER_GUIDE_INSTALL.md` - Updated installation guide
- `docs/architecture/c4/container-diagram.md` - Updated deployment

## Related
- GitHub Issue: https://github.com/oakensoul/aida-marketplace/issues/6 (marketplace sync work)

## Test Plan
- [x] All 273 tests pass
- [x] Linting passes (ruff, yamllint, markdownlint, frontmatter)
- [ ] Manual test: Installation flow works after marketplace is updated