### PR TITLE
Add Edit, Write, and NotebookEdit to project permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,9 @@
 {
   "permissions": {
     "allow": [
+      "Edit",
+      "Write",
+      "NotebookEdit",
       "Bash(make:*)",
       "Bash(pytest:*)",
       "Bash(python:*)",


### PR DESCRIPTION
## Summary

- Add `Edit`, `Write`, and `NotebookEdit` to the `allow` list in `.claude/settings.json`
- Eliminates permission prompts for file editing operations, especially for subagents in delegate mode

Resolves #8

## Test plan

- [ ] Verify subagents no longer prompt for Edit/Write permissions in delegate mode
- [ ] Confirm existing Bash permissions still work as expected