### PR TITLE
feat: add /aida plugin update for standards migration

### DIFF
--- a/.issues/in-progress/issue-27/README.md
+++ b/.issues/in-progress/issue-27/README.md
@@ -1,0 +1,67 @@
+---
+type: issue
+issue: 27
+title: "Plugin upgrade: /aida plugin update should migrate existing plugins to current standards"
+status: "In Progress"
+branch: "milestone-v1.0/feature/27-plugin-update"
+worktree: "issue-27-plugin-update"
+started: "2026-02-24"
+created: "2026-02-16"
+github_url: "https://github.com/oakensoul/aida-core-plugin/issues/27"
+assignee: "@me"
+---
+
+# Issue #27: Plugin upgrade - /aida plugin update
+
+**Status**: In Progress
+**Labels**: (none)
+**Milestone**: 1.0.0
+**Assignees**: oakensoul
+
+## Description
+
+Add `/aida plugin update` as a standards migration tool for existing
+plugins. As AIDA plugin standards evolve (new linting configs, updated
+Makefile targets, CI workflows, new required files), existing plugins
+fall behind with no automated way to catch up.
+
+### Key Design Principles
+
+- **Detect-and-patch**, not generate-from-scratch
+- Respect custom content in CLAUDE.md, README.md, aida-config.json
+- Non-destructive patching of boilerplate (Makefile, .gitignore,
+  linting configs, CI)
+- Version-aware migrations (apply delta between scaffolded version
+  and current standards)
+- Merge strategy similar to package managers (overwrite, skip, merge)
+
+### Proposed Behavior
+
+1. Scan current plugin directory against latest scaffolding standards
+2. Identify gaps: missing files, outdated configs, deprecated patterns
+3. Generate diff report (current vs needs attention)
+4. Offer to patch non-destructively:
+   - Add missing files
+   - Merge new Makefile targets
+   - Update CI workflows
+   - Preserve custom content
+5. Handle version-aware migrations (e.g., v0.7 -> v0.9 delta)
+6. Produce summary of changes made and manual steps remaining
+
+## Work Tracking
+
+- Branch: `milestone-v1.0/feature/27-plugin-update`
+- Worktree: `issue-27-plugin-update`
+- Started: 2026-02-24
+- Work directory: `.issues/in-progress/issue-27/`
+
+## Related Links
+
+- [GitHub Issue](https://github.com/oakensoul/aida-core-plugin/issues/27)
+- Issue #23 / PR #30 - Plugin scaffolding (defines the standards)
+- Issue #31 / PR #32 - Decomposition (plugin-manager owns this)
+
+## Notes
+
+This feature lives in `skills/plugin-manager/` as a new operation
+alongside scaffold, create, validate, version, and list.

--- a/.issues/in-progress/issue-27/workplan.md
+++ b/.issues/in-progress/issue-27/workplan.md
@@ -1,0 +1,950 @@
+---
+type: workplan
+issue: 27
+title: "Workplan: /aida plugin update"
+date: 2026-02-24
+reviewers:
+  - system-architect
+  - claude-code-expert
+  - product-manager
+  - tech-lead
+status: draft
+---
+
+# Workplan: /aida plugin update (Issue #27)
+
+## Executive Summary
+
+This workplan defines the implementation of `/aida plugin update`, a
+standards migration tool that brings existing plugins into compliance
+with the current scaffolding templates. As AIDA plugin standards evolve
+(new linting configs, updated Makefile targets, CI workflows, required
+files), plugins scaffolded under older versions fall behind with no
+automated way to catch up. The update operation closes that gap by
+scanning a plugin against the latest templates, producing a categorized
+diff report, and applying non-destructive patches with user approval.
+
+The design follows the project's established two-phase API pattern: Phase
+1 scans the plugin and returns a read-only diff report with questions
+about merge strategy preferences; Phase 2 applies the approved patches.
+This mirrors the existing scaffold operation's architecture while keeping
+implementation fully decoupled. Templates are the shared source of truth
+between scaffold and update -- both consume them independently, and no
+code coupling is introduced between the two modules.
+
+The implementation is structured as a new `operations/update.py` module
+with an `update_ops/` subpackage containing scanner, differ, patcher,
+and strategy modules. The file classification system uses four categories
+(custom/skip, boilerplate/overwrite, composite/merge, missing/add) with
+sensible defaults that minimize user decisions while preserving safety.
+Backups are created before any modification, and all writes use atomic
+file operations. The estimated effort is 6-8 person-days across 11
+implementation tasks.
+
+## Architecture Decisions
+
+1. **New module, not an extension of scaffold.py.** The update operation
+   gets its own `operations/update.py` entry point and `update_ops/`
+   subpackage, following the same structural pattern as
+   `scaffold.py` / `scaffold_ops/`. This keeps responsibilities clean
+   and avoids bloating scaffold with comparison logic. (All reviewers
+   agreed.)
+
+2. **Templates are a shared contract, not shared code.** Both scaffold
+   and update independently consume the Jinja2 templates in
+   `templates/scaffold/`. The update operation renders templates to
+   produce "expected" content, then compares against actual files. No
+   code is shared between scaffold and update beyond the template
+   files themselves and the `render_template` utility from
+   `shared/utils.py`. (System Architect, Claude Code Expert.)
+
+3. **`GENERATOR_VERSION` extracted to shared constant.** The version
+   string currently lives in `scaffold.py` line 72. It will be moved
+   to a new `operations/constants.py` file so both scaffold and update
+   can reference the canonical version without importing each other.
+   (System Architect.)
+
+4. **Template variable construction extracted to shared helper.** The
+   `variables` dict built in `scaffold.py:execute()` (lines 391-433)
+   will be extracted into a `build_template_variables()` function in a
+   new `operations/shared.py` module. Update needs the same variables
+   to render templates for comparison. (System Architect, Tech Lead.)
+
+5. **`generator_version` tracked in `aida-config.json`.** The version
+   of the scaffolder that created (or last updated) the plugin is
+   stored in `.claude-plugin/aida-config.json` under a new
+   `"generator_version"` key. This avoids polluting `plugin.json`
+   (which is Claude Code's schema) with AIDA-specific metadata. The
+   scaffold operation will be updated to write this field. (Claude
+   Code Expert, System Architect, Product Manager -- Tech Lead
+   initially proposed `plugin.json` but deferred to consensus.)
+
+6. **Four-category file classification with fixed defaults.** Files
+   are classified into categories with default strategies that minimize
+   user decisions. See the File Classification table below. (All
+   reviewers agreed on categories; strategies reflect resolved
+   disagreements.)
+
+7. **Phase 1 is read-only; Phase 2 is user-approved patch.** Phase 1
+   performs a full scan and returns the diff report inside the
+   `inferred` payload (matching the existing response shape). Phase 2
+   re-scans to confirm state, then applies patches per the approved
+   strategy. (All reviewers.)
+
+8. **Backup before modification.** Before any file is modified, the
+   entire plugin directory is backed up to `.aida-backup/{timestamp}/`.
+   This location is visible and not nested inside `.claude-plugin/`.
+   (System Architect -- Tech Lead initially proposed
+   `.claude-plugin/.update-backup/` but the more visible location was
+   preferred.)
+
+9. **Atomic file writes.** All file writes go to a `.tmp` sibling
+   first, then are renamed into place. This prevents partial writes
+   from corrupting files on failure. (Tech Lead.)
+
+10. **Conservative Makefile merge for v1.0.** The Makefile merge
+    strategy adds missing targets only; it does not modify existing
+    targets. Sentinel comment markers in templates are planned for v1.1
+    to enable section-level diffing. (Tech Lead for v1.0 approach;
+    Claude Code Expert for v1.1 sentinel design.)
+
+11. **CI workflows: add-if-missing, skip-if-exists.** CI workflow files
+    (`.github/workflows/ci.yml`) are added only if the file does not
+    exist. Existing CI files are never modified because they are too
+    diverse to auto-merge safely. (Product Manager, Tech Lead.)
+
+12. **Dependency files flagged for manual review.** `pyproject.toml` and
+    `package.json` are never auto-merged. The diff report flags them
+    with a "manual review recommended" note listing specific
+    differences. (System Architect.)
+
+## File Classification and Merge Strategies
+
+| Category | Strategy | Files | Rationale | User Override? |
+| --- | --- | --- | --- | --- |
+| **Custom content** | `skip` | `CLAUDE.md`, `README.md`, `LICENSE` | User-authored content; never override | No |
+| **AIDA metadata** | `skip` | `.claude-plugin/aida-config.json` | User-configured preferences/permissions | No |
+| **Pure boilerplate** | `overwrite` | `.markdownlint.json`, `.yamllint.yml`, `.frontmatter-schema.json`, `.python-version`, `.nvmrc`, `.prettierrc.json`, `eslint.config.mjs`, `tsconfig.json`, `vitest.config.ts` | Entirely template-generated; safe to replace | Yes (can override to `skip`) |
+| **Plugin metadata** | `overwrite` | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` | Schema-driven, safe to regenerate (preserves user values) | Yes (can override to `skip`) |
+| **Composite: gitignore** | `merge` | `.gitignore` | Append-only: add missing entries, never remove | No |
+| **Composite: makefile** | `merge` | `Makefile` | Add missing targets only; never modify existing | No |
+| **CI workflows** | `add` | `.github/workflows/ci.yml` | Add if missing; skip if exists | Yes (can override to `skip`) |
+| **Dependency configs** | `manual_review` | `pyproject.toml`, `package.json` | Too risky to auto-merge; flag differences | No |
+| **Test scaffolding** | `add` | `tests/conftest.py` | Add if missing; skip if exists | Yes (can override to `skip`) |
+| **New additions** | `add` | Any template file not in plugin | Added if file does not exist | Yes (can override to `skip`) |
+
+## Scope: v1.0 MVP
+
+### In Scope
+
+- P0: Full plugin scan with categorized diff report (Phase 1)
+- P0: Add missing files from templates
+- P0: Append-only `.gitignore` merge (add missing entries)
+- P0: Conservative Makefile merge (add missing targets)
+- P0: Overwrite pure boilerplate linting configs
+- P0: Post-update summary with manual steps remaining
+- P0: Two-phase workflow matching existing API pattern
+- P0: Language detection from existing plugin structure
+- P0: Backup before any modification
+- P0: `generator_version` tracking in `aida-config.json`
+- P0: Update SKILL.md with update operation documentation
+- P0: Reference document `update-workflow.md`
+- P1: Single strategy override question for boilerplate class
+- P1: Dirty git tree warning (advisory, non-blocking)
+- P1: Plugin metadata regeneration preserving user values
+
+### Out of Scope (Deferred)
+
+- Per-file interactive accept/skip (v1.1)
+- Inline diff preview for modified files (v1.1)
+- Sentinel comment markers in Makefile templates (v1.1)
+- `--dry-run` CLI flag (Phase 1 already serves this purpose)
+- "outdated" indicator in `plugin list` output (v1.1)
+- Multi-language detection (v1.1)
+- Batch update across multiple plugins (v1.1)
+- Git auto-commit after update (v1.1)
+- Remote/installed plugin update support (v2.0)
+- Migration scripts for complex version jumps (v2.0)
+- Version delta maps / changelog-driven migrations (v2.0)
+- Backup retention policy / auto-cleanup (v1.1)
+
+## Implementation Tasks
+
+### Task 1: Extract shared constants and template variable builder
+
+**Description:** Move `GENERATOR_VERSION` from `scaffold.py` into a new
+`operations/constants.py`. Extract the template variable construction
+logic from `scaffold.py:execute()` (lines 362-433) into a
+`build_template_variables()` function in a new `operations/shared.py`.
+Update `scaffold.py` to import from both new modules. All existing
+scaffold tests must continue to pass.
+
+**Files to create:**
+
+- `skills/plugin-manager/scripts/operations/constants.py`
+- `skills/plugin-manager/scripts/operations/shared.py`
+
+**Files to modify:**
+
+- `skills/plugin-manager/scripts/operations/scaffold.py`
+  (remove `GENERATOR_VERSION` definition, import from `constants`;
+  replace inline variable building with call to
+  `build_template_variables()`)
+
+**Dependencies:** None (foundational task).
+
+**Size:** S
+
+**Key implementation notes:**
+
+- `constants.py` contains only `GENERATOR_VERSION = "0.9.0"` and
+  `SUPPORTED_LANGUAGES = ("python", "typescript")` (both currently
+  in scaffold.py).
+- `build_template_variables(context, license_text)` returns the
+  `dict[str, Any]` currently built inline. It takes the full context
+  dict and the resolved license text as inputs.
+- `shared.py` imports from `constants.py` and from `scaffold_ops`
+  helpers (like `_normalize_python_version`) as needed.
+- Do NOT move `SCAFFOLD_TEMPLATES_DIR` or other path constants --
+  those stay in their respective modules.
+- Run `make test` to confirm no regressions.
+
+---
+
+### Task 2: Add `generator_version` to `aida-config.json` template and scaffold output
+
+**Description:** Add a `"generator_version"` field to the
+`aida-config.json.jinja2` template so newly scaffolded plugins
+track which version of the scaffolder created them. Update the
+schemas reference document.
+
+**Files to modify:**
+
+- `skills/plugin-manager/templates/scaffold/shared/aida-config.json.jinja2`
+  (add `"generator_version": {{ generator_version | tojson }}` at
+  top level)
+- `skills/plugin-manager/references/schemas.md`
+  (document the new field under `## aida-config.json`)
+
+**Dependencies:** Task 1 (uses `GENERATOR_VERSION` from constants).
+
+**Size:** S
+
+**Key implementation notes:**
+
+- The `generator_version` variable is already passed to templates by
+  scaffold (line 432 in scaffold.py). The template just needs to
+  consume it.
+- Place the field at the top level of `aida-config.json`, not nested
+  inside `config`:
+
+  ```json
+  {
+    "generator_version": "0.9.0",
+    "config": { ... },
+    ...
+  }
+  ```
+
+- Update existing scaffold tests that snapshot `aida-config.json`
+  output to expect the new field.
+- For plugins scaffolded before this change (no `generator_version`
+  field), the update scanner (Task 4) will treat them as version
+  `"0.0.0"` (unknown/pre-tracking).
+
+---
+
+### Task 3: Create `update_ops/` subpackage with dataclasses and strategy registry
+
+**Description:** Create the `update_ops/` subpackage with core data
+structures (`FileStatus`, `ScanResult`, `FileDiff`, `DiffReport`,
+`PatchResult`) and the strategy registry that maps file paths to
+categories and default strategies.
+
+**Files to create:**
+
+- `skills/plugin-manager/scripts/operations/update_ops/__init__.py`
+- `skills/plugin-manager/scripts/operations/update_ops/models.py`
+- `skills/plugin-manager/scripts/operations/update_ops/strategies.py`
+
+**Dependencies:** Task 1 (imports `SUPPORTED_LANGUAGES` from constants).
+
+**Size:** M
+
+**Key implementation notes:**
+
+- `models.py` defines these dataclasses:
+
+  ```python
+  from dataclasses import dataclass, field
+  from enum import Enum
+
+  class FileCategory(Enum):
+      CUSTOM = "custom"
+      BOILERPLATE = "boilerplate"
+      COMPOSITE = "composite"
+      CI_WORKFLOW = "ci_workflow"
+      DEPENDENCY_CONFIG = "dependency_config"
+      TEST_SCAFFOLD = "test_scaffold"
+      METADATA = "metadata"
+      NEW_ADDITION = "new_addition"
+
+  class MergeStrategy(Enum):
+      SKIP = "skip"
+      OVERWRITE = "overwrite"
+      MERGE = "merge"
+      ADD = "add"
+      MANUAL_REVIEW = "manual_review"
+
+  class FileStatus(Enum):
+      MISSING = "missing"
+      OUTDATED = "outdated"
+      UP_TO_DATE = "up_to_date"
+      CUSTOM_SKIP = "custom_skip"
+
+  @dataclass
+  class FileDiff:
+      path: str
+      category: FileCategory
+      status: FileStatus
+      strategy: MergeStrategy
+      expected_content: str | None = None
+      actual_content: str | None = None
+      diff_summary: str = ""
+
+  @dataclass
+  class DiffReport:
+      plugin_path: str
+      language: str
+      generator_version: str
+      current_version: str
+      files: list[FileDiff] = field(default_factory=list)
+
+      @property
+      def missing_files(self) -> list[FileDiff]:
+          return [f for f in self.files
+                  if f.status == FileStatus.MISSING]
+
+      @property
+      def outdated_files(self) -> list[FileDiff]:
+          return [f for f in self.files
+                  if f.status == FileStatus.OUTDATED]
+
+      @property
+      def up_to_date_files(self) -> list[FileDiff]:
+          return [f for f in self.files
+                  if f.status == FileStatus.UP_TO_DATE]
+
+      @property
+      def custom_skip_files(self) -> list[FileDiff]:
+          return [f for f in self.files
+                  if f.status == FileStatus.CUSTOM_SKIP]
+
+  @dataclass
+  class PatchResult:
+      path: str
+      action: str  # "created", "updated", "skipped", "failed"
+      message: str
+      backup_path: str = ""
+  ```
+
+- `strategies.py` defines the `FileSpec` mapping and
+  `get_file_specs(language)` function:
+
+  ```python
+  @dataclass
+  class FileSpec:
+      path: str
+      template: str  # template path relative to scaffold dir
+      category: FileCategory
+      default_strategy: MergeStrategy
+      user_overridable: bool = False
+  ```
+
+  The function returns a list of `FileSpec` for all files that the
+  scaffolder would produce for the given language. This is the
+  single source of truth for file classification.
+
+- Use modern type hints (`str | None`, not `Optional[str]`).
+- All enums use lowercase string values for JSON serialization.
+
+---
+
+### Task 4: Implement the scanner module
+
+**Description:** Create the scanner that reads an existing plugin
+directory and produces a `DiffReport` by comparing actual files
+against template-rendered expectations.
+
+**Files to create:**
+
+- `skills/plugin-manager/scripts/operations/update_ops/scanner.py`
+
+**Dependencies:** Task 1 (shared template variable builder), Task 3
+(models and strategy registry).
+
+**Size:** L
+
+**Key implementation notes:**
+
+- `scan_plugin(plugin_path, templates_dir)` is the main entry point.
+  Returns a `DiffReport`.
+- Scanner flow:
+  1. Read `.claude-plugin/plugin.json` to get plugin name, version,
+     description, author info, etc.
+  2. Read `.claude-plugin/aida-config.json` to get `generator_version`
+     (default `"0.0.0"` if missing).
+  3. Detect language by checking for `pyproject.toml` (python) or
+     `package.json` (typescript). Fall back to directory heuristics
+     (`scripts/` = python, `src/` + no `scripts/` = typescript).
+  4. Build template variables using `build_template_variables()`.
+  5. Get file specs using `get_file_specs(language)`.
+  6. For each file spec:
+     - Render the template to get expected content.
+     - Read the actual file (if it exists).
+     - Classify: missing, outdated (content differs), up-to-date,
+       or custom-skip (based on category).
+     - Populate a `FileDiff` with both contents and a summary.
+- For composite files (`.gitignore`, `Makefile`), the "expected"
+  content is the rendered template; the diff summary describes
+  what entries/targets are missing rather than a full content diff.
+- For `.gitignore` comparison: parse both into sets of non-empty,
+  non-comment lines; report lines present in expected but absent
+  from actual.
+- For `Makefile` comparison: extract target names (lines matching
+  `^[a-zA-Z_-]+:`) from both; report targets present in expected
+  but absent from actual.
+- For dependency configs (`pyproject.toml`, `package.json`): compare
+  key structural sections and summarize differences without producing
+  a patch.
+- The scanner MUST NOT modify any files. It is purely read-only.
+- Handle missing `plugin.json` gracefully: return an error result
+  (not a valid plugin directory).
+- Handle missing `aida-config.json` gracefully: use defaults.
+
+---
+
+### Task 5: Implement the patcher module
+
+**Description:** Create the patcher that applies approved patches to
+the plugin directory, with backup and atomic writes.
+
+**Files to create:**
+
+- `skills/plugin-manager/scripts/operations/update_ops/patcher.py`
+
+**Dependencies:** Task 3 (models), Task 4 (scanner for re-scan).
+
+**Size:** L
+
+**Key implementation notes:**
+
+- `apply_patches(plugin_path, diff_report, overrides)` is the main
+  entry point. Returns `list[PatchResult]`.
+- `overrides` is a `dict[str, MergeStrategy]` allowing the user to
+  override default strategies for specific file paths or categories.
+- Before any modification:
+  1. Create backup directory:
+     `.aida-backup/{YYYYMMDD_HHMMSS}/`
+     inside the plugin root.
+  2. Copy all files that will be modified into the backup.
+- Strategy implementations:
+  - **`skip`**: Do nothing. Return `PatchResult` with action
+    `"skipped"`.
+  - **`overwrite`**: Write rendered template content to file using
+    atomic write (write to `{path}.tmp`, then `os.replace()`).
+  - **`add`**: Same as overwrite but only when file does not exist.
+    If file exists, skip.
+  - **`merge` (gitignore)**: Parse current `.gitignore` into a set
+    of entries. Parse expected into a set. Append missing entries
+    (grouped under a `# Added by aida plugin update` comment
+    header). Write atomically.
+  - **`merge` (makefile)**: Parse current Makefile to extract target
+    names. Render expected Makefile, extract targets. For each
+    missing target, extract the full target block (target line +
+    recipe lines) from the rendered template and append to the
+    Makefile under a `# Added by aida plugin update` comment
+    header. Write atomically.
+  - **`manual_review`**: Do nothing. Return `PatchResult` with
+    action `"skipped"` and a message listing differences for the
+    user to address manually.
+- After patching, update `generator_version` in `aida-config.json`
+  to the current `GENERATOR_VERSION`.
+- If any write fails, log the error and continue with remaining
+  files. Return all results including failures. Do NOT roll back
+  other successful writes (the backup serves as rollback).
+- For plugin metadata (`plugin.json`, `marketplace.json`):
+  re-render template using actual plugin values (name, version,
+  description from the existing file), NOT the template defaults.
+  This preserves user values while updating schema structure.
+
+---
+
+### Task 6: Implement the `update.py` entry point
+
+**Description:** Create the main `operations/update.py` module that
+implements `get_questions()` and `execute()` following the two-phase
+API pattern. Wire it into `manage.py` routing.
+
+**Files to create:**
+
+- `skills/plugin-manager/scripts/operations/update.py`
+
+**Files to modify:**
+
+- `skills/plugin-manager/scripts/manage.py`
+  (add `from operations import update`, add
+  `is_update_operation()` check, route to `update.get_questions()`
+  and `update.execute()`)
+
+**Dependencies:** Task 4 (scanner), Task 5 (patcher).
+
+**Size:** M
+
+**Key implementation notes:**
+
+- `get_questions(context)` flow:
+  1. Validate `context` has `"plugin_path"` (required -- the path
+     to the existing plugin to update).
+  2. Call `scanner.scan_plugin()` to produce the `DiffReport`.
+  3. If scan fails (not a valid plugin), return error.
+  4. Build the `inferred` payload containing the serialized
+     `DiffReport` under a `"scan_result"` key.
+  5. Build questions list. For v1.0, the only question is:
+     - `"boilerplate_strategy"`: choice of `"overwrite"` (default)
+       or `"skip"` for the boilerplate file category.
+  6. Return `{"questions": [...], "inferred": {...}, "phase": "get_questions"}`.
+
+- `execute(context, responses)` flow:
+  1. Extract `plugin_path` from context.
+  2. Re-scan plugin (confirm current state).
+  3. Build overrides dict from user responses.
+  4. Call `patcher.apply_patches()`.
+  5. Build result summary:
+     - Files created, updated, skipped, failed.
+     - Manual steps remaining (from `manual_review` items).
+     - Backup location.
+     - Updated `generator_version`.
+  6. Return standard result dict with `success`, `message`,
+     `files_modified`, `files_created`, `files_skipped`,
+     `manual_steps`, `backup_path`.
+
+- `manage.py` changes:
+
+  ```python
+  from operations import update  # noqa: E402
+
+  def is_update_operation(context: dict[str, Any]) -> bool:
+      return context.get("operation") == "update"
+  ```
+
+  Add routing in `get_questions()` and `execute()` before the
+  extension fallthrough:
+
+  ```python
+  if is_update_operation(context):
+      return update.get_questions(context)
+
+  if is_update_operation(context):
+      return update.execute(context, responses)
+  ```
+
+- The update operation does NOT use `templates_dir` from `_paths.py`
+  for extension templates. It uses `SCAFFOLD_TEMPLATES_DIR` from
+  `scaffold.py` (or better, from its own path resolution, since
+  both point to the same `templates/scaffold/` directory).
+
+---
+
+### Task 7: Update SKILL.md with update operation documentation
+
+**Description:** Add the update operation to the SKILL.md document:
+operations table, activation trigger, workflow section, and resources.
+
+**Files to modify:**
+
+- `skills/plugin-manager/SKILL.md`
+
+**Dependencies:** Task 6 (API is defined).
+
+**Size:** S
+
+**Key implementation notes:**
+
+- Add to the Activation section:
+  "- User invokes /aida plugin update"
+- Add to the Operations table:
+  `| update | Update | Scan and patch an existing plugin to current standards |`
+- Add a new `### Update Operation` section after `### Scaffold
+  Operation` documenting:
+  - Phase 1 command syntax with example
+  - Phase 2 command syntax with example
+  - What the scan report contains
+  - What the patch does
+  - Backup location
+- Add to Resources section:
+  - `operations/update.py` -- Plugin update entry point
+  - `operations/update_ops/` -- Update submodules (scanner, differ,
+    patcher, strategies, models)
+- Add to references section:
+  - `update-workflow.md` -- Update workflow reference
+
+---
+
+### Task 8: Create `references/update-workflow.md`
+
+**Description:** Create the reference document that describes the
+end-to-end update workflow, file classification details, and merge
+strategy behavior.
+
+**Files to create:**
+
+- `skills/plugin-manager/references/update-workflow.md`
+
+**Dependencies:** Task 6 (workflow is finalized).
+
+**Size:** S
+
+**Key implementation notes:**
+
+- Follow the structure of `scaffolding-workflow.md` as a model.
+- Include:
+  - End-to-end flow (numbered steps)
+  - File classification table (from this workplan)
+  - Merge strategy details for each category
+  - Template variable source (how they are inferred from the
+    existing plugin)
+  - Backup and rollback information
+  - Error handling table
+  - Post-update steps
+- Use YAML frontmatter: `type: reference`, `title: Plugin Update
+  Workflow`.
+- Line length: 88 characters (matches ruff/markdownlint config).
+
+---
+
+### Task 9: Unit tests for scanner
+
+**Description:** Write comprehensive unit tests for the scanner
+module covering all file categories, language detection, missing
+files, outdated files, up-to-date files, and edge cases.
+
+**Files to create:**
+
+- `tests/unit/test_update_scanner.py`
+
+**Dependencies:** Task 4 (scanner implementation).
+
+**Size:** L
+
+**Key implementation notes:**
+
+- Follow the test patterns in `tests/unit/test_scaffold.py`:
+  `unittest.TestCase` classes with `@patch` decorators and
+  `tempfile.TemporaryDirectory` for filesystem tests.
+- Path setup block at top of file (same pattern as test_scaffold.py):
+
+  ```python
+  _project_root = Path(__file__).parent.parent.parent
+  _plugin_scripts = (
+      _project_root / "skills" / "plugin-manager" / "scripts"
+  )
+  sys.path.insert(0, str(_project_root / "scripts"))
+  sys.path.insert(0, str(_plugin_scripts))
+  ```
+
+- Test classes:
+  - `TestScanValidPlugin` -- scaffolded plugin with all files
+    present and up to date
+  - `TestScanMissingFiles` -- plugin missing specific files
+  - `TestScanOutdatedFiles` -- plugin with stale boilerplate
+  - `TestScanCustomFiles` -- verify CLAUDE.md, README.md are
+    always classified as custom/skip
+  - `TestScanLanguageDetection` -- python vs typescript detection
+  - `TestScanNoPluginJson` -- invalid plugin directory
+  - `TestScanNoAidaConfig` -- missing aida-config.json (defaults
+    to version 0.0.0)
+  - `TestScanGitignoreDiff` -- missing entries detected
+  - `TestScanMakefileDiff` -- missing targets detected
+  - `TestScanDependencyConfig` -- pyproject.toml flagged for
+    manual review
+- Create test fixtures using `tempfile.TemporaryDirectory`:
+  scaffold a minimal plugin structure with known file contents,
+  then selectively modify/delete files to test each scenario.
+- Use the actual templates directory for rendering expected content
+  (do not mock template rendering -- this catches template drift).
+
+---
+
+### Task 10: Unit tests for patcher
+
+**Description:** Write unit tests for the patcher module covering
+all merge strategies, atomic writes, backup creation, and error
+handling.
+
+**Files to create:**
+
+- `tests/unit/test_update_patcher.py`
+
+**Dependencies:** Task 5 (patcher implementation).
+
+**Size:** L
+
+**Key implementation notes:**
+
+- Test classes:
+  - `TestBackupCreation` -- verify backup directory structure and
+    contents
+  - `TestOverwriteStrategy` -- file replaced with new content
+  - `TestAddStrategy` -- file created when missing, skipped when
+    present
+  - `TestSkipStrategy` -- file never modified
+  - `TestGitignoreMerge` -- missing entries appended, existing
+    entries preserved, duplicates not added
+  - `TestMakefileMerge` -- missing targets appended, existing
+    targets preserved
+  - `TestManualReviewStrategy` -- no modification, informational
+    result returned
+  - `TestAtomicWrites` -- verify .tmp file is used (mock
+    `os.replace` to confirm call)
+  - `TestPartialFailure` -- one write fails, others succeed,
+    all results returned
+  - `TestGeneratorVersionUpdate` -- aida-config.json updated
+    after patching
+  - `TestUserOverrides` -- strategy overrides applied correctly
+- Use `tempfile.TemporaryDirectory` for all filesystem tests.
+- Verify backup contents match originals byte-for-byte.
+
+---
+
+### Task 11: Integration test and end-to-end validation
+
+**Description:** Write integration tests that exercise the full
+update flow through `manage.py` (Phase 1 scan, Phase 2 patch) and
+validate the end-to-end behavior.
+
+**Files to create:**
+
+- `tests/unit/test_update_integration.py`
+
+**Dependencies:** Task 6 (full flow wired up), Task 9, Task 10.
+
+**Size:** M
+
+**Key implementation notes:**
+
+- Test classes:
+  - `TestUpdatePhase1` -- call `manage.py --get-questions` with
+    `operation: update` and verify scan report structure
+  - `TestUpdatePhase2` -- call `manage.py --execute` with
+    `operation: update` and verify files are patched
+  - `TestUpdateRoundTrip` -- scaffold a plugin, modify some files,
+    run update, verify corrections
+  - `TestUpdateIdempotent` -- run update twice on same plugin,
+    verify no changes on second run
+  - `TestUpdatePreservesCustomContent` -- modify CLAUDE.md and
+    README.md, run update, verify they are untouched
+- Use `tempfile.TemporaryDirectory` to create an isolated plugin.
+- Scaffold a known plugin using `scaffold.execute()`, then:
+  1. Delete a boilerplate file (e.g., `.markdownlint.json`).
+  2. Modify `.gitignore` to remove some entries.
+  3. Delete a Makefile target.
+  4. Run update Phase 1 and verify the diff report.
+  5. Run update Phase 2 and verify the patched state.
+  6. Run update Phase 1 again and verify everything is up to date.
+- Run `make lint` on the patched plugin directory to verify the
+  output is lint-clean.
+
+## Task Dependency Graph
+
+```text
+Task 1: Extract shared constants + template var builder
+  |
+  +---> Task 2: Add generator_version to aida-config template
+  |
+  +---> Task 3: Create update_ops/ with models + strategies
+          |
+          +---> Task 4: Implement scanner
+          |       |
+          |       +---> Task 9: Unit tests for scanner
+          |       |
+          |       +---> Task 5: Implement patcher
+          |               |
+          |               +---> Task 10: Unit tests for patcher
+          |               |
+          |               +---> Task 6: Implement update.py + manage.py routing
+          |                       |
+          |                       +---> Task 7: Update SKILL.md
+          |                       |
+          |                       +---> Task 8: Create update-workflow.md
+          |                       |
+          |                       +---> Task 11: Integration tests
+
+Parallelizable groups:
+  - Tasks 2 and 3 (after Task 1)
+  - Tasks 9 and 5 (after Task 4)
+  - Tasks 7, 8, and 11 (after Task 6)
+```
+
+## Acceptance Criteria
+
+These criteria are derived from the Product Manager review, refined
+with technical constraints from the other reviewers.
+
+**AC-1: Scan report accuracy.** Phase 1 produces a categorized diff
+report that correctly classifies every scaffolded file into one of
+the four categories (custom, boilerplate, composite, new) with
+accurate status (missing, outdated, up-to-date, custom-skip).
+
+**AC-2: Missing file detection.** Files present in the current
+scaffold templates but absent from the plugin are reported as
+MISSING with the correct add/overwrite strategy.
+
+**AC-3: Outdated file detection.** Boilerplate files whose content
+differs from the current template rendering are reported as
+OUTDATED.
+
+**AC-4: Custom content preservation.** `CLAUDE.md`, `README.md`,
+`LICENSE`, and `aida-config.json` are never modified by the update
+operation regardless of their content.
+
+**AC-5: Boilerplate overwrite.** When the user approves (or accepts
+the default), outdated boilerplate files are replaced with current
+template output.
+
+**AC-6: Gitignore merge.** Missing `.gitignore` entries are appended
+without removing or reordering existing entries.
+
+**AC-7: Makefile merge.** Missing Makefile targets are appended
+without modifying or removing existing targets.
+
+**AC-8: Backup creation.** A timestamped backup of all files that
+will be modified is created at `.aida-backup/{timestamp}/` before
+any patches are applied.
+
+**AC-9: Generator version tracking.** After a successful update,
+`aida-config.json` contains the current `generator_version`. Newly
+scaffolded plugins also include this field.
+
+**AC-10: Idempotent.** Running update on an already up-to-date
+plugin produces no changes and reports all files as UP_TO_DATE.
+
+**AC-11: Language detection.** The scanner correctly detects Python
+vs TypeScript plugins based on `pyproject.toml` / `package.json`
+presence.
+
+**AC-12: Dependency config safety.** `pyproject.toml` and
+`package.json` are never auto-modified. Differences are reported
+for manual review.
+
+**AC-13: Two-phase API compliance.** The update operation follows
+the same `get_questions()` / `execute()` pattern as scaffold and
+extension operations, with the same JSON response shape.
+
+## Testing Strategy
+
+### Unit Tests (Tasks 9, 10)
+
+- **Scanner tests** (`test_update_scanner.py`): ~15 test methods
+  covering all file categories, language detection, edge cases.
+- **Patcher tests** (`test_update_patcher.py`): ~15 test methods
+  covering all strategies, atomic writes, backup, error handling.
+- **Model tests**: Implicitly covered by scanner/patcher tests.
+  Add dedicated tests if model logic grows beyond property methods.
+
+### Integration Tests (Task 11)
+
+- **Round-trip test**: Scaffold -> modify -> update -> verify.
+- **Idempotency test**: Update -> update -> verify no changes.
+- **Preservation test**: Modify custom files -> update -> verify
+  untouched.
+- **Phase 1/Phase 2 contract test**: Verify JSON response shapes.
+
+### Test Fixtures
+
+- Use `tempfile.TemporaryDirectory` for all filesystem tests (no
+  permanent fixtures needed).
+- Scaffold minimal plugins programmatically using the existing
+  `scaffold.execute()` function (integration tests) or by creating
+  files directly (unit tests).
+- Use the real templates directory for rendering (catches template
+  drift; no mocking of template content).
+
+### Test Conventions
+
+- `unittest.TestCase` with `@patch` decorators (matching existing
+  test patterns in `tests/unit/test_scaffold.py`).
+- Path setup via `sys.path.insert()` at top of each test file.
+- Module cache clearing for operations imports (same pattern as
+  existing tests).
+- Ruff-compliant: 88-char line length, modern type hints.
+
+## Risk Register
+
+| # | Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- | --- |
+| R1 | Makefile merge produces invalid syntax | Medium | High | Conservative approach: only append complete target blocks; validate by checking for tab-indented recipe lines. Add lint verification in integration tests. |
+| R2 | Template changes break scanner expectations | Medium | Medium | Scanner uses real template rendering, not hardcoded expectations. Integration test scaffolds then updates to catch drift. |
+| R3 | `.gitignore` merge adds duplicate entries | Low | Low | Set-based comparison ensures entries are only added if truly missing. |
+| R4 | Plugin has manually restructured files | Medium | Medium | Scanner only checks files listed in the strategy registry. Unknown files are ignored. The report clearly shows what was checked. |
+| R5 | `aida-config.json` has user customizations that conflict with new field | Low | Medium | `generator_version` is added at top level, not inside `config`. JSON merge preserves existing keys. |
+| R6 | Backup directory grows unbounded | Low | Low | Out of scope for v1.0. Documented as deferred (v1.1 backup retention policy). Advisory note in post-update summary. |
+| R7 | Atomic write fails on some filesystems | Low | High | Fallback: if `os.replace()` fails, fall back to direct write with a warning. Backup ensures recoverability either way. |
+| R8 | Version bootstrapping for pre-tracking plugins | Medium | Low | Default to `"0.0.0"` when `generator_version` is absent. Scanner compares actual content, not versions, so this is informational only. |
+| R9 | Plugin uses language not yet supported | Low | Medium | Scanner validates detected language against `SUPPORTED_LANGUAGES`. Returns clear error if unsupported. |
+| R10 | Test isolation: operations module cache conflicts | Medium | Medium | Use the same `sys.modules` cache-clearing pattern established in `test_scaffold.py`. |
+
+## Open Questions
+
+1. **Makefile `.PHONY` line handling.** When appending new targets,
+   should the patcher also update the `.PHONY` declaration? The
+   current scaffold templates declare `.PHONY` at the section level.
+   Recommendation: Yes, append missing target names to the
+   appropriate `.PHONY` line, or add a new `.PHONY` line for the
+   appended block.
+
+2. **Plugin metadata re-rendering.** When overwriting `plugin.json`
+   or `marketplace.json`, the patcher re-renders the template with
+   values read from the existing file. Should we deep-merge existing
+   JSON with template output, or render fresh and overwrite?
+   Recommendation: Read existing values, use them as template
+   variables, render fresh. This updates schema structure while
+   preserving user data.
+
+3. **Multi-language plugins.** Should the scanner support plugins
+   that have both Python and TypeScript tooling? Recommendation:
+   Not for v1.0. Detect the primary language and warn if artifacts
+   of both are present.
+
+4. **Update from non-scaffolded plugins.** Plugins created manually
+   (not via `/aida plugin scaffold`) may have very different
+   structures. Should update support them? Recommendation: Yes,
+   with reduced confidence. The scanner reports what it finds; the
+   patcher only modifies files in the strategy registry. Manual
+   plugins get an advisory note in the report.
+
+## Definition of Done
+
+- [ ] `operations/constants.py` created with `GENERATOR_VERSION` and
+      `SUPPORTED_LANGUAGES`
+- [ ] `operations/shared.py` created with `build_template_variables()`
+- [ ] `scaffold.py` imports from `constants.py` and `shared.py`;
+      all existing scaffold tests pass
+- [ ] `aida-config.json.jinja2` template includes `generator_version`
+- [ ] `schemas.md` updated with `generator_version` documentation
+- [ ] `update_ops/` subpackage created with `models.py` and
+      `strategies.py`
+- [ ] `update_ops/scanner.py` implemented and tested
+- [ ] `update_ops/patcher.py` implemented and tested
+- [ ] `operations/update.py` implemented with `get_questions()` and
+      `execute()`
+- [ ] `manage.py` routes `operation: "update"` to `update` module
+- [ ] SKILL.md updated with update operation documentation
+- [ ] `references/update-workflow.md` created
+- [ ] Unit tests for scanner: all pass (`test_update_scanner.py`)
+- [ ] Unit tests for patcher: all pass (`test_update_patcher.py`)
+- [ ] Integration tests: round-trip, idempotency, preservation
+      (`test_update_integration.py`)
+- [ ] `make lint` passes with zero warnings
+- [ ] `make test` passes with zero failures
+- [ ] No regressions in existing scaffold, extension, or manage tests

--- a/skills/aida/SKILL.md
+++ b/skills/aida/SKILL.md
@@ -140,14 +140,16 @@ For `plugin` commands (including `plugin scaffold`):
 
 - **Invoke the `plugin-manager` skill** to handle these operations
 - Pass the full command arguments to the skill
-- The skill handles create, validate, version, list, and scaffold operations
+- The skill handles create, validate, version, list, scaffold, and update
+  operations
 - Scaffold creates a NEW plugin project (not an extension inside an existing
   project)
+- Update scans an existing plugin and patches it to current standards
 
 **Process:**
 
 1. Parse the command to extract:
-   - Operation: `create`, `validate`, `version`, `list`, `scaffold`
+   - Operation: `create`, `validate`, `version`, `list`, `scaffold`, `update`
    - Arguments: name, description, options
 
 2. Invoke `plugin-manager` skill with the parsed context
@@ -160,6 +162,7 @@ For `plugin` commands (including `plugin scaffold`):
 /aida plugin list                        → plugin-manager skill
 /aida plugin scaffold "my-new-plugin"    → plugin-manager skill
 /aida plugin scaffold                    → plugin-manager skill (will ask)
+/aida plugin update "/path/to/plugin"   → plugin-manager skill
 ```
 
 ### Hook Management Commands
@@ -296,7 +299,7 @@ When displaying help (for `help` command or no arguments), show:
 ### Extension Management
 - `/aida agent [create|validate|version|list]` - Manage agents
 - `/aida skill [create|validate|version|list]` - Manage skills
-- `/aida plugin [scaffold|create|validate|version|list]` - Manage plugins
+- `/aida plugin [scaffold|create|validate|version|list|update]` - Manage plugins
 - `/aida hook [list|add|remove|validate]` - Manage hooks (settings.json)
 
 ### Session Persistence

--- a/skills/plugin-manager/SKILL.md
+++ b/skills/plugin-manager/SKILL.md
@@ -32,17 +32,19 @@ This skill activates when:
 - User invokes `/aida plugin version`
 - User invokes `/aida plugin list`
 - User invokes `/aida plugin scaffold`
+- User invokes `/aida plugin update`
 - Routed from `aida` skill for any plugin operation
 
 ## Operations
 
-| Operation  | Mode       | Description                          |
-| ---------- | ---------- | ------------------------------------ |
-| `create`   | Extension  | Create plugin extension dirs/files   |
-| `validate` | Extension  | Validate plugin.json metadata        |
-| `version`  | Extension  | Bump plugin.json version             |
-| `list`     | Extension  | List discovered plugins              |
-| `scaffold` | Scaffolding| Scaffold a full new plugin project   |
+| Operation  | Mode        | Description                                |
+| ---------- | ----------- | ------------------------------------------ |
+| `create`   | Extension   | Create plugin extension dirs/files         |
+| `validate` | Extension   | Validate plugin.json metadata              |
+| `version`  | Extension   | Bump plugin.json version                   |
+| `list`     | Extension   | List discovered plugins                    |
+| `scaffold` | Scaffolding | Scaffold a full new plugin project         |
+| `update`   | Migration   | Scan and patch plugin to current standards |
 
 ## Path Resolution
 
@@ -116,6 +118,80 @@ Creates a complete plugin project with:
 - Optional agent and skill stubs
 - Initialized git repository with initial commit
 
+### Update Operation
+
+#### Phase 1: Scan and Report
+
+```bash
+python {base_directory}/scripts/manage.py --get-questions \
+  --context='{"operation": "update", "plugin_path": "/path/to/plugin"}'
+```
+
+Scans the plugin directory against current scaffold standards.
+Returns a diff report with file-by-file comparison results
+categorized as: missing, outdated, up-to-date, or custom-skip.
+
+The orchestrator should present the scan report to the user
+in this order:
+
+1. Version context: scaffolded version vs current standard
+2. Summary counts (missing, outdated, up-to-date, skipped)
+3. Missing files (will be added)
+4. Outdated files (will be updated per merge strategy)
+5. Files flagged for manual review
+6. Custom content files (will NOT be touched)
+7. Merge strategy question (if boilerplate files need
+   updating)
+
+#### Phase 2: Apply Patches
+
+```bash
+python {base_directory}/scripts/manage.py --execute \
+  --context='{"operation": "update", "plugin_path": "/path/to/plugin"}' \
+  --responses='{"boilerplate_strategy": "overwrite"}'
+```
+
+Applies approved patches to the plugin:
+
+- Creates backup at `.aida-backup/{timestamp}/`
+- Adds missing files from templates
+- Overwrites or skips outdated boilerplate per strategy
+- Merges composite files (`.gitignore`, `Makefile`)
+  append-only
+- Skips custom content files (`CLAUDE.md`, `README.md`)
+- Flags dependency configs for manual review
+- Updates `generator_version` in `aida-config.json`
+
+#### Present Results
+
+After Phase 2 completes, present the results in this order:
+
+1. Success message with old and new generator version
+2. Files created (from `files_created`)
+3. Files updated (from `files_updated`)
+4. Files skipped (from `files_skipped`, brief)
+5. Backup location (`backup_path`) if any files were
+   modified
+6. Manual steps required (`manual_steps`) -- present as
+   a numbered checklist
+
+#### File Categories
+
+| Category         | Strategy        | Files                     |
+| ---------------- | --------------- | ------------------------- |
+| Custom content   | `skip`          | CLAUDE.md, README.md,     |
+|                  |                 | LICENSE                   |
+| AIDA metadata    | `skip`          | aida-config.json          |
+| Plugin metadata  | `skip`          | plugin.json,              |
+|                  |                 | marketplace.json          |
+| Boilerplate      | `overwrite`     | Linting configs, version  |
+|                  |                 | files                     |
+| Composite        | `merge`         | .gitignore, Makefile      |
+| CI workflows     | `add`           | .github/workflows/ci.yml  |
+| Test scaffold    | `add`           | tests/conftest.py         |
+| Dependencies     | `manual_review` | pyproject.toml,           |
+|                  |                 | package.json              |
+
 ### Post-Scaffold: GitHub Repository (Optional)
 
 If the user requested `create_github_repo: true`, the result
@@ -153,6 +229,18 @@ includes `path` and `files_created` for any partial output.
   - **context.py** -- Git config inference, directory validation
   - **generators.py** -- Directory creation, template rendering
   - **licenses.py** -- License text templates
+- **operations/constants.py** -- Shared constants
+  (GENERATOR_VERSION, SUPPORTED_LANGUAGES)
+- **operations/shared.py** -- Shared template variable
+  builder used by both scaffold and update
+- **operations/update.py** -- Plugin update entry point
+  (scan and patch operations)
+- **operations/update_ops/** -- Update submodules
+  - **scanner.py** -- Plugin scanning and comparison
+  - **patcher.py** -- File patching with backup
+  - **models.py** -- Data structures (DiffReport, etc.)
+  - **strategies.py** -- File classification registry
+  - **parsers.py** -- Shared gitignore/Makefile parsing
 - **operations/utils.py** -- Re-export shim for shared utilities
 
 ### templates/
@@ -168,4 +256,5 @@ includes `path` and `files_created` for any partial output.
 
 - **scaffolding-workflow.md** -- Scaffolding workflow reference
 - **validate-workflow.md** -- Plugin validation reference
+- **update-workflow.md** -- Update workflow reference
 - **schemas.md** -- Plugin JSON schema reference

--- a/skills/plugin-manager/references/schemas.md
+++ b/skills/plugin-manager/references/schemas.md
@@ -59,10 +59,27 @@ which rejects unrecognized keys in `plugin.json`.
 
 ```json
 {
+  "generator_version": "0.9.0",
   "config": { },
   "recommendedPermissions": { }
 }
 ```
+
+### Generator Version
+
+The `generator_version` field records which version of the
+AIDA scaffolder created or last updated the plugin. This
+field is used by the `update` operation to determine what
+changes need to be applied.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `generator_version` | string | No | Semver of the scaffolder that created/updated this plugin |
+
+Plugins created before this field was introduced (or
+created manually) will not have it. The update operation
+treats missing `generator_version` as `"0.0.0"`
+(pre-tracking).
 
 ### Config Section
 
@@ -110,9 +127,13 @@ Plugins can declare user-configurable preferences:
 
 | Type | Fields | Description |
 | --- | --- | --- |
-| `boolean` | `key`, `label`, `default` | On/off toggle |
-| `choice` | `key`, `label`, `options`, `default` | Select from list |
-| `string` | `key`, `label`, `default` | Free-text input |
+| `boolean` | `key`, `label`, `default`, `required?` | On/off toggle |
+| `choice` | `key`, `label`, `options`, `default`, `required?` | Select from list |
+| `string` | `key`, `label`, `default`, `required?` | Free-text input |
+
+All preference types accept an optional `required` boolean
+field (defaults to `false`) indicating whether the preference
+must be configured before the plugin is usable.
 
 ### Recommended Permissions Section
 

--- a/skills/plugin-manager/references/update-workflow.md
+++ b/skills/plugin-manager/references/update-workflow.md
@@ -1,0 +1,161 @@
+---
+type: reference
+title: Plugin Update Workflow
+description: >-
+  Detailed reference for the plugin-manager update process
+  including file classification, merge strategies, version
+  tracking, and backup recovery
+---
+
+# Plugin Update Workflow
+
+Detailed reference for the plugin-manager update process.
+
+## End-to-End Flow
+
+1. User invokes `/aida plugin update`
+2. Dispatch routes to `plugin-manager` skill
+3. Skill runs `manage.py --get-questions` with plugin path
+4. Script scans plugin, compares against current standards
+5. Skill presents diff report and asks merge strategy
+6. Skill runs `manage.py --execute` with strategy response
+7. Script backs up files, applies patches, updates version
+8. Skill presents summary and manual steps to user
+
+## File Classification
+
+The update operation classifies each scaffolded file into one of these categories:
+
+| Category | Default Strategy | Override? | Rationale |
+| --- | --- | --- | --- |
+| Custom content | skip | No | CLAUDE.md, README.md, LICENSE |
+| AIDA metadata | skip | No | aida-config.json |
+| Plugin metadata | skip | No | plugin.json, marketplace.json |
+| Boilerplate | overwrite | Yes (skip) | Linting configs, version files |
+| Composite | merge | No | .gitignore, Makefile |
+| CI workflow | add | Yes (skip) | .github/workflows/ci.yml |
+| Dependencies | manual_review | No | pyproject.toml, package.json |
+| Test scaffold | add | Yes (skip) | tests/conftest.py |
+
+## Merge Strategy Details
+
+### Overwrite
+
+Replaces the file entirely with the current template output.
+Used for pure boilerplate files that users rarely customize
+(linting configs, version files).
+
+### Skip
+
+Never modifies the file. Used for user-authored content
+(CLAUDE.md, README.md, LICENSE) and AIDA metadata
+(aida-config.json).
+
+### Add
+
+Creates the file only if it does not exist on disk. Used
+for CI workflows and test scaffolding. If the file already
+exists, it is left untouched regardless of content.
+
+### Merge: .gitignore
+
+Append-only merge:
+
+- Parses current and expected content into entry sets
+- Identifies entries in expected but absent from current
+- Appends missing entries under a comment header:
+  `# Added by aida plugin update`
+- Never removes or reorders existing entries
+
+### Merge: Makefile
+
+Conservative target-addition:
+
+- Extracts target names from current and expected Makefiles
+- Identifies targets in expected but absent from current
+- Extracts full target blocks (definition + recipe lines)
+- Appends missing blocks with `.PHONY` declarations under:
+  `# Added by aida plugin update`
+- Never modifies or removes existing targets
+
+### Manual Review
+
+Does not modify the file. Reports differences between
+the current file and the template output in the post-update
+summary. The user is responsible for reviewing and applying
+changes manually. Used for dependency configs
+(pyproject.toml, package.json).
+
+## Version Tracking
+
+### generator_version Field
+
+The `generator_version` field in `.claude-plugin/aida-config.json`
+records which version of the scaffolder created or last
+updated the plugin.
+
+- Written by scaffold when creating a new plugin
+- Updated by update after successful patching
+- Read by update to determine the version gap
+
+### Missing generator_version
+
+Plugins created before version tracking (or created manually)
+will not have this field. The update operation treats missing
+`generator_version` as `"0.0.0"` and performs a full scan
+against current standards.
+
+## Backup and Recovery
+
+Before applying any patches, the update operation creates
+a timestamped backup directory:
+
+```text
+{plugin_root}/.aida-backup/{YYYYMMDD_HHMMSS}/
+```
+
+Only files that will be modified are backed up. Missing files
+(to be added) do not have backups. To restore from backup:
+
+1. Navigate to the backup directory shown in the summary
+2. Copy files back to their original locations
+3. Or use `git checkout -- .` if changes were not committed
+
+## Template Variable Resolution
+
+During update, template variables are extracted from the
+existing plugin rather than asked from the user:
+
+| Variable | Source |
+| --- | --- |
+| `plugin_name` | `.claude-plugin/plugin.json` name field |
+| `description` | `.claude-plugin/plugin.json` description |
+| `version` | `.claude-plugin/plugin.json` version |
+| `author_name` | plugin.json author or git config |
+| `author_email` | git config |
+| `license_id` | plugin.json license field |
+| `language` | Detected from pyproject.toml / package.json |
+| `keywords` | plugin.json keywords array |
+| `repository_url` | plugin.json repository field |
+| `generator_version` | Current GENERATOR_VERSION constant |
+
+## Error Handling
+
+| Error | Cause | Resolution |
+| --- | --- | --- |
+| "plugin_path is required" | No path provided | Provide plugin directory path |
+| "not a valid plugin" | No plugin.json found | Verify the path or scaffold first |
+| "Cannot detect language" | No pyproject.toml or package.json | Specify language in context |
+| Partial patch failure | Write error on one file | Check summary; other files OK |
+| "Plugin is up to date" | No changes needed | No action required |
+
+## Post-Update Steps
+
+After the update completes:
+
+1. Review the summary of changes made
+2. Check files flagged for manual review
+3. Run `make lint` to verify the updated configuration
+4. Run `make test` to ensure nothing is broken
+5. Review changes with `git diff` before committing
+6. Commit the update as a separate commit

--- a/skills/plugin-manager/scripts/manage.py
+++ b/skills/plugin-manager/scripts/manage.py
@@ -4,6 +4,7 @@
 Entry point for all plugin operations:
 - Extension CRUD: create, validate, version, list
 - Project scaffolding: scaffold
+- Standards migration: update
 
 Routes to the appropriate operations module based on context.
 
@@ -15,6 +16,10 @@ Usage:
     # Scaffold operation
     python manage.py --get-questions --context='{"operation": "scaffold", ...}'
     python manage.py --execute --context='{"operation": "scaffold", ...}'
+
+    # Update operation
+    python manage.py --get-questions --context='{"operation": "update", ...}'
+    python manage.py --execute --context='{"operation": "update", ...}'
 
 Exit codes:
     0   - Success
@@ -33,6 +38,7 @@ import _paths  # noqa: F401
 from shared.utils import safe_json_load  # noqa: E402
 from operations import extensions  # noqa: E402
 from operations import scaffold  # noqa: E402
+from operations import update  # noqa: E402
 
 # Configure logging
 logging.basicConfig(
@@ -55,6 +61,18 @@ def is_scaffold_operation(context: dict[str, Any]) -> bool:
     return context.get("operation") == "scaffold"
 
 
+def is_update_operation(context: dict[str, Any]) -> bool:
+    """Determine if this is an update operation.
+
+    Args:
+        context: Operation context
+
+    Returns:
+        True if the operation is update
+    """
+    return context.get("operation") == "update"
+
+
 def get_questions(
     context: dict[str, Any],
 ) -> dict[str, Any]:
@@ -68,6 +86,9 @@ def get_questions(
     """
     if is_scaffold_operation(context):
         return scaffold.get_questions(context)
+
+    if is_update_operation(context):
+        return update.get_questions(context)
 
     # Force type to plugin for extension operations
     context["type"] = "plugin"
@@ -92,6 +113,9 @@ def execute(
         if responses:
             context.update(responses)
         return scaffold.execute(context)
+
+    if is_update_operation(context):
+        return update.execute(context, responses)
 
     # Force type to plugin for extension operations
     context["type"] = "plugin"

--- a/skills/plugin-manager/scripts/operations/constants.py
+++ b/skills/plugin-manager/scripts/operations/constants.py
@@ -1,0 +1,4 @@
+"""Shared constants for plugin-manager operations."""
+
+GENERATOR_VERSION = "0.9.0"
+SUPPORTED_LANGUAGES = ("python", "typescript")

--- a/skills/plugin-manager/scripts/operations/shared.py
+++ b/skills/plugin-manager/scripts/operations/shared.py
@@ -1,0 +1,111 @@
+"""Shared helpers for plugin-manager operations.
+
+Provides template variable construction used by both scaffold
+and update operations.
+"""
+
+from datetime import datetime, timezone
+from typing import Any
+
+from .constants import GENERATOR_VERSION
+
+
+def _normalize_python_version(version: str) -> str:
+    """Normalize python version to X.Y format."""
+    parts = version.split(".")
+    if len(parts) >= 2:
+        return f"{parts[0]}.{parts[1]}"
+    return version
+
+
+def build_template_variables(
+    context: dict[str, Any],
+    license_text: str,
+) -> dict[str, Any]:
+    """Build the standard template variables dictionary.
+
+    Constructs the full set of Jinja2 template variables from
+    a plugin context dictionary and resolved license text. Used
+    by both scaffold and update operations.
+
+    Args:
+        context: Plugin context containing at minimum:
+            - plugin_name: kebab-case name
+            - description: plugin description
+            - version: semver string
+            - author_name: author name
+            - author_email: author email
+            - license_id: SPDX license identifier
+            - language: "python" or "typescript"
+        license_text: Resolved full license body text
+
+    Returns:
+        Template variables dictionary for Jinja2 rendering
+    """
+    plugin_name = context["plugin_name"]
+    plugin_display_name = (
+        plugin_name.replace("-", " ").title()
+    )
+    language = context.get("language", "python")
+    script_extension = (
+        ".py" if language == "python" else ".ts"
+    )
+
+    year = str(datetime.now(timezone.utc).year)
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    keywords_raw = context.get("keywords", "")
+    if isinstance(keywords_raw, str):
+        keywords = [
+            k.strip()
+            for k in keywords_raw.split(",")
+            if k.strip()
+        ]
+    else:
+        keywords = (
+            list(keywords_raw) if keywords_raw else []
+        )
+
+    return {
+        "plugin_name": plugin_name,
+        "plugin_display_name": plugin_display_name,
+        "description": context.get("description", ""),
+        "version": context.get("version", "0.1.0"),
+        "author_name": context.get("author_name", ""),
+        "author_email": context.get("author_email", ""),
+        "license_id": context.get("license_id", "MIT"),
+        "license_text": license_text,
+        "year": year,
+        "language": language,
+        "script_extension": script_extension,
+        "python_version": _normalize_python_version(
+            context.get("python_version", "3.11")
+        ),
+        "node_version": context.get("node_version", "22"),
+        "keywords": keywords,
+        "repository_url": context.get(
+            "repository_url", ""
+        ),
+        "include_agent_stub": context.get(
+            "include_agent_stub", False
+        ),
+        "agent_stub_name": context.get(
+            "agent_stub_name", plugin_name
+        ),
+        "agent_stub_description": context.get(
+            "agent_stub_description",
+            f"Agent for {plugin_display_name}",
+        ),
+        "include_skill_stub": context.get(
+            "include_skill_stub", False
+        ),
+        "skill_stub_name": context.get(
+            "skill_stub_name", plugin_name
+        ),
+        "skill_stub_description": context.get(
+            "skill_stub_description",
+            f"Skill for {plugin_display_name}",
+        ),
+        "timestamp": timestamp,
+        "generator_version": GENERATOR_VERSION,
+    }

--- a/skills/plugin-manager/scripts/operations/update.py
+++ b/skills/plugin-manager/scripts/operations/update.py
@@ -1,0 +1,359 @@
+"""Plugin Update Operations - Two-Phase API
+
+Scans existing plugin projects against current scaffold
+standards and applies non-destructive patches.
+
+Usage (via manage.py):
+    # Phase 1: Scan and report (returns JSON)
+    python manage.py --get-questions \
+        --context='{"operation": "update", "plugin_path": "..."}'
+
+    # Phase 2: Apply patches (returns JSON)
+    python manage.py --execute \
+        --context='{"operation": "update", "plugin_path": "..."}'
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import _paths
+
+from .constants import GENERATOR_VERSION
+from .update_ops import patcher, scanner
+from .update_ops.models import (
+    FileCategory,
+    FileStatus,
+    MergeStrategy,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_questions(
+    context: dict[str, Any],
+) -> dict[str, Any]:
+    """Phase 1: Scan plugin and return diff report with questions.
+
+    Scans the plugin directory against current scaffold
+    standards and returns a diff report along with questions
+    about how to handle outdated files.
+
+    Args:
+        context: Operation context containing at minimum
+            ``plugin_path`` (str)
+
+    Returns:
+        Dictionary with 'questions', 'inferred', and 'phase'
+    """
+    plugin_path_str = context.get("plugin_path")
+    if not plugin_path_str:
+        return {
+            "success": False,
+            "message": (
+                "plugin_path is required for update operation"
+            ),
+        }
+
+    plugin_path = Path(plugin_path_str).resolve()
+    templates_dir = _paths.SCAFFOLD_TEMPLATES_DIR
+
+    try:
+        report = scanner.scan_plugin(
+            plugin_path, templates_dir
+        )
+    except ValueError as exc:
+        return {
+            "success": False,
+            "message": str(exc),
+        }
+    except Exception as exc:
+        logger.error(
+            "Scan failed: %s", exc, exc_info=True
+        )
+        return {
+            "success": False,
+            "message": f"Scan failed: {exc}",
+        }
+
+    inferred = _serialize_report(report)
+
+    if not report.needs_update:
+        return {
+            "questions": [],
+            "inferred": inferred,
+            "phase": "get_questions",
+            "message": (
+                "Plugin is up to date with current standards"
+            ),
+        }
+
+    questions: list[dict[str, Any]] = []
+
+    has_outdated_boilerplate = any(
+        f.category == FileCategory.BOILERPLATE
+        and f.status == FileStatus.OUTDATED
+        for f in report.files
+    )
+
+    if has_outdated_boilerplate:
+        questions.append({
+            "id": "boilerplate_strategy",
+            "question": (
+                "How should outdated boilerplate "
+                "files be handled?"
+            ),
+            "type": "choice",
+            "options": ["overwrite", "skip"],
+            "default": "overwrite",
+        })
+
+    return {
+        "questions": questions,
+        "inferred": inferred,
+        "phase": "get_questions",
+    }
+
+
+def execute(
+    context: dict[str, Any],
+    responses: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Phase 2: Apply approved patches to the plugin.
+
+    Re-scans the plugin for fresh state, builds overrides
+    from user responses, then applies patches.
+
+    Args:
+        context: Operation context containing at minimum
+            ``plugin_path`` (str)
+        responses: User responses from Phase 1 questions
+
+    Returns:
+        Result dictionary with success status and details
+    """
+    plugin_path_str = context.get("plugin_path")
+    if not plugin_path_str:
+        return {
+            "success": False,
+            "message": (
+                "plugin_path is required for update operation"
+            ),
+        }
+
+    plugin_path = Path(plugin_path_str).resolve()
+    templates_dir = _paths.SCAFFOLD_TEMPLATES_DIR
+
+    try:
+        report = scanner.scan_plugin(
+            plugin_path, templates_dir
+        )
+    except ValueError as exc:
+        return {
+            "success": False,
+            "message": str(exc),
+        }
+    except Exception as exc:
+        logger.error(
+            "Scan failed: %s", exc, exc_info=True
+        )
+        return {
+            "success": False,
+            "message": f"Scan failed: {exc}",
+        }
+
+    if not report.needs_update:
+        return {
+            "success": True,
+            "message": "Plugin is up to date",
+            "files_created": [],
+            "files_updated": [],
+            "files_skipped": [],
+            "manual_steps": [],
+            "generator_version": GENERATOR_VERSION,
+        }
+
+    overrides = _build_overrides(report, responses)
+
+    try:
+        results = patcher.apply_patches(
+            plugin_path, report, overrides
+        )
+    except Exception as exc:
+        logger.error(
+            "Patching failed: %s", exc, exc_info=True
+        )
+        return {
+            "success": False,
+            "message": f"Patching failed: {exc}",
+        }
+
+    files_created = [
+        r.path for r in results if r.action == "created"
+    ]
+    files_updated = [
+        r.path for r in results if r.action == "updated"
+    ]
+    files_skipped = [
+        r.path for r in results if r.action == "skipped"
+    ]
+
+    backup_path = ""
+    for r in results:
+        if r.backup_path:
+            backup_path = r.backup_path
+            break
+
+    manual_steps = _build_manual_steps(report, results)
+
+    old_version = report.generator_version
+    new_version = GENERATOR_VERSION
+
+    return {
+        "success": True,
+        "message": (
+            f"Updated plugin '{report.plugin_name}' "
+            f"from v{old_version} to v{new_version}"
+        ),
+        "files_created": files_created,
+        "files_updated": files_updated,
+        "files_skipped": files_skipped,
+        "manual_steps": manual_steps,
+        "backup_path": backup_path,
+        "generator_version": GENERATOR_VERSION,
+    }
+
+
+def _serialize_report(
+    report: scanner.DiffReport,
+) -> dict[str, Any]:
+    """Serialize a DiffReport into the inferred payload.
+
+    Args:
+        report: Scan results from the scanner module
+
+    Returns:
+        Dictionary suitable for the 'inferred' response key
+    """
+    manual_review_files = [
+        f
+        for f in report.files
+        if f.strategy == MergeStrategy.MANUAL_REVIEW
+        and f.status
+        in (FileStatus.MISSING, FileStatus.OUTDATED)
+    ]
+
+    return {
+        "plugin_name": report.plugin_name,
+        "plugin_path": report.plugin_path,
+        "language": report.language,
+        "generator_version": report.generator_version,
+        "current_standard": report.current_version,
+        "scan_result": {
+            "summary": report.summary,
+            "needs_update": report.needs_update,
+            "missing_files": [
+                {
+                    "path": f.path,
+                    "diff_summary": f.diff_summary,
+                }
+                for f in report.missing_files
+            ],
+            "outdated_files": [
+                {
+                    "path": f.path,
+                    "diff_summary": f.diff_summary,
+                    "category": f.category.value,
+                }
+                for f in report.outdated_files
+            ],
+            "up_to_date_files": [
+                {"path": f.path}
+                for f in report.up_to_date_files
+            ],
+            "custom_skip_files": [
+                {"path": f.path}
+                for f in report.custom_skip_files
+            ],
+            "manual_review_files": [
+                {
+                    "path": f.path,
+                    "diff_summary": f.diff_summary,
+                }
+                for f in manual_review_files
+            ],
+        },
+    }
+
+
+def _build_overrides(
+    report: scanner.DiffReport,
+    responses: dict[str, Any] | None,
+) -> dict[str, MergeStrategy]:
+    """Build strategy overrides from user responses.
+
+    Args:
+        report: Scan results from the scanner module
+        responses: User responses from Phase 1
+
+    Returns:
+        Mapping of file paths to override strategies
+    """
+    if not responses:
+        return {}
+
+    overrides: dict[str, MergeStrategy] = {}
+
+    strategy_value = responses.get("boilerplate_strategy")
+    if strategy_value == "skip":
+        for f in report.files:
+            if f.category == FileCategory.BOILERPLATE:
+                overrides[f.path] = MergeStrategy.SKIP
+
+    return overrides
+
+
+def _build_manual_steps(
+    report: scanner.DiffReport,
+    results: list[patcher.PatchResult],
+) -> list[str]:
+    """Build the list of manual follow-up steps.
+
+    Includes messages for files flagged for manual review
+    in the diff report, plus standard post-update
+    verification steps.
+
+    Args:
+        report: Scan results from the scanner module
+        results: Patch results from the patcher
+
+    Returns:
+        List of human-readable manual step strings
+    """
+    steps: list[str] = []
+
+    # Identify files that were flagged for manual review
+    # by checking the strategy in the diff report
+    manual_review_paths = {
+        f.path
+        for f in report.files
+        if f.strategy == MergeStrategy.MANUAL_REVIEW
+        and f.status
+        in (FileStatus.MISSING, FileStatus.OUTDATED)
+    }
+
+    for r in results:
+        if r.path in manual_review_paths:
+            steps.append(
+                f"Review {r.path}: {r.message}"
+            )
+
+    steps.extend([
+        "Run `make lint` to verify the updated configuration",
+        "Run `make test` to ensure nothing is broken",
+        "Review changes with `git diff` before committing",
+    ])
+
+    return steps

--- a/skills/plugin-manager/scripts/operations/update_ops/__init__.py
+++ b/skills/plugin-manager/scripts/operations/update_ops/__init__.py
@@ -1,0 +1,5 @@
+"""Update operations subpackage for plugin-manager.
+
+Provides scanning, diffing, patching, and strategy modules
+for the plugin update operation.
+"""

--- a/skills/plugin-manager/scripts/operations/update_ops/models.py
+++ b/skills/plugin-manager/scripts/operations/update_ops/models.py
@@ -1,0 +1,157 @@
+"""Data models for the plugin update operation.
+
+Defines enums for file categories, merge strategies, and
+statuses, plus dataclasses for file diffs, diff reports,
+and patch results.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class FileCategory(Enum):
+    """Classification of files managed by the scaffolder."""
+
+    CUSTOM = "custom"
+    BOILERPLATE = "boilerplate"
+    COMPOSITE = "composite"
+    CI_WORKFLOW = "ci_workflow"
+    DEPENDENCY_CONFIG = "dependency_config"
+    TEST_SCAFFOLD = "test_scaffold"
+    METADATA = "metadata"
+
+
+class MergeStrategy(Enum):
+    """How to handle a file during update."""
+
+    SKIP = "skip"
+    OVERWRITE = "overwrite"
+    MERGE = "merge"
+    ADD = "add"
+    MANUAL_REVIEW = "manual_review"
+
+
+class FileStatus(Enum):
+    """Status of a file compared to current standards."""
+
+    MISSING = "missing"
+    OUTDATED = "outdated"
+    UP_TO_DATE = "up_to_date"
+    CUSTOM_SKIP = "custom_skip"
+
+
+@dataclass
+class FileDiff:
+    """Comparison result for a single file.
+
+    Attributes:
+        path: Relative path from plugin root
+        category: File classification
+        status: Comparison result
+        strategy: Recommended merge strategy
+        expected_content: What the template would produce
+        actual_content: What currently exists on disk
+        diff_summary: Human-readable description of changes
+    """
+
+    path: str
+    category: FileCategory
+    status: FileStatus
+    strategy: MergeStrategy
+    expected_content: str | None = None
+    actual_content: str | None = None
+    diff_summary: str = ""
+
+
+@dataclass
+class DiffReport:
+    """Full scan report for a plugin.
+
+    Attributes:
+        plugin_path: Absolute path to the plugin
+        plugin_name: Plugin name from plugin.json
+        language: Detected language ("python" or "typescript")
+        generator_version: Version the plugin was created with
+        current_version: Current standard version
+        files: List of file comparisons
+    """
+
+    plugin_path: str
+    plugin_name: str
+    language: str
+    generator_version: str
+    current_version: str
+    files: list[FileDiff] = field(default_factory=list)
+
+    @property
+    def missing_files(self) -> list[FileDiff]:
+        """Files present in standards but absent from plugin."""
+        return [
+            f
+            for f in self.files
+            if f.status == FileStatus.MISSING
+        ]
+
+    @property
+    def outdated_files(self) -> list[FileDiff]:
+        """Files that exist but differ from current standards."""
+        return [
+            f
+            for f in self.files
+            if f.status == FileStatus.OUTDATED
+        ]
+
+    @property
+    def up_to_date_files(self) -> list[FileDiff]:
+        """Files that match current standards."""
+        return [
+            f
+            for f in self.files
+            if f.status == FileStatus.UP_TO_DATE
+        ]
+
+    @property
+    def custom_skip_files(self) -> list[FileDiff]:
+        """Files classified as custom content (never modified)."""
+        return [
+            f
+            for f in self.files
+            if f.status == FileStatus.CUSTOM_SKIP
+        ]
+
+    @property
+    def summary(self) -> dict[str, int]:
+        """Count of files by status."""
+        return {
+            "missing": len(self.missing_files),
+            "outdated": len(self.outdated_files),
+            "up_to_date": len(self.up_to_date_files),
+            "custom_skip": len(self.custom_skip_files),
+            "total": len(self.files),
+        }
+
+    @property
+    def needs_update(self) -> bool:
+        """Whether any files need attention."""
+        return bool(
+            self.missing_files or self.outdated_files
+        )
+
+
+@dataclass
+class PatchResult:
+    """Result of patching a single file.
+
+    Attributes:
+        path: Relative path from plugin root
+        action: What was done
+        message: Human-readable description
+        backup_path: Path to backup if created
+    """
+
+    path: str
+    action: str  # "created", "updated", "skipped", "failed"
+    message: str
+    backup_path: str = ""

--- a/skills/plugin-manager/scripts/operations/update_ops/parsers.py
+++ b/skills/plugin-manager/scripts/operations/update_ops/parsers.py
@@ -1,0 +1,58 @@
+"""Shared parsing utilities for the update operation.
+
+Extracted from scanner.py and patcher.py to eliminate
+duplication. Both modules import these functions for
+gitignore and Makefile comparison/merge logic.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+_MAKEFILE_TARGET_RE = re.compile(
+    r"^[a-zA-Z_][a-zA-Z0-9_-]*:"
+)
+
+
+def parse_gitignore_entries(content: str) -> set[str]:
+    """Extract meaningful entries from gitignore content.
+
+    Strips comments, blank lines, and leading/trailing
+    whitespace to produce a set of active ignore patterns.
+
+    Args:
+        content: Raw .gitignore text
+
+    Returns:
+        Set of non-empty, non-comment lines
+    """
+    entries: set[str] = set()
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            entries.add(stripped)
+    return entries
+
+
+def extract_makefile_targets(
+    content: str,
+) -> set[str]:
+    """Extract target names from Makefile content.
+
+    Matches lines that look like Makefile targets
+    (``name:`` at the start of a line).
+
+    Args:
+        content: Raw Makefile text
+
+    Returns:
+        Set of target name strings (without the colon)
+    """
+    targets: set[str] = set()
+    for line in content.splitlines():
+        match = _MAKEFILE_TARGET_RE.match(line)
+        if match:
+            target = match.group(0).rstrip(":")
+            targets.add(target)
+    return targets

--- a/skills/plugin-manager/scripts/operations/update_ops/patcher.py
+++ b/skills/plugin-manager/scripts/operations/update_ops/patcher.py
@@ -1,0 +1,616 @@
+"""Plugin patcher for the update operation.
+
+Applies approved patches to a plugin directory with backup
+creation and atomic file writes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ..constants import GENERATOR_VERSION
+from .models import (
+    DiffReport,
+    FileDiff,
+    FileStatus,
+    MergeStrategy,
+    PatchResult,
+)
+from .parsers import extract_makefile_targets, parse_gitignore_entries
+
+logger = logging.getLogger(__name__)
+
+_AIDA_UPDATE_HEADER = "# Added by aida plugin update"
+
+
+def apply_patches(
+    plugin_path: Path,
+    diff_report: DiffReport,
+    overrides: dict[str, MergeStrategy] | None = None,
+) -> list[PatchResult]:
+    """Apply patches to a plugin directory.
+
+    Processes every file in the diff report that needs action,
+    creates a backup before modifications, applies the
+    appropriate merge strategy, and updates the generator
+    version.
+
+    Args:
+        plugin_path: Absolute path to the plugin directory
+        diff_report: Scan results from the scanner module
+        overrides: Optional mapping of file paths to
+            strategies that override the defaults
+
+    Returns:
+        List of PatchResult for every file processed
+    """
+    if overrides is None:
+        overrides = {}
+
+    actionable = [
+        f
+        for f in diff_report.files
+        if f.status in (FileStatus.MISSING, FileStatus.OUTDATED)
+    ]
+
+    if not actionable:
+        logger.info("No files need patching")
+        return [
+            _update_generator_version(plugin_path),
+        ]
+
+    backup_path = _create_backup(plugin_path, actionable)
+
+    results: list[PatchResult] = []
+    for file_diff in actionable:
+        strategy = overrides.get(
+            file_diff.path, file_diff.strategy
+        )
+        try:
+            result = _apply_strategy(
+                plugin_path, file_diff, strategy, backup_path
+            )
+            results.append(result)
+        except Exception:
+            logger.error(
+                "Failed to patch %s",
+                file_diff.path,
+                exc_info=True,
+            )
+            results.append(
+                PatchResult(
+                    path=file_diff.path,
+                    action="failed",
+                    message="Unexpected error during patching",
+                )
+            )
+
+    results.append(_update_generator_version(plugin_path))
+    return results
+
+
+def _create_backup(
+    plugin_path: Path,
+    actionable: list[FileDiff],
+) -> Path:
+    """Create a backup of files that will be modified.
+
+    Only backs up files that exist on disk; missing files
+    are skipped since there is nothing to preserve.
+
+    Args:
+        plugin_path: Absolute path to the plugin directory
+        actionable: Files that will be patched
+
+    Returns:
+        Path to the backup directory
+    """
+    timestamp = datetime.now(timezone.utc).strftime(
+        "%Y%m%d_%H%M%S"
+    )
+    backup_path = (
+        plugin_path / ".aida-backup" / timestamp
+    )
+    backup_path.mkdir(parents=True, exist_ok=True)
+
+    for file_diff in actionable:
+        source = plugin_path / file_diff.path
+        if source.exists():
+            dest = backup_path / file_diff.path
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(str(source), str(dest))
+            logger.debug("Backed up %s", file_diff.path)
+
+    logger.info("Backup created at %s", backup_path)
+    return backup_path
+
+
+def _apply_strategy(
+    plugin_path: Path,
+    file_diff: FileDiff,
+    strategy: MergeStrategy,
+    backup_path: Path,
+) -> PatchResult:
+    """Route a file to the appropriate strategy handler.
+
+    Args:
+        plugin_path: Absolute path to the plugin directory
+        file_diff: Comparison data for the file
+        strategy: Merge strategy to apply
+        backup_path: Path to the backup directory
+
+    Returns:
+        PatchResult describing what was done
+    """
+    if strategy == MergeStrategy.SKIP:
+        return _apply_skip(file_diff)
+    if strategy == MergeStrategy.OVERWRITE:
+        return _apply_overwrite(
+            plugin_path, file_diff, backup_path
+        )
+    if strategy == MergeStrategy.ADD:
+        return _apply_add(plugin_path, file_diff)
+    if strategy == MergeStrategy.MERGE:
+        return _apply_merge(
+            plugin_path, file_diff, backup_path
+        )
+    if strategy == MergeStrategy.MANUAL_REVIEW:
+        return _apply_manual_review(file_diff)
+
+    logger.warning(
+        "Unknown strategy %s for %s, skipping",
+        strategy,
+        file_diff.path,
+    )
+    return PatchResult(
+        path=file_diff.path,
+        action="skipped",
+        message=f"Unknown strategy: {strategy.value}",
+    )
+
+
+def _apply_skip(file_diff: FileDiff) -> PatchResult:
+    """Handle a file with SKIP strategy.
+
+    Args:
+        file_diff: Comparison data for the file
+
+    Returns:
+        PatchResult with action skipped
+    """
+    return PatchResult(
+        path=file_diff.path,
+        action="skipped",
+        message=(
+            "Skipped: file is managed by the plugin author"
+        ),
+    )
+
+
+def _apply_overwrite(
+    plugin_path: Path,
+    file_diff: FileDiff,
+    backup_path: Path,
+) -> PatchResult:
+    """Overwrite a file with expected content.
+
+    Args:
+        plugin_path: Absolute path to the plugin directory
+        file_diff: Comparison data with expected_content
+        backup_path: Path to the backup directory
+
+    Returns:
+        PatchResult with action updated
+    """
+    target = plugin_path / file_diff.path
+    content = file_diff.expected_content or ""
+
+    _atomic_write(target, content)
+
+    backup_file = backup_path / file_diff.path
+    backup_ref = (
+        str(backup_file) if backup_file.exists() else ""
+    )
+
+    return PatchResult(
+        path=file_diff.path,
+        action="updated",
+        message="Overwritten with current standard",
+        backup_path=backup_ref,
+    )
+
+
+def _apply_add(
+    plugin_path: Path,
+    file_diff: FileDiff,
+) -> PatchResult:
+    """Add a file only if it does not already exist.
+
+    Args:
+        plugin_path: Absolute path to the plugin directory
+        file_diff: Comparison data with expected_content
+
+    Returns:
+        PatchResult with action created or skipped
+    """
+    target = plugin_path / file_diff.path
+
+    if target.exists():
+        return PatchResult(
+            path=file_diff.path,
+            action="skipped",
+            message="File already exists",
+        )
+
+    content = file_diff.expected_content or ""
+    _atomic_write(target, content)
+
+    return PatchResult(
+        path=file_diff.path,
+        action="created",
+        message="Created from current standard",
+    )
+
+
+def _apply_merge(
+    plugin_path: Path,
+    file_diff: FileDiff,
+    backup_path: Path,
+) -> PatchResult:
+    """Route merge to the file-specific handler.
+
+    Args:
+        plugin_path: Absolute path to the plugin directory
+        file_diff: Comparison data for the file
+        backup_path: Path to the backup directory
+
+    Returns:
+        PatchResult from the appropriate merge handler
+    """
+    if file_diff.path == ".gitignore":
+        return _merge_gitignore(
+            plugin_path, file_diff, backup_path
+        )
+    if file_diff.path == "Makefile":
+        return _merge_makefile(
+            plugin_path, file_diff, backup_path
+        )
+
+    logger.warning(
+        "No merge handler for %s, falling back to "
+        "overwrite",
+        file_diff.path,
+    )
+    return _apply_overwrite(
+        plugin_path, file_diff, backup_path
+    )
+
+
+def _merge_gitignore(
+    plugin_path: Path,
+    file_diff: FileDiff,
+    backup_path: Path,
+) -> PatchResult:
+    """Append-only merge for .gitignore files.
+
+    Parses both current and expected content into sets of
+    active entries, then appends any missing entries under
+    a clearly marked comment header.
+
+    Args:
+        plugin_path: Absolute path to the plugin directory
+        file_diff: Comparison data for .gitignore
+        backup_path: Path to the backup directory
+
+    Returns:
+        PatchResult describing the merge outcome
+    """
+    target = plugin_path / file_diff.path
+    current = file_diff.actual_content or ""
+    expected = file_diff.expected_content or ""
+
+    # If file is missing on disk, write the full expected
+    if file_diff.status == FileStatus.MISSING:
+        _atomic_write(target, expected)
+        return PatchResult(
+            path=file_diff.path,
+            action="created",
+            message="Created .gitignore from standard",
+        )
+
+    current_entries = parse_gitignore_entries(current)
+    expected_entries = parse_gitignore_entries(expected)
+
+    missing = sorted(expected_entries - current_entries)
+
+    if not missing:
+        return PatchResult(
+            path=file_diff.path,
+            action="skipped",
+            message="All expected entries already present",
+        )
+
+    # Preserve original content and append missing entries
+    merged = current.rstrip("\n")
+    merged += "\n\n" + _AIDA_UPDATE_HEADER + "\n"
+    merged += "\n".join(missing) + "\n"
+
+    _atomic_write(target, merged)
+
+    backup_file = backup_path / file_diff.path
+    backup_ref = (
+        str(backup_file) if backup_file.exists() else ""
+    )
+
+    return PatchResult(
+        path=file_diff.path,
+        action="updated",
+        message=(
+            f"Added {len(missing)} entries: "
+            + ", ".join(missing[:5])
+            + (
+                f" (and {len(missing) - 5} more)"
+                if len(missing) > 5
+                else ""
+            )
+        ),
+        backup_path=backup_ref,
+    )
+
+
+def _merge_makefile(
+    plugin_path: Path,
+    file_diff: FileDiff,
+    backup_path: Path,
+) -> PatchResult:
+    """Conservative target-addition merge for Makefiles.
+
+    Extracts target names from both current and expected
+    content, then appends full target blocks for any targets
+    that are present in the expected content but missing from
+    the current Makefile.
+
+    Args:
+        plugin_path: Absolute path to the plugin directory
+        file_diff: Comparison data for Makefile
+        backup_path: Path to the backup directory
+
+    Returns:
+        PatchResult describing the merge outcome
+    """
+    target = plugin_path / file_diff.path
+    current = file_diff.actual_content or ""
+    expected = file_diff.expected_content or ""
+
+    # If file is missing on disk, write the full expected
+    if file_diff.status == FileStatus.MISSING:
+        _atomic_write(target, expected)
+        return PatchResult(
+            path=file_diff.path,
+            action="created",
+            message="Created Makefile from standard",
+        )
+
+    current_targets = extract_makefile_targets(current)
+    expected_targets = extract_makefile_targets(expected)
+
+    missing = sorted(expected_targets - current_targets)
+
+    if not missing:
+        return PatchResult(
+            path=file_diff.path,
+            action="skipped",
+            message="All expected targets already present",
+        )
+
+    # Extract full blocks for each missing target
+    blocks: list[str] = []
+    added_targets: list[str] = []
+    for name in missing:
+        block = _extract_makefile_target_block(
+            expected, name
+        )
+        if block:
+            blocks.append(block)
+            added_targets.append(name)
+
+    if not blocks:
+        return PatchResult(
+            path=file_diff.path,
+            action="skipped",
+            message=(
+                "Could not extract blocks for missing "
+                "targets"
+            ),
+        )
+
+    # Build .PHONY declaration only for targets we
+    # actually extracted
+    phony_line = ".PHONY: " + " ".join(added_targets)
+
+    # Preserve original and append
+    merged = current.rstrip("\n")
+    merged += "\n\n" + _AIDA_UPDATE_HEADER + "\n"
+    merged += phony_line + "\n\n"
+    merged += "\n\n".join(blocks) + "\n"
+
+    _atomic_write(target, merged)
+
+    backup_file = backup_path / file_diff.path
+    backup_ref = (
+        str(backup_file) if backup_file.exists() else ""
+    )
+
+    return PatchResult(
+        path=file_diff.path,
+        action="updated",
+        message=(
+            f"Added {len(added_targets)} targets: "
+            + ", ".join(added_targets[:5])
+            + (
+                f" (and {len(added_targets) - 5} more)"
+                if len(added_targets) > 5
+                else ""
+            )
+        ),
+        backup_path=backup_ref,
+    )
+
+
+def _apply_manual_review(
+    file_diff: FileDiff,
+) -> PatchResult:
+    """Handle a file that needs manual review.
+
+    Args:
+        file_diff: Comparison data for the file
+
+    Returns:
+        PatchResult with action skipped and review note
+    """
+    return PatchResult(
+        path=file_diff.path,
+        action="skipped",
+        message=(
+            "Needs manual review: automatic merge not "
+            "supported for this file type"
+        ),
+    )
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write content atomically using a temporary file.
+
+    Writes to a .tmp sibling file then uses os.replace()
+    for an atomic rename. Cleans up the temporary file on
+    error.
+
+    Args:
+        path: Target file path
+        content: String content to write
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = Path(str(path) + ".tmp")
+
+    try:
+        tmp_path.write_text(content)
+        os.replace(str(tmp_path), str(path))
+    except Exception:
+        # Clean up temp file on failure
+        if tmp_path.exists():
+            tmp_path.unlink()
+        raise
+
+
+def _update_generator_version(
+    plugin_path: Path,
+) -> PatchResult:
+    """Update generator_version in aida-config.json.
+
+    Reads the existing config, updates the version field,
+    and writes back atomically. Creates the file if it does
+    not exist.
+
+    Args:
+        plugin_path: Absolute path to the plugin directory
+
+    Returns:
+        PatchResult for the version update
+    """
+    config_path = (
+        plugin_path / ".claude-plugin" / "aida-config.json"
+    )
+
+    try:
+        if config_path.exists():
+            data: dict[str, Any] = json.loads(
+                config_path.read_text()
+            )
+        else:
+            data = {}
+
+        data["generator_version"] = GENERATOR_VERSION
+
+        content = json.dumps(data, indent=2) + "\n"
+        _atomic_write(config_path, content)
+
+        return PatchResult(
+            path=".claude-plugin/aida-config.json",
+            action="updated",
+            message=(
+                f"Generator version set to "
+                f"{GENERATOR_VERSION}"
+            ),
+        )
+    except Exception:
+        logger.error(
+            "Failed to update generator version",
+            exc_info=True,
+        )
+        return PatchResult(
+            path=".claude-plugin/aida-config.json",
+            action="failed",
+            message="Could not update generator version",
+        )
+
+
+def _extract_makefile_target_block(
+    content: str,
+    target_name: str,
+) -> str:
+    """Extract a full target block from Makefile content.
+
+    Finds the target definition line and collects all
+    subsequent lines that are tab-indented or empty, stopping
+    at the next target definition or a non-empty line that is
+    not tab-indented.
+
+    Args:
+        content: Full Makefile text
+        target_name: Name of the target to extract
+
+    Returns:
+        The complete target block including the definition
+        line, or empty string if not found
+    """
+    lines = content.splitlines()
+    target_pattern = re.compile(
+        rf"^{re.escape(target_name)}:"
+    )
+
+    start_idx: int | None = None
+    for i, line in enumerate(lines):
+        if target_pattern.match(line):
+            start_idx = i
+            break
+
+    if start_idx is None:
+        return ""
+
+    block_lines = [lines[start_idx]]
+
+    for i in range(start_idx + 1, len(lines)):
+        line = lines[i]
+        # Empty lines are part of the block
+        if not line.strip():
+            block_lines.append(line)
+            continue
+        # Tab-indented lines are recipe lines
+        if line.startswith("\t"):
+            block_lines.append(line)
+            continue
+        # Anything else ends the block
+        break
+
+    # Strip trailing empty lines from the block
+    while block_lines and not block_lines[-1].strip():
+        block_lines.pop()
+
+    return "\n".join(block_lines)

--- a/skills/plugin-manager/scripts/operations/update_ops/scanner.py
+++ b/skills/plugin-manager/scripts/operations/update_ops/scanner.py
@@ -1,0 +1,646 @@
+"""Plugin scanner for the update operation.
+
+Scans an existing plugin directory, compares each file against
+the current scaffold templates, and produces a DiffReport.
+
+This module is strictly read-only: it never modifies any files
+on disk.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from shared.utils import render_template
+
+from ..constants import GENERATOR_VERSION
+from ..shared import build_template_variables
+from .models import (
+    DiffReport,
+    FileCategory,
+    FileDiff,
+    FileStatus,
+    MergeStrategy,
+)
+from .parsers import extract_makefile_targets, parse_gitignore_entries
+from .strategies import FileSpec, get_file_specs
+
+logger = logging.getLogger(__name__)
+
+
+def scan_plugin(
+    plugin_path: Path,
+    templates_dir: Path,
+) -> DiffReport:
+    """Scan a plugin directory and produce a DiffReport.
+
+    Reads the plugin metadata, detects the language, renders
+    each scaffold template, and compares expected vs actual
+    file contents.
+
+    Args:
+        plugin_path: Absolute path to the plugin directory
+        templates_dir: Path to the scaffold templates directory
+
+    Returns:
+        DiffReport comparing actual files to current standards
+
+    Raises:
+        ValueError: If plugin_path lacks a plugin.json manifest
+    """
+    plugin_json = (
+        plugin_path / ".claude-plugin" / "plugin.json"
+    )
+    if not plugin_json.exists():
+        raise ValueError(
+            f"Not a valid plugin: {plugin_path} "
+            "(missing .claude-plugin/plugin.json)"
+        )
+
+    metadata = _read_plugin_metadata(plugin_path)
+    gen_version = _read_generator_version(plugin_path)
+    language = _detect_language(plugin_path)
+
+    context = _build_scan_context(
+        plugin_path, metadata, language
+    )
+    license_text = _resolve_license_text(context)
+    variables = build_template_variables(
+        context, license_text
+    )
+
+    specs = get_file_specs(language)
+    diffs: list[FileDiff] = []
+
+    for spec in specs:
+        try:
+            diff = _compare_file(
+                plugin_path, spec, variables, templates_dir
+            )
+            diffs.append(diff)
+        except Exception:
+            logger.warning(
+                "Error comparing %s, marking as outdated",
+                spec.path,
+                exc_info=True,
+            )
+            diffs.append(
+                FileDiff(
+                    path=spec.path,
+                    category=spec.category,
+                    status=FileStatus.OUTDATED,
+                    strategy=spec.default_strategy,
+                    diff_summary=(
+                        "Error during comparison"
+                    ),
+                )
+            )
+
+    return DiffReport(
+        plugin_path=str(plugin_path),
+        plugin_name=metadata.get("name", "unknown"),
+        language=language,
+        generator_version=gen_version,
+        current_version=GENERATOR_VERSION,
+        files=diffs,
+    )
+
+
+def _read_plugin_metadata(
+    plugin_path: Path,
+) -> dict[str, Any]:
+    """Read and parse .claude-plugin/plugin.json.
+
+    Args:
+        plugin_path: Absolute path to the plugin directory
+
+    Returns:
+        Parsed plugin.json as a dictionary
+    """
+    plugin_json = (
+        plugin_path / ".claude-plugin" / "plugin.json"
+    )
+    try:
+        return json.loads(plugin_json.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning(
+            "Failed to read plugin.json: %s", exc
+        )
+        return {}
+
+
+def _read_generator_version(plugin_path: Path) -> str:
+    """Read the generator_version from aida-config.json.
+
+    Args:
+        plugin_path: Absolute path to the plugin directory
+
+    Returns:
+        Version string, or "0.0.0" if unavailable
+    """
+    config_path = (
+        plugin_path / ".claude-plugin" / "aida-config.json"
+    )
+    if not config_path.exists():
+        return "0.0.0"
+
+    try:
+        data = json.loads(config_path.read_text())
+        return data.get("generator_version", "0.0.0")
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning(
+            "Failed to read aida-config.json: %s", exc
+        )
+        return "0.0.0"
+
+
+def _detect_language(plugin_path: Path) -> str:
+    """Detect the plugin language from filesystem markers.
+
+    Checks for language-specific files in order of
+    specificity:
+    - pyproject.toml -> "python"
+    - package.json -> "typescript"
+    - scripts/ directory -> "python"
+    - src/ directory -> "typescript"
+    - default: "python"
+
+    Args:
+        plugin_path: Absolute path to the plugin directory
+
+    Returns:
+        "python" or "typescript"
+    """
+    if (plugin_path / "pyproject.toml").exists():
+        return "python"
+    if (plugin_path / "package.json").exists():
+        return "typescript"
+    if (plugin_path / "scripts").is_dir():
+        return "python"
+    if (plugin_path / "src").is_dir():
+        return "typescript"
+    return "python"
+
+
+def _build_scan_context(
+    plugin_path: Path,
+    metadata: dict[str, Any],
+    language: str,
+) -> dict[str, Any]:
+    """Build a context dict from existing plugin metadata.
+
+    Extracts values from plugin.json and supplements with
+    git config for fields not stored in the manifest (e.g.
+    author_email).
+
+    Args:
+        plugin_path: Absolute path to the plugin directory
+        metadata: Parsed plugin.json dictionary
+        language: Detected language string
+
+    Returns:
+        Context dict suitable for build_template_variables()
+    """
+    # Import here to avoid circular dependency at module
+    # level; scaffold_ops.context is a sibling subpackage.
+    from ..scaffold_ops.context import infer_git_config
+
+    git_config = infer_git_config()
+
+    # plugin.json stores author as an object or a string
+    author_field = metadata.get("author", "")
+    if isinstance(author_field, dict):
+        author_name = author_field.get("name", "")
+        author_email = author_field.get("email", "")
+    else:
+        author_name = str(author_field)
+        author_email = ""
+
+    # Fall back to git config when metadata is incomplete
+    if not author_name:
+        author_name = git_config.get("author_name", "")
+    if not author_email:
+        author_email = git_config.get("author_email", "")
+
+    keywords = metadata.get("keywords", [])
+
+    return {
+        "plugin_name": metadata.get("name", "unknown"),
+        "description": metadata.get("description", ""),
+        "version": metadata.get("version", "0.1.0"),
+        "author_name": author_name,
+        "author_email": author_email,
+        "license_id": metadata.get("license", "MIT"),
+        "language": language,
+        "keywords": keywords,
+        "repository_url": metadata.get("repository", ""),
+    }
+
+
+def _resolve_license_text(
+    context: dict[str, Any],
+) -> str:
+    """Resolve the full license text for template rendering.
+
+    Args:
+        context: Scan context dictionary
+
+    Returns:
+        Rendered license body text
+    """
+    from ..scaffold_ops.licenses import get_license_text
+
+    year = str(datetime.now(timezone.utc).year)
+    author = context.get("author_name", "")
+    license_id = context.get("license_id", "MIT")
+
+    try:
+        return get_license_text(license_id, year, author)
+    except ValueError:
+        logger.warning(
+            "Unsupported license '%s', falling back to MIT",
+            license_id,
+        )
+        return get_license_text("MIT", year, author)
+
+
+def _compare_file(
+    plugin_path: Path,
+    spec: FileSpec,
+    variables: dict[str, Any],
+    templates_dir: Path,
+) -> FileDiff:
+    """Compare a single file against its template.
+
+    Routes to specialised handlers for COMPOSITE files and
+    returns early for CUSTOM / SKIP files.
+
+    Args:
+        plugin_path: Absolute path to the plugin directory
+        spec: File specification from the strategy registry
+        variables: Rendered template variables
+        templates_dir: Path to scaffold templates directory
+
+    Returns:
+        FileDiff describing the comparison result
+    """
+    # Custom and metadata files with SKIP strategy are never
+    # compared; they belong to the plugin author.
+    if (
+        spec.category
+        in (FileCategory.CUSTOM, FileCategory.METADATA)
+        or spec.default_strategy == MergeStrategy.SKIP
+    ):
+        return FileDiff(
+            path=spec.path,
+            category=spec.category,
+            status=FileStatus.CUSTOM_SKIP,
+            strategy=MergeStrategy.SKIP,
+        )
+
+    # Composite files need special merge-aware comparison
+    if spec.category == FileCategory.COMPOSITE:
+        if spec.path == ".gitignore":
+            return _compare_gitignore(
+                plugin_path, variables, templates_dir
+            )
+        if spec.path == "Makefile":
+            return _compare_makefile(
+                plugin_path, variables, templates_dir
+            )
+        # Unknown composite -- treat as manual review
+        return FileDiff(
+            path=spec.path,
+            category=spec.category,
+            status=FileStatus.OUTDATED,
+            strategy=MergeStrategy.MANUAL_REVIEW,
+            diff_summary="Unknown composite file",
+        )
+
+    # Dependency configs: presence-only check
+    if spec.category == FileCategory.DEPENDENCY_CONFIG:
+        actual_path = plugin_path / spec.path
+        status = (
+            FileStatus.UP_TO_DATE
+            if actual_path.exists()
+            else FileStatus.MISSING
+        )
+        return FileDiff(
+            path=spec.path,
+            category=spec.category,
+            status=status,
+            strategy=MergeStrategy.MANUAL_REVIEW,
+            diff_summary=(
+                ""
+                if status == FileStatus.UP_TO_DATE
+                else "File does not exist"
+            ),
+        )
+
+    # Regular template-backed files
+    return _compare_templated_file(
+        plugin_path, spec, variables, templates_dir
+    )
+
+
+def _compare_templated_file(
+    plugin_path: Path,
+    spec: FileSpec,
+    variables: dict[str, Any],
+    templates_dir: Path,
+) -> FileDiff:
+    """Compare a regular template-backed file.
+
+    Renders the template and compares byte-for-byte against
+    the file on disk.
+
+    Args:
+        plugin_path: Absolute path to the plugin directory
+        spec: File specification with a non-None template
+        variables: Rendered template variables
+        templates_dir: Path to scaffold templates directory
+
+    Returns:
+        FileDiff with status MISSING, OUTDATED,
+        or UP_TO_DATE
+    """
+    actual_path = plugin_path / spec.path
+
+    if spec.template is None:
+        # No template to compare against; skip quietly
+        return FileDiff(
+            path=spec.path,
+            category=spec.category,
+            status=FileStatus.CUSTOM_SKIP,
+            strategy=MergeStrategy.SKIP,
+        )
+
+    expected = render_template(
+        templates_dir, spec.template, variables
+    )
+
+    if not actual_path.exists():
+        return FileDiff(
+            path=spec.path,
+            category=spec.category,
+            status=FileStatus.MISSING,
+            strategy=spec.default_strategy,
+            expected_content=expected,
+            diff_summary="File does not exist",
+        )
+
+    actual = actual_path.read_text()
+
+    if actual == expected:
+        return FileDiff(
+            path=spec.path,
+            category=spec.category,
+            status=FileStatus.UP_TO_DATE,
+            strategy=spec.default_strategy,
+            expected_content=expected,
+            actual_content=actual,
+        )
+
+    return FileDiff(
+        path=spec.path,
+        category=spec.category,
+        status=FileStatus.OUTDATED,
+        strategy=spec.default_strategy,
+        expected_content=expected,
+        actual_content=actual,
+        diff_summary="Content differs from template",
+    )
+
+
+def _render_composite_gitignore(
+    variables: dict[str, Any],
+    templates_dir: Path,
+) -> str:
+    """Render the expected .gitignore from template fragments.
+
+    Concatenates the shared and language-specific gitignore
+    templates, matching the logic in
+    scaffold_ops.generators.assemble_gitignore.
+
+    Args:
+        variables: Template variables (language key used)
+        templates_dir: Path to scaffold templates directory
+
+    Returns:
+        Expected .gitignore content as a single string
+    """
+    language = variables.get("language", "python")
+
+    shared = render_template(
+        templates_dir,
+        "shared/gitignore-shared.jinja2",
+        {},
+    )
+
+    if language == "python":
+        lang_part = render_template(
+            templates_dir,
+            "python/gitignore-python.jinja2",
+            {},
+        )
+    else:
+        lang_part = render_template(
+            templates_dir,
+            "typescript/gitignore-node.jinja2",
+            {},
+        )
+
+    return "\n".join([shared, lang_part])
+
+
+def _compare_gitignore(
+    plugin_path: Path,
+    variables: dict[str, Any],
+    templates_dir: Path,
+) -> FileDiff:
+    """Compare .gitignore against expected template output.
+
+    Uses set-based comparison of active entries rather than
+    exact string matching so that ordering differences and
+    user additions do not trigger false positives.
+
+    Args:
+        plugin_path: Absolute path to the plugin directory
+        variables: Rendered template variables
+        templates_dir: Path to scaffold templates directory
+
+    Returns:
+        FileDiff for .gitignore
+    """
+    expected_content = _render_composite_gitignore(
+        variables, templates_dir
+    )
+    actual_path = plugin_path / ".gitignore"
+
+    if not actual_path.exists():
+        return FileDiff(
+            path=".gitignore",
+            category=FileCategory.COMPOSITE,
+            status=FileStatus.MISSING,
+            strategy=MergeStrategy.MERGE,
+            expected_content=expected_content,
+            diff_summary="File does not exist",
+        )
+
+    actual_content = actual_path.read_text()
+    expected_entries = parse_gitignore_entries(
+        expected_content
+    )
+    actual_entries = parse_gitignore_entries(
+        actual_content
+    )
+
+    missing = expected_entries - actual_entries
+
+    if not missing:
+        return FileDiff(
+            path=".gitignore",
+            category=FileCategory.COMPOSITE,
+            status=FileStatus.UP_TO_DATE,
+            strategy=MergeStrategy.MERGE,
+            expected_content=expected_content,
+            actual_content=actual_content,
+        )
+
+    sorted_missing = sorted(missing)
+    summary = (
+        f"Missing {len(sorted_missing)} entries: "
+        + ", ".join(sorted_missing[:10])
+    )
+    if len(sorted_missing) > 10:
+        summary += f" (and {len(sorted_missing) - 10} more)"
+
+    return FileDiff(
+        path=".gitignore",
+        category=FileCategory.COMPOSITE,
+        status=FileStatus.OUTDATED,
+        strategy=MergeStrategy.MERGE,
+        expected_content=expected_content,
+        actual_content=actual_content,
+        diff_summary=summary,
+    )
+
+
+def _render_composite_makefile(
+    variables: dict[str, Any],
+    templates_dir: Path,
+) -> str:
+    """Render the expected Makefile from template fragments.
+
+    Concatenates the header and language-specific target
+    templates, matching the logic in
+    scaffold_ops.generators.assemble_makefile.
+
+    Args:
+        variables: Template variables
+        templates_dir: Path to scaffold templates directory
+
+    Returns:
+        Expected Makefile content as a single string
+    """
+    language = variables.get("language", "python")
+
+    header = render_template(
+        templates_dir,
+        "shared/makefile-header.jinja2",
+        variables,
+    )
+
+    if language == "python":
+        lang_targets = render_template(
+            templates_dir,
+            "python/makefile-python.jinja2",
+            variables,
+        )
+    else:
+        lang_targets = render_template(
+            templates_dir,
+            "typescript/makefile-typescript.jinja2",
+            variables,
+        )
+
+    return "\n".join([header, lang_targets])
+
+
+def _compare_makefile(
+    plugin_path: Path,
+    variables: dict[str, Any],
+    templates_dir: Path,
+) -> FileDiff:
+    """Compare Makefile against expected template output.
+
+    Uses target-name comparison rather than exact string
+    matching so that custom additions or formatting changes
+    do not trigger false positives.
+
+    Args:
+        plugin_path: Absolute path to the plugin directory
+        variables: Rendered template variables
+        templates_dir: Path to scaffold templates directory
+
+    Returns:
+        FileDiff for Makefile
+    """
+    expected_content = _render_composite_makefile(
+        variables, templates_dir
+    )
+    actual_path = plugin_path / "Makefile"
+
+    if not actual_path.exists():
+        return FileDiff(
+            path="Makefile",
+            category=FileCategory.COMPOSITE,
+            status=FileStatus.MISSING,
+            strategy=MergeStrategy.MERGE,
+            expected_content=expected_content,
+            diff_summary="File does not exist",
+        )
+
+    actual_content = actual_path.read_text()
+    expected_targets = extract_makefile_targets(
+        expected_content
+    )
+    actual_targets = extract_makefile_targets(
+        actual_content
+    )
+
+    missing = expected_targets - actual_targets
+
+    if not missing:
+        return FileDiff(
+            path="Makefile",
+            category=FileCategory.COMPOSITE,
+            status=FileStatus.UP_TO_DATE,
+            strategy=MergeStrategy.MERGE,
+            expected_content=expected_content,
+            actual_content=actual_content,
+        )
+
+    sorted_missing = sorted(missing)
+    summary = (
+        f"Missing {len(sorted_missing)} targets: "
+        + ", ".join(sorted_missing[:10])
+    )
+    if len(sorted_missing) > 10:
+        summary += (
+            f" (and {len(sorted_missing) - 10} more)"
+        )
+
+    return FileDiff(
+        path="Makefile",
+        category=FileCategory.COMPOSITE,
+        status=FileStatus.OUTDATED,
+        strategy=MergeStrategy.MERGE,
+        expected_content=expected_content,
+        actual_content=actual_content,
+        diff_summary=summary,
+    )

--- a/skills/plugin-manager/scripts/operations/update_ops/strategies.py
+++ b/skills/plugin-manager/scripts/operations/update_ops/strategies.py
@@ -1,0 +1,292 @@
+"""File classification and strategy registry for plugin update.
+
+Maps each scaffolded file to its category, template source,
+and default merge strategy. This is the single source of truth
+for how the update operation treats each file.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .models import FileCategory, MergeStrategy
+
+
+@dataclass(frozen=True)
+class FileSpec:
+    """Specification for a scaffolded file.
+
+    Attributes:
+        path: Relative path from plugin root
+        template: Template path relative to scaffold dir
+            (None for files with special handling)
+        category: File classification
+        default_strategy: How to handle during update
+        language: None for shared files, "python" or
+            "typescript" for language-specific files
+        user_overridable: Whether the user can change
+            the strategy
+    """
+
+    path: str
+    template: str | None
+    category: FileCategory
+    default_strategy: MergeStrategy
+    language: str | None = None
+    user_overridable: bool = False
+
+
+# Custom content: never modified by update
+_CUSTOM_FILES: list[FileSpec] = [
+    FileSpec(
+        "CLAUDE.md",
+        "shared/claude-md.jinja2",
+        FileCategory.CUSTOM,
+        MergeStrategy.SKIP,
+    ),
+    FileSpec(
+        "README.md",
+        "shared/readme.md.jinja2",
+        FileCategory.CUSTOM,
+        MergeStrategy.SKIP,
+    ),
+    FileSpec(
+        "LICENSE",
+        None,
+        FileCategory.CUSTOM,
+        MergeStrategy.SKIP,
+    ),
+]
+
+# AIDA metadata: never modified by update (generator_version
+# is updated separately by the patcher, not via template)
+_AIDA_METADATA_FILES: list[FileSpec] = [
+    FileSpec(
+        ".claude-plugin/aida-config.json",
+        "shared/aida-config.json.jinja2",
+        FileCategory.METADATA,
+        MergeStrategy.SKIP,
+    ),
+]
+
+# Pure boilerplate: safe to overwrite
+_BOILERPLATE_SHARED: list[FileSpec] = [
+    FileSpec(
+        ".markdownlint.json",
+        "shared/markdownlint.json.jinja2",
+        FileCategory.BOILERPLATE,
+        MergeStrategy.OVERWRITE,
+        user_overridable=True,
+    ),
+    FileSpec(
+        ".yamllint.yml",
+        "shared/yamllint.yml.jinja2",
+        FileCategory.BOILERPLATE,
+        MergeStrategy.OVERWRITE,
+        user_overridable=True,
+    ),
+    FileSpec(
+        ".frontmatter-schema.json",
+        "shared/frontmatter-schema.json.jinja2",
+        FileCategory.BOILERPLATE,
+        MergeStrategy.OVERWRITE,
+        user_overridable=True,
+    ),
+]
+
+_BOILERPLATE_PYTHON: list[FileSpec] = [
+    FileSpec(
+        ".python-version",
+        "python/python-version.jinja2",
+        FileCategory.BOILERPLATE,
+        MergeStrategy.OVERWRITE,
+        language="python",
+        user_overridable=True,
+    ),
+    FileSpec(
+        "tests/conftest.py",
+        "python/conftest.py.jinja2",
+        FileCategory.TEST_SCAFFOLD,
+        MergeStrategy.ADD,
+        language="python",
+        user_overridable=True,
+    ),
+]
+
+_BOILERPLATE_TYPESCRIPT: list[FileSpec] = [
+    FileSpec(
+        ".nvmrc",
+        "typescript/nvmrc.jinja2",
+        FileCategory.BOILERPLATE,
+        MergeStrategy.OVERWRITE,
+        language="typescript",
+        user_overridable=True,
+    ),
+    FileSpec(
+        ".prettierrc.json",
+        "typescript/prettierrc.json.jinja2",
+        FileCategory.BOILERPLATE,
+        MergeStrategy.OVERWRITE,
+        language="typescript",
+        user_overridable=True,
+    ),
+    FileSpec(
+        "eslint.config.mjs",
+        "typescript/eslint.config.mjs.jinja2",
+        FileCategory.BOILERPLATE,
+        MergeStrategy.OVERWRITE,
+        language="typescript",
+        user_overridable=True,
+    ),
+    FileSpec(
+        "tsconfig.json",
+        "typescript/tsconfig.json.jinja2",
+        FileCategory.BOILERPLATE,
+        MergeStrategy.OVERWRITE,
+        language="typescript",
+        user_overridable=True,
+    ),
+    FileSpec(
+        "vitest.config.ts",
+        "typescript/vitest.config.ts.jinja2",
+        FileCategory.BOILERPLATE,
+        MergeStrategy.OVERWRITE,
+        language="typescript",
+        user_overridable=True,
+    ),
+]
+
+# Plugin metadata: skip for v1.0 (deep-merge not yet
+# implemented; SKIP avoids overwriting user-added fields)
+_METADATA_FILES: list[FileSpec] = [
+    FileSpec(
+        ".claude-plugin/plugin.json",
+        "shared/plugin.json.jinja2",
+        FileCategory.METADATA,
+        MergeStrategy.SKIP,
+    ),
+    FileSpec(
+        ".claude-plugin/marketplace.json",
+        "shared/marketplace.json.jinja2",
+        FileCategory.METADATA,
+        MergeStrategy.SKIP,
+    ),
+]
+
+# Composite files: merge (append-only)
+_COMPOSITE_FILES: list[FileSpec] = [
+    FileSpec(
+        ".gitignore",
+        None,
+        FileCategory.COMPOSITE,
+        MergeStrategy.MERGE,
+    ),
+    FileSpec(
+        "Makefile",
+        None,
+        FileCategory.COMPOSITE,
+        MergeStrategy.MERGE,
+    ),
+]
+
+# CI workflows: add if missing, skip if exists
+_CI_FILES: list[FileSpec] = [
+    FileSpec(
+        ".github/workflows/ci.yml",
+        "python/ci.yml.jinja2",
+        FileCategory.CI_WORKFLOW,
+        MergeStrategy.ADD,
+        language="python",
+        user_overridable=True,
+    ),
+    FileSpec(
+        ".github/workflows/ci.yml",
+        "typescript/ci.yml.jinja2",
+        FileCategory.CI_WORKFLOW,
+        MergeStrategy.ADD,
+        language="typescript",
+        user_overridable=True,
+    ),
+]
+
+# Dependency configs: flag for manual review
+_DEPENDENCY_PYTHON: list[FileSpec] = [
+    FileSpec(
+        "pyproject.toml",
+        "python/pyproject.toml.jinja2",
+        FileCategory.DEPENDENCY_CONFIG,
+        MergeStrategy.MANUAL_REVIEW,
+        language="python",
+    ),
+]
+
+_DEPENDENCY_TYPESCRIPT: list[FileSpec] = [
+    FileSpec(
+        "package.json",
+        "typescript/package.json.jinja2",
+        FileCategory.DEPENDENCY_CONFIG,
+        MergeStrategy.MANUAL_REVIEW,
+        language="typescript",
+    ),
+]
+
+
+def get_file_specs(
+    language: str,
+) -> list[FileSpec]:
+    """Get the file specifications for a given language.
+
+    Returns the complete list of files that the scaffolder
+    would produce for a plugin of the given language.
+
+    Args:
+        language: "python" or "typescript"
+
+    Returns:
+        List of FileSpec for all applicable files
+    """
+    specs: list[FileSpec] = []
+
+    # Shared files (all languages)
+    specs.extend(_CUSTOM_FILES)
+    specs.extend(_AIDA_METADATA_FILES)
+    specs.extend(_BOILERPLATE_SHARED)
+    specs.extend(_METADATA_FILES)
+    specs.extend(_COMPOSITE_FILES)
+
+    # Language-specific files
+    if language == "python":
+        specs.extend(_BOILERPLATE_PYTHON)
+        specs.extend(
+            s for s in _CI_FILES if s.language == "python"
+        )
+        specs.extend(_DEPENDENCY_PYTHON)
+    elif language == "typescript":
+        specs.extend(_BOILERPLATE_TYPESCRIPT)
+        specs.extend(
+            s
+            for s in _CI_FILES
+            if s.language == "typescript"
+        )
+        specs.extend(_DEPENDENCY_TYPESCRIPT)
+
+    return specs
+
+
+def get_spec_by_path(
+    path: str,
+    language: str,
+) -> FileSpec | None:
+    """Look up a file spec by its relative path.
+
+    Args:
+        path: Relative path from plugin root
+        language: Plugin language
+
+    Returns:
+        FileSpec if found, None otherwise
+    """
+    for spec in get_file_specs(language):
+        if spec.path == path:
+            return spec
+    return None

--- a/skills/plugin-manager/templates/scaffold/shared/aida-config.json.jinja2
+++ b/skills/plugin-manager/templates/scaffold/shared/aida-config.json.jinja2
@@ -1,4 +1,5 @@
 {
+  "generator_version": {{ generator_version | tojson }},
   "config": {
     "label": {{ (plugin_display_name + " Configuration") | tojson }},
     "description": {{ ("Configure " + plugin_display_name + " preferences") | tojson }},

--- a/tests/unit/test_update_integration.py
+++ b/tests/unit/test_update_integration.py
@@ -1,0 +1,612 @@
+"""Integration tests for plugin update end-to-end flow."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# Add scripts directories to path
+_project_root = Path(__file__).parent.parent.parent
+_plugin_scripts = (
+    _project_root / "skills" / "plugin-manager" / "scripts"
+)
+sys.path.insert(0, str(_project_root / "scripts"))
+sys.path.insert(0, str(_plugin_scripts))
+
+# Clear cached operations modules to avoid cross-manager
+# conflicts in pytest
+for _mod_name in list(sys.modules):
+    if _mod_name == "operations" or _mod_name.startswith(
+        "operations."
+    ):
+        del sys.modules[_mod_name]
+
+from operations import update as update_mod  # noqa: E402
+from operations import scaffold as scaffold_mod  # noqa: E402
+from operations.constants import (  # noqa: E402
+    GENERATOR_VERSION,
+)
+
+_GIT_MOCK_PATH = (
+    "operations.scaffold_ops.context.infer_git_config"
+)
+_GIT_MOCK_RETURN = {
+    "author_name": "Test Author",
+    "author_email": "test@test.com",
+}
+_GIT_INIT_PATH = (
+    "operations.scaffold_ops.generators.initialize_git"
+)
+_GIT_COMMIT_PATH = (
+    "operations.scaffold_ops.generators"
+    ".create_initial_commit"
+)
+
+
+def _scaffold_plugin(
+    tmp_dir: str,
+    name: str = "int-test-plugin",
+    language: str = "python",
+) -> Path:
+    """Scaffold a real plugin in a temp directory.
+
+    Returns:
+        Path to the created plugin directory.
+    """
+    target = str(Path(tmp_dir) / name)
+    context = {
+        "operation": "scaffold",
+        "plugin_name": name,
+        "description": (
+            "A test plugin for integration testing"
+        ),
+        "language": language,
+        "license": "MIT",
+        "author_name": "Test Author",
+        "author_email": "test@test.com",
+        "target_directory": target,
+        "include_agent_stub": False,
+        "include_skill_stub": False,
+        "keywords": "test",
+    }
+    result = scaffold_mod.execute(context)
+    assert result["success"], (
+        f"Scaffold failed: {result.get('message')}"
+    )
+    return Path(result["path"])
+
+
+class TestUpdatePhase1(unittest.TestCase):
+    """Tests for update_mod.get_questions (Phase 1)."""
+
+    def test_missing_plugin_path_returns_error(self):
+        """Should return error when plugin_path is missing."""
+        context: dict = {"operation": "update"}
+        result = update_mod.get_questions(context)
+        self.assertFalse(result["success"])
+        self.assertIn("plugin_path", result["message"])
+
+    def test_invalid_plugin_returns_error(self):
+        """Should return error for a non-plugin directory."""
+        with tempfile.TemporaryDirectory() as tmp:
+            context = {
+                "operation": "update",
+                "plugin_path": tmp,
+            }
+            result = update_mod.get_questions(context)
+            self.assertFalse(result["success"])
+            self.assertIn(
+                "plugin.json", result["message"]
+            )
+
+    @patch(
+        _GIT_COMMIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_INIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_up_to_date_plugin_no_questions(
+        self, _mock_git, _mock_init, _mock_commit
+    ):
+        """Fresh scaffolded plugin should need no updates."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _scaffold_plugin(tmp)
+            context = {
+                "operation": "update",
+                "plugin_path": str(plugin_dir),
+            }
+            result = update_mod.get_questions(context)
+
+            self.assertEqual(result["questions"], [])
+            self.assertFalse(
+                result["inferred"]["scan_result"][
+                    "needs_update"
+                ]
+            )
+
+    @patch(
+        _GIT_COMMIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_INIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_outdated_plugin_has_questions(
+        self, _mock_git, _mock_init, _mock_commit
+    ):
+        """Outdated boilerplate should produce questions."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _scaffold_plugin(tmp)
+            # Modify a boilerplate file to make it outdated
+            ml_path = plugin_dir / ".markdownlint.json"
+            ml_path.write_text('{"old": "config"}\n')
+
+            context = {
+                "operation": "update",
+                "plugin_path": str(plugin_dir),
+            }
+            result = update_mod.get_questions(context)
+
+            self.assertGreater(
+                len(result["questions"]), 0
+            )
+            scan = result["inferred"]["scan_result"]
+            self.assertTrue(scan["needs_update"])
+            outdated_paths = [
+                f["path"]
+                for f in scan["outdated_files"]
+            ]
+            self.assertIn(
+                ".markdownlint.json", outdated_paths
+            )
+
+    @patch(
+        _GIT_COMMIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_INIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_missing_only_no_boilerplate_question(
+        self, _mock_git, _mock_init, _mock_commit
+    ):
+        """Missing boilerplate should not ask boilerplate question."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _scaffold_plugin(tmp)
+            # Delete (not modify) a boilerplate file
+            ml_path = plugin_dir / ".markdownlint.json"
+            ml_path.unlink()
+
+            context = {
+                "operation": "update",
+                "plugin_path": str(plugin_dir),
+            }
+            result = update_mod.get_questions(context)
+
+            scan = result["inferred"]["scan_result"]
+            self.assertTrue(scan["needs_update"])
+            # No boilerplate question since only
+            # missing files (not outdated)
+            question_ids = [
+                q["id"] for q in result["questions"]
+            ]
+            self.assertNotIn(
+                "boilerplate_strategy", question_ids
+            )
+
+    @patch(
+        _GIT_COMMIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_INIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_inferred_contains_scan_result(
+        self, _mock_git, _mock_init, _mock_commit
+    ):
+        """Phase 1 inferred payload has expected structure."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _scaffold_plugin(tmp)
+            context = {
+                "operation": "update",
+                "plugin_path": str(plugin_dir),
+            }
+            result = update_mod.get_questions(context)
+
+            inferred = result["inferred"]
+            self.assertIn("plugin_name", inferred)
+            self.assertIn("language", inferred)
+            self.assertIn(
+                "generator_version", inferred
+            )
+            self.assertIn(
+                "current_standard", inferred
+            )
+            self.assertIn("scan_result", inferred)
+
+            scan = inferred["scan_result"]
+            self.assertIn("summary", scan)
+            self.assertIn("needs_update", scan)
+            self.assertIn("missing_files", scan)
+            self.assertIn("outdated_files", scan)
+            self.assertIn("up_to_date_files", scan)
+            self.assertIn("custom_skip_files", scan)
+
+
+class TestUpdatePhase2(unittest.TestCase):
+    """Tests for update_mod.execute (Phase 2)."""
+
+    @patch(
+        _GIT_COMMIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_INIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_up_to_date_returns_no_changes(
+        self, _mock_git, _mock_init, _mock_commit
+    ):
+        """Fresh plugin should return up-to-date result."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _scaffold_plugin(tmp)
+            context = {
+                "operation": "update",
+                "plugin_path": str(plugin_dir),
+            }
+            result = update_mod.execute(context)
+
+            self.assertTrue(result["success"])
+            self.assertIn(
+                "up to date", result["message"]
+            )
+            self.assertEqual(result["files_created"], [])
+            self.assertEqual(result["files_updated"], [])
+
+    @patch(
+        _GIT_COMMIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_INIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_restores_deleted_boilerplate(
+        self, _mock_git, _mock_init, _mock_commit
+    ):
+        """Deleted boilerplate file should be recreated."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _scaffold_plugin(tmp)
+            ml_path = plugin_dir / ".markdownlint.json"
+            ml_path.unlink()
+            self.assertFalse(ml_path.exists())
+
+            context = {
+                "operation": "update",
+                "plugin_path": str(plugin_dir),
+            }
+            result = update_mod.execute(context)
+
+            self.assertTrue(result["success"])
+            self.assertTrue(ml_path.exists())
+            # Verify the restored content is valid JSON
+            data = json.loads(ml_path.read_text())
+            self.assertIsInstance(data, dict)
+
+    @patch(
+        _GIT_COMMIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_INIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_preserves_custom_claudemd(
+        self, _mock_git, _mock_init, _mock_commit
+    ):
+        """CLAUDE.md custom content should be preserved."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _scaffold_plugin(tmp)
+            claude_md = plugin_dir / "CLAUDE.md"
+            custom_content = "# My Custom Instructions\n"
+            claude_md.write_text(custom_content)
+
+            # Delete a file to force an update run
+            ml_path = plugin_dir / ".markdownlint.json"
+            ml_path.unlink()
+
+            context = {
+                "operation": "update",
+                "plugin_path": str(plugin_dir),
+            }
+            update_mod.execute(context)
+
+            self.assertEqual(
+                claude_md.read_text(), custom_content
+            )
+
+    @patch(
+        _GIT_COMMIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_INIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_updates_generator_version(
+        self, _mock_git, _mock_init, _mock_commit
+    ):
+        """Generator version should be updated after patch."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _scaffold_plugin(tmp)
+            # Manually set an old generator_version
+            config_path = (
+                plugin_dir
+                / ".claude-plugin"
+                / "aida-config.json"
+            )
+            config = json.loads(config_path.read_text())
+            config["generator_version"] = "0.1.0"
+            config_path.write_text(
+                json.dumps(config, indent=2) + "\n"
+            )
+
+            # Delete a file so update has work to do
+            ml_path = plugin_dir / ".markdownlint.json"
+            ml_path.unlink()
+
+            context = {
+                "operation": "update",
+                "plugin_path": str(plugin_dir),
+            }
+            result = update_mod.execute(context)
+
+            self.assertTrue(result["success"])
+            self.assertEqual(
+                result["generator_version"],
+                GENERATOR_VERSION,
+            )
+
+            # Verify on-disk config was updated
+            updated = json.loads(
+                config_path.read_text()
+            )
+            self.assertEqual(
+                updated["generator_version"],
+                GENERATOR_VERSION,
+            )
+
+
+class TestUpdateRoundTrip(unittest.TestCase):
+    """Full round-trip tests (Phase 1 -> Phase 2)."""
+
+    @patch(
+        _GIT_COMMIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_INIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_full_round_trip(
+        self, _mock_git, _mock_init, _mock_commit
+    ):
+        """Phase 1 scan -> Phase 2 patch -> Phase 1 clean."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _scaffold_plugin(tmp)
+
+            # Delete two files to simulate drift
+            ml_path = plugin_dir / ".markdownlint.json"
+            fs_path = (
+                plugin_dir / ".frontmatter-schema.json"
+            )
+            ml_path.unlink()
+            fs_path.unlink()
+
+            context = {
+                "operation": "update",
+                "plugin_path": str(plugin_dir),
+            }
+
+            # Phase 1: scan should detect 2 missing files
+            phase1 = update_mod.get_questions(context)
+            scan = phase1["inferred"]["scan_result"]
+            self.assertTrue(scan["needs_update"])
+            missing_paths = [
+                f["path"] for f in scan["missing_files"]
+            ]
+            self.assertIn(
+                ".markdownlint.json", missing_paths
+            )
+            self.assertIn(
+                ".frontmatter-schema.json", missing_paths
+            )
+
+            # Phase 2: apply patches with default responses
+            phase2 = update_mod.execute(context, {})
+            self.assertTrue(phase2["success"])
+            self.assertTrue(ml_path.exists())
+            self.assertTrue(fs_path.exists())
+
+            # Phase 1 again: should be clean
+            phase1_after = update_mod.get_questions(
+                context
+            )
+            self.assertFalse(
+                phase1_after["inferred"]["scan_result"][
+                    "needs_update"
+                ]
+            )
+            self.assertEqual(
+                phase1_after["questions"], []
+            )
+
+
+class TestUpdateIdempotent(unittest.TestCase):
+    """Test that updates are idempotent."""
+
+    @patch(
+        _GIT_COMMIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_INIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_double_update_no_changes(
+        self, _mock_git, _mock_init, _mock_commit
+    ):
+        """Second update on same plugin reports up-to-date."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _scaffold_plugin(tmp)
+            ml_path = plugin_dir / ".markdownlint.json"
+            ml_path.unlink()
+
+            context = {
+                "operation": "update",
+                "plugin_path": str(plugin_dir),
+            }
+
+            # First update: should make changes
+            first = update_mod.execute(context)
+            self.assertTrue(first["success"])
+            self.assertTrue(ml_path.exists())
+
+            # Second update: should report up-to-date
+            second = update_mod.execute(context)
+            self.assertTrue(second["success"])
+            self.assertIn(
+                "up to date", second["message"]
+            )
+            self.assertEqual(
+                second["files_created"], []
+            )
+            self.assertEqual(
+                second["files_updated"], []
+            )
+
+
+class TestUpdatePreservesContent(unittest.TestCase):
+    """Test that updates preserve user-owned content."""
+
+    @patch(
+        _GIT_COMMIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_INIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_preserves_readme(
+        self, _mock_git, _mock_init, _mock_commit
+    ):
+        """README.md custom content survives an update."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _scaffold_plugin(tmp)
+            readme = plugin_dir / "README.md"
+            custom = "# My Custom README\n\nHello world.\n"
+            readme.write_text(custom)
+
+            # Delete a file to force an update
+            ml_path = plugin_dir / ".markdownlint.json"
+            ml_path.unlink()
+
+            context = {
+                "operation": "update",
+                "plugin_path": str(plugin_dir),
+            }
+            update_mod.execute(context)
+
+            self.assertEqual(readme.read_text(), custom)
+
+    @patch(
+        _GIT_COMMIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_INIT_PATH,
+        return_value=True,
+    )
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_preserves_license(
+        self, _mock_git, _mock_init, _mock_commit
+    ):
+        """LICENSE file custom content survives an update."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _scaffold_plugin(tmp)
+            license_file = plugin_dir / "LICENSE"
+            original = license_file.read_text()
+
+            # Delete a file to force an update
+            ml_path = plugin_dir / ".markdownlint.json"
+            ml_path.unlink()
+
+            context = {
+                "operation": "update",
+                "plugin_path": str(plugin_dir),
+            }
+            update_mod.execute(context)
+
+            self.assertEqual(
+                license_file.read_text(), original
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_update_patcher.py
+++ b/tests/unit/test_update_patcher.py
@@ -1,0 +1,1028 @@
+"""Unit tests for plugin-manager update patcher."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Add scripts directories to path
+_project_root = Path(__file__).parent.parent.parent
+_plugin_scripts = (
+    _project_root / "skills" / "plugin-manager" / "scripts"
+)
+sys.path.insert(0, str(_project_root / "scripts"))
+sys.path.insert(0, str(_plugin_scripts))
+
+# Clear cached operations modules to avoid cross-manager
+# conflicts in pytest
+for _mod_name in list(sys.modules):
+    if _mod_name == "operations" or _mod_name.startswith(
+        "operations."
+    ):
+        del sys.modules[_mod_name]
+
+from operations.update_ops.patcher import (  # noqa: E402
+    _atomic_write,
+    _create_backup,
+    _extract_makefile_target_block,
+    _merge_gitignore,
+    _merge_makefile,
+    _update_generator_version,
+    apply_patches,
+)
+from operations.update_ops.parsers import (  # noqa: E402
+    extract_makefile_targets,
+    parse_gitignore_entries,
+)
+from operations.update_ops.models import (  # noqa: E402
+    DiffReport,
+    FileDiff,
+    FileCategory,
+    FileStatus,
+    MergeStrategy,
+    PatchResult,
+)
+from operations.constants import (  # noqa: E402
+    GENERATOR_VERSION,
+)
+
+
+def _make_diff_report(
+    plugin_path: str,
+    files: list[FileDiff] | None = None,
+) -> DiffReport:
+    """Create a DiffReport for testing."""
+    return DiffReport(
+        plugin_path=plugin_path,
+        plugin_name="test-plugin",
+        language="python",
+        generator_version="0.7.0",
+        current_version=GENERATOR_VERSION,
+        files=files or [],
+    )
+
+
+def _make_file_diff(
+    path: str,
+    status: FileStatus = FileStatus.MISSING,
+    strategy: MergeStrategy = MergeStrategy.ADD,
+    category: FileCategory = FileCategory.BOILERPLATE,
+    expected_content: str = "expected content\n",
+    actual_content: str | None = None,
+    diff_summary: str = "",
+) -> FileDiff:
+    """Create a FileDiff for testing."""
+    return FileDiff(
+        path=path,
+        category=category,
+        status=status,
+        strategy=strategy,
+        expected_content=expected_content,
+        actual_content=actual_content,
+        diff_summary=diff_summary,
+    )
+
+
+class TestAtomicWrite(unittest.TestCase):
+    """Test _atomic_write for safe file writes."""
+
+    def test_writes_file_content(self):
+        """Write content and read back to verify match."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "test.txt"
+            _atomic_write(target, "hello world\n")
+            self.assertEqual(
+                target.read_text(), "hello world\n"
+            )
+
+    def test_creates_parent_directories(self):
+        """Write to nested path and verify dirs created."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = (
+                Path(tmp) / "a" / "b" / "c" / "deep.txt"
+            )
+            _atomic_write(target, "deep content\n")
+            self.assertTrue(target.exists())
+            self.assertEqual(
+                target.read_text(), "deep content\n"
+            )
+
+    def test_overwrites_existing_file(self):
+        """Write twice and verify second content wins."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "overwrite.txt"
+            _atomic_write(target, "first\n")
+            _atomic_write(target, "second\n")
+            self.assertEqual(target.read_text(), "second\n")
+
+    def test_cleans_up_tmp_on_success(self):
+        """After write, verify no .tmp file remains."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "clean.txt"
+            _atomic_write(target, "content\n")
+            tmp_file = Path(str(target) + ".tmp")
+            self.assertFalse(tmp_file.exists())
+
+
+class TestCreateBackup(unittest.TestCase):
+    """Test _create_backup for pre-patch safety copies."""
+
+    def test_creates_backup_directory(self):
+        """Backup dir should exist with timestamp format."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = Path(tmp) / "plugin"
+            plugin.mkdir()
+            src = plugin / "file.txt"
+            src.write_text("old content\n")
+
+            actionable = [
+                _make_file_diff(
+                    "file.txt",
+                    status=FileStatus.OUTDATED,
+                    strategy=MergeStrategy.OVERWRITE,
+                )
+            ]
+            backup = _create_backup(plugin, actionable)
+
+            self.assertTrue(backup.exists())
+            self.assertTrue(backup.is_dir())
+            # Backup lives under .aida-backup/
+            self.assertEqual(
+                backup.parent.name, ".aida-backup"
+            )
+            # Timestamp directory name: YYYYMMDD_HHMMSS
+            self.assertRegex(
+                backup.name, r"^\d{8}_\d{6}$"
+            )
+
+    def test_copies_existing_files(self):
+        """Files on disk that will be modified appear in backup."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = Path(tmp) / "plugin"
+            plugin.mkdir()
+            src = plugin / "readme.txt"
+            src.write_text("original readme\n")
+
+            actionable = [
+                _make_file_diff(
+                    "readme.txt",
+                    status=FileStatus.OUTDATED,
+                    strategy=MergeStrategy.OVERWRITE,
+                )
+            ]
+            backup = _create_backup(plugin, actionable)
+
+            backed_up = backup / "readme.txt"
+            self.assertTrue(backed_up.exists())
+            self.assertEqual(
+                backed_up.read_text(), "original readme\n"
+            )
+
+    def test_skips_missing_files(self):
+        """MISSING files have nothing on disk to back up."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = Path(tmp) / "plugin"
+            plugin.mkdir()
+
+            actionable = [
+                _make_file_diff(
+                    "new_file.txt",
+                    status=FileStatus.MISSING,
+                    strategy=MergeStrategy.ADD,
+                )
+            ]
+            backup = _create_backup(plugin, actionable)
+
+            # Backup dir exists but the missing file is not
+            # inside it
+            self.assertTrue(backup.exists())
+            self.assertFalse(
+                (backup / "new_file.txt").exists()
+            )
+
+    def test_preserves_directory_structure(self):
+        """Subdirectory paths are preserved in backup."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = Path(tmp) / "plugin"
+            (plugin / ".claude-plugin").mkdir(parents=True)
+            nested = plugin / ".claude-plugin" / "plugin.json"
+            nested.write_text('{"name":"test"}\n')
+
+            actionable = [
+                _make_file_diff(
+                    ".claude-plugin/plugin.json",
+                    status=FileStatus.OUTDATED,
+                    strategy=MergeStrategy.OVERWRITE,
+                )
+            ]
+            backup = _create_backup(plugin, actionable)
+
+            backed_up = (
+                backup / ".claude-plugin" / "plugin.json"
+            )
+            self.assertTrue(backed_up.exists())
+            self.assertEqual(
+                backed_up.read_text(), '{"name":"test"}\n'
+            )
+
+
+class TestMergeGitignore(unittest.TestCase):
+    """Test _merge_gitignore append-only merge logic."""
+
+    def _run_merge(
+        self,
+        current: str,
+        expected: str,
+        status: FileStatus = FileStatus.OUTDATED,
+    ) -> tuple[PatchResult, str]:
+        """Run a gitignore merge and return result + file.
+
+        Creates a temporary plugin directory, writes the
+        current content to .gitignore, and invokes the merge.
+
+        Returns:
+            Tuple of (PatchResult, final file content).
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = Path(tmp) / "plugin"
+            plugin.mkdir()
+            backup = plugin / ".aida-backup" / "test"
+            backup.mkdir(parents=True)
+
+            target = plugin / ".gitignore"
+            if status != FileStatus.MISSING:
+                target.write_text(current)
+                # Copy to backup so backup_path resolves
+                bk = backup / ".gitignore"
+                bk.write_text(current)
+
+            fd = _make_file_diff(
+                ".gitignore",
+                status=status,
+                strategy=MergeStrategy.MERGE,
+                category=FileCategory.COMPOSITE,
+                expected_content=expected,
+                actual_content=(
+                    current
+                    if status != FileStatus.MISSING
+                    else None
+                ),
+            )
+
+            result = _merge_gitignore(plugin, fd, backup)
+            content = target.read_text()
+        return result, content
+
+    def test_appends_missing_entries(self):
+        """Missing entries appended under update header."""
+        current = "__pycache__/\n*.pyc\n"
+        expected = (
+            "__pycache__/\n*.pyc\n.ruff_cache/\ndist/\n"
+        )
+        result, content = self._run_merge(current, expected)
+
+        self.assertEqual(result.action, "updated")
+        self.assertIn(".ruff_cache/", content)
+        self.assertIn("dist/", content)
+        self.assertIn(
+            "# Added by aida plugin update", content
+        )
+
+    def test_preserves_existing_entries(self):
+        """All original entries still present after merge."""
+        current = "__pycache__/\n*.pyc\nmy_custom_dir/\n"
+        expected = "__pycache__/\n*.pyc\n.ruff_cache/\n"
+        _, content = self._run_merge(current, expected)
+
+        self.assertIn("__pycache__/", content)
+        self.assertIn("*.pyc", content)
+        self.assertIn("my_custom_dir/", content)
+
+    def test_no_duplicates(self):
+        """Already-present entries are not added again."""
+        current = "__pycache__/\n*.pyc\n.ruff_cache/\n"
+        expected = "__pycache__/\n*.pyc\n.ruff_cache/\n"
+        result, content = self._run_merge(current, expected)
+
+        self.assertEqual(result.action, "skipped")
+        # Content should not contain the update header
+        self.assertNotIn(
+            "# Added by aida plugin update", content
+        )
+
+    def test_handles_empty_current(self):
+        """Empty .gitignore gets all expected entries."""
+        current = ""
+        expected = "__pycache__/\n*.pyc\n"
+        result, content = self._run_merge(current, expected)
+
+        self.assertEqual(result.action, "updated")
+        self.assertIn("__pycache__/", content)
+        self.assertIn("*.pyc", content)
+
+    def test_handles_comments_and_blanks(self):
+        """Comments and blank lines are preserved."""
+        current = (
+            "# Python artifacts\n"
+            "__pycache__/\n"
+            "\n"
+            "# Build output\n"
+            "dist/\n"
+        )
+        expected = "__pycache__/\ndist/\n.ruff_cache/\n"
+        _, content = self._run_merge(current, expected)
+
+        self.assertIn("# Python artifacts", content)
+        self.assertIn("# Build output", content)
+
+
+class TestMergeMakefile(unittest.TestCase):
+    """Test _merge_makefile conservative target merge."""
+
+    def _run_merge(
+        self,
+        current: str,
+        expected: str,
+        status: FileStatus = FileStatus.OUTDATED,
+    ) -> tuple[PatchResult, str]:
+        """Run a Makefile merge and return result + file.
+
+        Returns:
+            Tuple of (PatchResult, final file content).
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = Path(tmp) / "plugin"
+            plugin.mkdir()
+            backup = plugin / ".aida-backup" / "test"
+            backup.mkdir(parents=True)
+
+            target = plugin / "Makefile"
+            if status != FileStatus.MISSING:
+                target.write_text(current)
+                bk = backup / "Makefile"
+                bk.write_text(current)
+
+            fd = _make_file_diff(
+                "Makefile",
+                status=status,
+                strategy=MergeStrategy.MERGE,
+                category=FileCategory.COMPOSITE,
+                expected_content=expected,
+                actual_content=(
+                    current
+                    if status != FileStatus.MISSING
+                    else None
+                ),
+            )
+
+            result = _merge_makefile(plugin, fd, backup)
+            content = target.read_text()
+        return result, content
+
+    def test_appends_missing_targets(self):
+        """Missing targets are appended to the Makefile."""
+        current = "lint:\n\truff check .\n"
+        expected = (
+            "lint:\n\truff check .\n\n"
+            "format:\n\truff format .\n"
+        )
+        result, content = self._run_merge(current, expected)
+
+        self.assertEqual(result.action, "updated")
+        self.assertIn("format:", content)
+        self.assertIn("\truff format .", content)
+
+    def test_preserves_existing_targets(self):
+        """Existing custom targets are untouched."""
+        current = (
+            "my-custom:\n"
+            "\techo custom\n\n"
+            "lint:\n"
+            "\truff check .\n"
+        )
+        expected = (
+            "lint:\n"
+            "\truff check .\n\n"
+            "format:\n"
+            "\truff format .\n"
+        )
+        _, content = self._run_merge(current, expected)
+
+        self.assertIn("my-custom:", content)
+        self.assertIn("\techo custom", content)
+
+    def test_adds_phony_declaration(self):
+        """Missing targets get a .PHONY line."""
+        current = "lint:\n\truff check .\n"
+        expected = (
+            "lint:\n\truff check .\n\n"
+            "test:\n\tpytest tests/\n"
+        )
+        _, content = self._run_merge(current, expected)
+
+        self.assertIn(".PHONY: test", content)
+
+    def test_preserves_tab_indentation(self):
+        """Recipe lines keep tab indentation."""
+        current = "lint:\n\truff check .\n"
+        expected = (
+            "lint:\n\truff check .\n\n"
+            "clean:\n\trm -rf build/\n"
+        )
+        _, content = self._run_merge(current, expected)
+
+        # Find the clean target and verify tab
+        lines = content.splitlines()
+        for i, line in enumerate(lines):
+            if line.startswith("clean:"):
+                self.assertTrue(
+                    lines[i + 1].startswith("\t"),
+                    "Recipe line must start with a tab",
+                )
+                break
+        else:
+            self.fail("clean: target not found in output")
+
+
+class TestApplyPatches(unittest.TestCase):
+    """Test apply_patches end-to-end patching flow."""
+
+    def _setup_plugin(
+        self, tmp: str
+    ) -> Path:
+        """Create a minimal plugin directory.
+
+        Returns:
+            Path to the plugin root directory.
+        """
+        plugin = Path(tmp) / "plugin"
+        config_dir = plugin / ".claude-plugin"
+        config_dir.mkdir(parents=True)
+        config = config_dir / "aida-config.json"
+        config.write_text(
+            json.dumps(
+                {"generator_version": "0.7.0"}, indent=2
+            )
+            + "\n"
+        )
+        return plugin
+
+    def test_add_missing_file(self):
+        """MISSING + ADD creates the file with expected content."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = self._setup_plugin(tmp)
+
+            fd = _make_file_diff(
+                "new_file.txt",
+                status=FileStatus.MISSING,
+                strategy=MergeStrategy.ADD,
+                expected_content="brand new content\n",
+            )
+            report = _make_diff_report(
+                str(plugin), files=[fd]
+            )
+            results = apply_patches(plugin, report)
+
+            created = plugin / "new_file.txt"
+            self.assertTrue(created.exists())
+            self.assertEqual(
+                created.read_text(), "brand new content\n"
+            )
+
+            actions = [r.action for r in results]
+            self.assertIn("created", actions)
+
+    def test_overwrite_outdated_file(self):
+        """OUTDATED + OVERWRITE replaces file content."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = self._setup_plugin(tmp)
+            target = plugin / "stale.txt"
+            target.write_text("old stuff\n")
+
+            fd = _make_file_diff(
+                "stale.txt",
+                status=FileStatus.OUTDATED,
+                strategy=MergeStrategy.OVERWRITE,
+                expected_content="new stuff\n",
+                actual_content="old stuff\n",
+            )
+            report = _make_diff_report(
+                str(plugin), files=[fd]
+            )
+            results = apply_patches(plugin, report)
+
+            self.assertEqual(
+                target.read_text(), "new stuff\n"
+            )
+            actions = [r.action for r in results]
+            self.assertIn("updated", actions)
+
+    def test_skip_custom_file(self):
+        """CUSTOM_SKIP files are not actionable."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = self._setup_plugin(tmp)
+            target = plugin / "custom.txt"
+            target.write_text("my stuff\n")
+
+            fd = _make_file_diff(
+                "custom.txt",
+                status=FileStatus.CUSTOM_SKIP,
+                strategy=MergeStrategy.SKIP,
+                actual_content="my stuff\n",
+            )
+            report = _make_diff_report(
+                str(plugin), files=[fd]
+            )
+            results = apply_patches(plugin, report)
+
+            # File unchanged
+            self.assertEqual(
+                target.read_text(), "my stuff\n"
+            )
+            # Only result is the version update
+            paths = [r.path for r in results]
+            self.assertNotIn("custom.txt", paths)
+
+    def test_skip_up_to_date_file(self):
+        """UP_TO_DATE files are filtered out entirely."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = self._setup_plugin(tmp)
+            target = plugin / "current.txt"
+            target.write_text("perfect\n")
+
+            fd = _make_file_diff(
+                "current.txt",
+                status=FileStatus.UP_TO_DATE,
+                strategy=MergeStrategy.SKIP,
+                expected_content="perfect\n",
+                actual_content="perfect\n",
+            )
+            report = _make_diff_report(
+                str(plugin), files=[fd]
+            )
+            results = apply_patches(plugin, report)
+
+            paths = [r.path for r in results]
+            self.assertNotIn("current.txt", paths)
+
+    def test_manual_review_not_modified(self):
+        """MANUAL_REVIEW files are skipped without changes."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = self._setup_plugin(tmp)
+            target = plugin / "complex.toml"
+            target.write_text("original\n")
+
+            fd = _make_file_diff(
+                "complex.toml",
+                status=FileStatus.OUTDATED,
+                strategy=MergeStrategy.MANUAL_REVIEW,
+                expected_content="updated\n",
+                actual_content="original\n",
+            )
+            report = _make_diff_report(
+                str(plugin), files=[fd]
+            )
+            results = apply_patches(plugin, report)
+
+            # File is not modified
+            self.assertEqual(
+                target.read_text(), "original\n"
+            )
+            # Result shows skipped
+            manual = [
+                r
+                for r in results
+                if r.path == "complex.toml"
+            ]
+            self.assertEqual(len(manual), 1)
+            self.assertEqual(manual[0].action, "skipped")
+
+    def test_add_skips_existing_file(self):
+        """ADD strategy does not overwrite existing files."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = self._setup_plugin(tmp)
+            target = plugin / "exists.txt"
+            target.write_text("keep me\n")
+
+            fd = _make_file_diff(
+                "exists.txt",
+                status=FileStatus.MISSING,
+                strategy=MergeStrategy.ADD,
+                expected_content="replacement\n",
+            )
+            report = _make_diff_report(
+                str(plugin), files=[fd]
+            )
+            results = apply_patches(plugin, report)
+
+            # File content unchanged
+            self.assertEqual(
+                target.read_text(), "keep me\n"
+            )
+            add_result = [
+                r
+                for r in results
+                if r.path == "exists.txt"
+            ]
+            self.assertEqual(len(add_result), 1)
+            self.assertEqual(
+                add_result[0].action, "skipped"
+            )
+
+    def test_user_override_to_skip(self):
+        """Override dict can force SKIP on a file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = self._setup_plugin(tmp)
+            target = plugin / "override.txt"
+            target.write_text("original\n")
+
+            fd = _make_file_diff(
+                "override.txt",
+                status=FileStatus.OUTDATED,
+                strategy=MergeStrategy.OVERWRITE,
+                expected_content="new\n",
+                actual_content="original\n",
+            )
+            report = _make_diff_report(
+                str(plugin), files=[fd]
+            )
+            overrides = {
+                "override.txt": MergeStrategy.SKIP
+            }
+            results = apply_patches(
+                plugin, report, overrides=overrides
+            )
+
+            # File not modified
+            self.assertEqual(
+                target.read_text(), "original\n"
+            )
+            skip_result = [
+                r
+                for r in results
+                if r.path == "override.txt"
+            ]
+            self.assertEqual(len(skip_result), 1)
+            self.assertEqual(
+                skip_result[0].action, "skipped"
+            )
+
+    def test_backup_created(self):
+        """Patching OUTDATED files creates a backup dir."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = self._setup_plugin(tmp)
+            target = plugin / "old.txt"
+            target.write_text("before\n")
+
+            fd = _make_file_diff(
+                "old.txt",
+                status=FileStatus.OUTDATED,
+                strategy=MergeStrategy.OVERWRITE,
+                expected_content="after\n",
+                actual_content="before\n",
+            )
+            report = _make_diff_report(
+                str(plugin), files=[fd]
+            )
+            apply_patches(plugin, report)
+
+            backup_dir = plugin / ".aida-backup"
+            self.assertTrue(backup_dir.exists())
+            # At least one timestamped subdirectory
+            subdirs = list(backup_dir.iterdir())
+            self.assertGreater(len(subdirs), 0)
+
+    def test_results_include_all_files(self):
+        """Every actionable file gets a PatchResult."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = self._setup_plugin(tmp)
+
+            # Create existing file for the OUTDATED entry
+            (plugin / "b.txt").write_text("old\n")
+
+            files = [
+                _make_file_diff(
+                    "a.txt",
+                    status=FileStatus.MISSING,
+                    strategy=MergeStrategy.ADD,
+                    expected_content="a\n",
+                ),
+                _make_file_diff(
+                    "b.txt",
+                    status=FileStatus.OUTDATED,
+                    strategy=MergeStrategy.OVERWRITE,
+                    expected_content="b\n",
+                    actual_content="old\n",
+                ),
+                _make_file_diff(
+                    "c.txt",
+                    status=FileStatus.MISSING,
+                    strategy=MergeStrategy.ADD,
+                    expected_content="c\n",
+                ),
+            ]
+            report = _make_diff_report(
+                str(plugin), files=files
+            )
+            results = apply_patches(plugin, report)
+
+            paths = [r.path for r in results]
+            self.assertIn("a.txt", paths)
+            self.assertIn("b.txt", paths)
+            self.assertIn("c.txt", paths)
+            # Plus the version update
+            self.assertIn(
+                ".claude-plugin/aida-config.json", paths
+            )
+
+
+class TestUpdateGeneratorVersion(unittest.TestCase):
+    """Test _update_generator_version config writing."""
+
+    def test_updates_existing_aida_config(self):
+        """Existing config gets its version updated."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = Path(tmp) / "plugin"
+            config_dir = plugin / ".claude-plugin"
+            config_dir.mkdir(parents=True)
+            config = config_dir / "aida-config.json"
+            config.write_text(
+                json.dumps(
+                    {"generator_version": "0.5.0"},
+                    indent=2,
+                )
+                + "\n"
+            )
+
+            result = _update_generator_version(plugin)
+
+            data = json.loads(config.read_text())
+            self.assertEqual(
+                data["generator_version"],
+                GENERATOR_VERSION,
+            )
+            self.assertEqual(result.action, "updated")
+
+    def test_creates_aida_config_if_missing(self):
+        """Missing config file is created with version."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = Path(tmp) / "plugin"
+            plugin.mkdir()
+
+            result = _update_generator_version(plugin)
+
+            config = (
+                plugin
+                / ".claude-plugin"
+                / "aida-config.json"
+            )
+            self.assertTrue(config.exists())
+            data = json.loads(config.read_text())
+            self.assertEqual(
+                data["generator_version"],
+                GENERATOR_VERSION,
+            )
+            self.assertEqual(result.action, "updated")
+
+    def test_preserves_other_fields(self):
+        """Non-version fields survive the update."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin = Path(tmp) / "plugin"
+            config_dir = plugin / ".claude-plugin"
+            config_dir.mkdir(parents=True)
+            config = config_dir / "aida-config.json"
+            original = {
+                "generator_version": "0.5.0",
+                "config": {"theme": "dark"},
+                "permissions": ["read", "write"],
+            }
+            config.write_text(
+                json.dumps(original, indent=2) + "\n"
+            )
+
+            _update_generator_version(plugin)
+
+            data = json.loads(config.read_text())
+            self.assertEqual(
+                data["generator_version"],
+                GENERATOR_VERSION,
+            )
+            self.assertEqual(
+                data["config"], {"theme": "dark"}
+            )
+            self.assertEqual(
+                data["permissions"], ["read", "write"]
+            )
+
+
+class TestParsers(unittest.TestCase):
+    """Test shared parser functions."""
+
+    def test_parse_gitignore_basic(self):
+        """Should extract active entries from gitignore."""
+        content = (
+            "# comment\n"
+            "__pycache__/\n"
+            "\n"
+            "*.pyc\n"
+            "  dist/  \n"
+        )
+        entries = parse_gitignore_entries(content)
+        self.assertEqual(
+            entries, {"__pycache__/", "*.pyc", "dist/"}
+        )
+
+    def test_parse_gitignore_empty(self):
+        """Should return empty set for empty content."""
+        self.assertEqual(
+            parse_gitignore_entries(""), set()
+        )
+
+    def test_parse_gitignore_only_comments(self):
+        """Should return empty set for comment-only content."""
+        content = "# comment\n# another\n"
+        self.assertEqual(
+            parse_gitignore_entries(content), set()
+        )
+
+    def test_extract_makefile_targets_basic(self):
+        """Should extract target names from Makefile."""
+        content = (
+            ".PHONY: lint test\n\n"
+            "lint:\n\truff check .\n\n"
+            "test:\n\tpytest tests/\n"
+        )
+        targets = extract_makefile_targets(content)
+        self.assertIn("lint", targets)
+        self.assertIn("test", targets)
+
+    def test_extract_makefile_targets_empty(self):
+        """Should return empty set for empty content."""
+        self.assertEqual(
+            extract_makefile_targets(""), set()
+        )
+
+    def test_extract_makefile_targets_no_targets(self):
+        """Should return empty for content without targets."""
+        content = "# Just a comment\n\t@echo hi\n"
+        self.assertEqual(
+            extract_makefile_targets(content), set()
+        )
+
+
+class TestExtractMakefileTargetBlock(unittest.TestCase):
+    """Test _extract_makefile_target_block edge cases."""
+
+    def test_extracts_simple_target(self):
+        """Should extract a target with recipe lines."""
+        content = (
+            "lint:\n"
+            "\truff check .\n"
+            "\n"
+            "test:\n"
+            "\tpytest tests/\n"
+        )
+        block = _extract_makefile_target_block(
+            content, "lint"
+        )
+        self.assertIn("lint:", block)
+        self.assertIn("\truff check .", block)
+
+    def test_extracts_last_target(self):
+        """Should extract the last target in the file."""
+        content = (
+            "lint:\n"
+            "\truff check .\n"
+            "\n"
+            "test:\n"
+            "\tpytest tests/\n"
+        )
+        block = _extract_makefile_target_block(
+            content, "test"
+        )
+        self.assertIn("test:", block)
+        self.assertIn("\tpytest tests/", block)
+
+    def test_returns_empty_for_missing_target(self):
+        """Should return empty string for nonexistent target."""
+        content = "lint:\n\truff check .\n"
+        block = _extract_makefile_target_block(
+            content, "missing"
+        )
+        self.assertEqual(block, "")
+
+    def test_handles_multi_line_recipe(self):
+        """Should extract target with multiple recipe lines."""
+        content = (
+            "clean:\n"
+            "\trm -rf build/\n"
+            "\trm -rf dist/\n"
+            "\trm -rf *.egg-info\n"
+        )
+        block = _extract_makefile_target_block(
+            content, "clean"
+        )
+        self.assertIn("rm -rf build/", block)
+        self.assertIn("rm -rf dist/", block)
+        self.assertIn("rm -rf *.egg-info", block)
+
+    def test_stops_at_next_target(self):
+        """Should not include content from next target."""
+        content = (
+            "lint:\n"
+            "\truff check .\n"
+            "test:\n"
+            "\tpytest tests/\n"
+        )
+        block = _extract_makefile_target_block(
+            content, "lint"
+        )
+        self.assertIn("lint:", block)
+        self.assertNotIn("test:", block)
+        self.assertNotIn("pytest", block)
+
+    def test_strips_trailing_empty_lines(self):
+        """Should not include trailing blank lines."""
+        content = (
+            "lint:\n"
+            "\truff check .\n"
+            "\n"
+            "\n"
+            "test:\n"
+            "\tpytest\n"
+        )
+        block = _extract_makefile_target_block(
+            content, "lint"
+        )
+        self.assertFalse(block.endswith("\n\n"))
+
+    def test_handles_empty_content(self):
+        """Should return empty string for empty content."""
+        self.assertEqual(
+            _extract_makefile_target_block("", "lint"), ""
+        )
+
+
+class TestScannerErrorFallback(unittest.TestCase):
+    """Test scanner error fallback path."""
+
+    def test_comparison_error_marks_outdated(self):
+        """File comparison error should mark as OUTDATED."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "plugin"
+            plugin_dir.mkdir()
+
+            # Create a minimal plugin
+            meta_dir = plugin_dir / ".claude-plugin"
+            meta_dir.mkdir()
+            (meta_dir / "plugin.json").write_text(
+                json.dumps({
+                    "name": "test",
+                    "version": "0.1.0",
+                    "description": "Test plugin for testing",
+                })
+            )
+            (meta_dir / "aida-config.json").write_text(
+                json.dumps({"generator_version": "0.9.0"})
+            )
+            (plugin_dir / "pyproject.toml").write_text("")
+
+            # Import scan_plugin for this test
+            from operations.update_ops.scanner import (
+                scan_plugin,
+            )
+
+            # Use a bogus templates dir to trigger errors
+            bogus_templates = Path(tmp) / "no-templates"
+            bogus_templates.mkdir()
+
+            # scan_plugin should handle errors gracefully
+            # and mark files as OUTDATED rather than crashing
+            from operations.update_ops.models import (
+                FileStatus as FS,
+            )
+
+            report = scan_plugin(
+                plugin_dir, bogus_templates
+            )
+            # Templated files should be marked as OUTDATED
+            # due to template rendering errors
+            errored = [
+                f
+                for f in report.files
+                if f.status == FS.OUTDATED
+                and "Error" in f.diff_summary
+            ]
+            self.assertGreater(
+                len(errored),
+                0,
+                "Expected at least one file marked OUTDATED "
+                "due to comparison error",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_update_scanner.py
+++ b/tests/unit/test_update_scanner.py
@@ -1,0 +1,654 @@
+"""Unit tests for plugin-manager update scanner."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# Add scripts directories to path
+_project_root = Path(__file__).parent.parent.parent
+_plugin_scripts = (
+    _project_root / "skills" / "plugin-manager" / "scripts"
+)
+sys.path.insert(0, str(_project_root / "scripts"))
+sys.path.insert(0, str(_plugin_scripts))
+
+# Clear cached operations modules to avoid cross-manager
+# conflicts in pytest
+for _mod_name in list(sys.modules):
+    if _mod_name == "operations" or _mod_name.startswith(
+        "operations."
+    ):
+        del sys.modules[_mod_name]
+
+from operations.update_ops.scanner import (  # noqa: E402
+    _detect_language,
+    _read_generator_version,
+    _read_plugin_metadata,
+    scan_plugin,
+)
+from operations.update_ops.models import (  # noqa: E402
+    FileCategory,
+    FileStatus,
+    MergeStrategy,
+)
+from operations.constants import (  # noqa: E402
+    GENERATOR_VERSION,
+)
+
+TEMPLATES_DIR = (
+    _plugin_scripts.parent / "templates" / "scaffold"
+)
+
+_GIT_MOCK_PATH = (
+    "operations.scaffold_ops.context.infer_git_config"
+)
+_GIT_MOCK_RETURN = {
+    "author_name": "Test Author",
+    "author_email": "test@test.com",
+}
+
+
+def _create_test_plugin(
+    base_dir: Path,
+    name: str = "test-plugin",
+    language: str = "python",
+    generator_version: str | None = GENERATOR_VERSION,
+    include_all_files: bool = False,
+) -> Path:
+    """Create a minimal plugin directory for testing."""
+    plugin_dir = base_dir / name
+    plugin_dir.mkdir(parents=True)
+
+    # .claude-plugin/plugin.json (required)
+    meta_dir = plugin_dir / ".claude-plugin"
+    meta_dir.mkdir()
+    plugin_json = {
+        "name": name,
+        "version": "0.1.0",
+        "description": "A test plugin for unit testing",
+        "author": "Test Author",
+        "license": "MIT",
+        "keywords": ["test"],
+        "repository": "",
+    }
+    (meta_dir / "plugin.json").write_text(
+        json.dumps(plugin_json, indent=2)
+    )
+
+    # .claude-plugin/aida-config.json
+    aida_config: dict = {
+        "config": {},
+        "recommendedPermissions": {},
+        "agents": [],
+        "skills": [],
+    }
+    if generator_version is not None:
+        aida_config["generator_version"] = generator_version
+    (meta_dir / "aida-config.json").write_text(
+        json.dumps(aida_config, indent=2)
+    )
+
+    # Language marker
+    if language == "python":
+        (plugin_dir / "pyproject.toml").write_text(
+            '[project]\nname = "test-plugin"\n'
+        )
+    else:
+        (plugin_dir / "package.json").write_text(
+            '{"name": "test-plugin"}\n'
+        )
+
+    return plugin_dir
+
+
+class TestReadPluginMetadata(unittest.TestCase):
+    """Test _read_plugin_metadata helper."""
+
+    def test_reads_valid_plugin_json(self):
+        """Should read and return parsed plugin.json fields."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _create_test_plugin(Path(tmp))
+            result = _read_plugin_metadata(plugin_dir)
+
+            self.assertEqual(result["name"], "test-plugin")
+            self.assertEqual(result["version"], "0.1.0")
+            self.assertEqual(result["license"], "MIT")
+            self.assertIn("description", result)
+
+    def test_returns_empty_on_missing_file(self):
+        """Should return empty dict when plugin.json is absent."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "no-plugin"
+            plugin_dir.mkdir()
+            result = _read_plugin_metadata(plugin_dir)
+            self.assertEqual(result, {})
+
+    def test_returns_empty_on_invalid_json(self):
+        """Should return empty dict on malformed JSON."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "bad-json"
+            plugin_dir.mkdir()
+            meta_dir = plugin_dir / ".claude-plugin"
+            meta_dir.mkdir()
+            (meta_dir / "plugin.json").write_text(
+                "{not valid json!!"
+            )
+            result = _read_plugin_metadata(plugin_dir)
+            self.assertEqual(result, {})
+
+
+class TestReadGeneratorVersion(unittest.TestCase):
+    """Test _read_generator_version helper."""
+
+    def test_reads_version_from_aida_config(self):
+        """Should read generator_version from aida-config."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _create_test_plugin(
+                Path(tmp),
+                generator_version="1.2.3",
+            )
+            result = _read_generator_version(plugin_dir)
+            self.assertEqual(result, "1.2.3")
+
+    def test_defaults_to_zero_on_missing_file(self):
+        """Should return 0.0.0 when aida-config is absent."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "no-config"
+            plugin_dir.mkdir()
+            (plugin_dir / ".claude-plugin").mkdir()
+            result = _read_generator_version(plugin_dir)
+            self.assertEqual(result, "0.0.0")
+
+    def test_defaults_to_zero_on_missing_field(self):
+        """Should return 0.0.0 when field is absent."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _create_test_plugin(
+                Path(tmp),
+                generator_version=None,
+            )
+            result = _read_generator_version(plugin_dir)
+            self.assertEqual(result, "0.0.0")
+
+
+class TestDetectLanguage(unittest.TestCase):
+    """Test _detect_language helper."""
+
+    def test_detects_python_from_pyproject(self):
+        """Should detect python from pyproject.toml."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "py-plugin"
+            plugin_dir.mkdir()
+            (plugin_dir / "pyproject.toml").write_text("")
+            self.assertEqual(
+                _detect_language(plugin_dir), "python"
+            )
+
+    def test_detects_typescript_from_package_json(self):
+        """Should detect typescript from package.json."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "ts-plugin"
+            plugin_dir.mkdir()
+            (plugin_dir / "package.json").write_text("{}")
+            self.assertEqual(
+                _detect_language(plugin_dir), "typescript"
+            )
+
+    def test_detects_python_from_scripts_dir(self):
+        """Should detect python from scripts/ directory."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "scripts-plugin"
+            plugin_dir.mkdir()
+            (plugin_dir / "scripts").mkdir()
+            self.assertEqual(
+                _detect_language(plugin_dir), "python"
+            )
+
+    def test_detects_typescript_from_src_dir(self):
+        """Should detect typescript from src/ directory."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "src-plugin"
+            plugin_dir.mkdir()
+            (plugin_dir / "src").mkdir()
+            self.assertEqual(
+                _detect_language(plugin_dir), "typescript"
+            )
+
+    def test_defaults_to_python(self):
+        """Should default to python for empty directories."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "empty-plugin"
+            plugin_dir.mkdir()
+            self.assertEqual(
+                _detect_language(plugin_dir), "python"
+            )
+
+
+class TestScanPluginValid(unittest.TestCase):
+    """Test scan_plugin with a valid plugin directory."""
+
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_scan_reports_correct_plugin_name(
+        self, _mock_git
+    ):
+        """Should report the correct plugin name."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _create_test_plugin(
+                Path(tmp), name="my-scanner-test"
+            )
+            report = scan_plugin(
+                plugin_dir, TEMPLATES_DIR
+            )
+            self.assertEqual(
+                report.plugin_name, "my-scanner-test"
+            )
+
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_scan_reports_correct_language(
+        self, _mock_git
+    ):
+        """Should report the detected language."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _create_test_plugin(Path(tmp))
+            report = scan_plugin(
+                plugin_dir, TEMPLATES_DIR
+            )
+            self.assertEqual(report.language, "python")
+
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_scan_reports_generator_version(
+        self, _mock_git
+    ):
+        """Should report the plugin generator_version."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _create_test_plugin(
+                Path(tmp), generator_version="0.5.0"
+            )
+            report = scan_plugin(
+                plugin_dir, TEMPLATES_DIR
+            )
+            self.assertEqual(
+                report.generator_version, "0.5.0"
+            )
+            self.assertEqual(
+                report.current_version, GENERATOR_VERSION
+            )
+
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_scan_up_to_date_boilerplate(
+        self, _mock_git
+    ):
+        """Should report files correctly across categories."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _create_test_plugin(Path(tmp))
+            report = scan_plugin(
+                plugin_dir, TEMPLATES_DIR
+            )
+            # The report should have files
+            self.assertGreater(len(report.files), 0)
+            # Check that summary counts are consistent
+            summary = report.summary
+            total = (
+                summary["missing"]
+                + summary["outdated"]
+                + summary["up_to_date"]
+                + summary["custom_skip"]
+            )
+            self.assertEqual(total, summary["total"])
+
+
+class TestScanPluginMissingFiles(unittest.TestCase):
+    """Test scan_plugin detects missing files."""
+
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_missing_markdownlint_detected(
+        self, _mock_git
+    ):
+        """Should detect missing .markdownlint.json."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _create_test_plugin(Path(tmp))
+            # Ensure .markdownlint.json does NOT exist
+            ml_path = plugin_dir / ".markdownlint.json"
+            if ml_path.exists():
+                ml_path.unlink()
+
+            report = scan_plugin(
+                plugin_dir, TEMPLATES_DIR
+            )
+            ml_diffs = [
+                f
+                for f in report.files
+                if f.path == ".markdownlint.json"
+            ]
+            self.assertEqual(len(ml_diffs), 1)
+            self.assertEqual(
+                ml_diffs[0].status, FileStatus.MISSING
+            )
+
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_missing_gitignore_detected(
+        self, _mock_git
+    ):
+        """Should detect missing .gitignore."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _create_test_plugin(Path(tmp))
+            report = scan_plugin(
+                plugin_dir, TEMPLATES_DIR
+            )
+            gi_diffs = [
+                f
+                for f in report.files
+                if f.path == ".gitignore"
+            ]
+            self.assertEqual(len(gi_diffs), 1)
+            self.assertEqual(
+                gi_diffs[0].status, FileStatus.MISSING
+            )
+
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_missing_makefile_detected(
+        self, _mock_git
+    ):
+        """Should detect missing Makefile."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _create_test_plugin(Path(tmp))
+            report = scan_plugin(
+                plugin_dir, TEMPLATES_DIR
+            )
+            mf_diffs = [
+                f
+                for f in report.files
+                if f.path == "Makefile"
+            ]
+            self.assertEqual(len(mf_diffs), 1)
+            self.assertEqual(
+                mf_diffs[0].status, FileStatus.MISSING
+            )
+
+
+class TestScanPluginCustomFiles(unittest.TestCase):
+    """Test scan_plugin marks custom files correctly."""
+
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_claudemd_always_custom_skip(
+        self, _mock_git
+    ):
+        """Should mark CLAUDE.md as CUSTOM_SKIP."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _create_test_plugin(Path(tmp))
+            (plugin_dir / "CLAUDE.md").write_text(
+                "# Custom content"
+            )
+            report = scan_plugin(
+                plugin_dir, TEMPLATES_DIR
+            )
+            claude_diffs = [
+                f
+                for f in report.files
+                if f.path == "CLAUDE.md"
+            ]
+            self.assertEqual(len(claude_diffs), 1)
+            self.assertEqual(
+                claude_diffs[0].status,
+                FileStatus.CUSTOM_SKIP,
+            )
+
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_readme_always_custom_skip(
+        self, _mock_git
+    ):
+        """Should mark README.md as CUSTOM_SKIP."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _create_test_plugin(Path(tmp))
+            (plugin_dir / "README.md").write_text(
+                "# My Plugin"
+            )
+            report = scan_plugin(
+                plugin_dir, TEMPLATES_DIR
+            )
+            readme_diffs = [
+                f
+                for f in report.files
+                if f.path == "README.md"
+            ]
+            self.assertEqual(len(readme_diffs), 1)
+            self.assertEqual(
+                readme_diffs[0].status,
+                FileStatus.CUSTOM_SKIP,
+            )
+
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_aida_config_always_custom_skip(
+        self, _mock_git
+    ):
+        """Should mark aida-config.json as CUSTOM_SKIP."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _create_test_plugin(Path(tmp))
+            report = scan_plugin(
+                plugin_dir, TEMPLATES_DIR
+            )
+            aida_diffs = [
+                f
+                for f in report.files
+                if f.path
+                == ".claude-plugin/aida-config.json"
+            ]
+            self.assertEqual(len(aida_diffs), 1)
+            self.assertEqual(
+                aida_diffs[0].status,
+                FileStatus.CUSTOM_SKIP,
+            )
+
+
+class TestScanPluginOutdated(unittest.TestCase):
+    """Test scan_plugin detects outdated boilerplate."""
+
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_outdated_boilerplate_detected(
+        self, _mock_git
+    ):
+        """Should detect outdated .markdownlint.json."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _create_test_plugin(Path(tmp))
+            # Write a .markdownlint.json with different
+            # content from the template
+            (plugin_dir / ".markdownlint.json").write_text(
+                '{"old": "config"}\n'
+            )
+            report = scan_plugin(
+                plugin_dir, TEMPLATES_DIR
+            )
+            ml_diffs = [
+                f
+                for f in report.files
+                if f.path == ".markdownlint.json"
+            ]
+            self.assertEqual(len(ml_diffs), 1)
+            self.assertEqual(
+                ml_diffs[0].status, FileStatus.OUTDATED
+            )
+            self.assertIn(
+                "differs", ml_diffs[0].diff_summary
+            )
+
+
+class TestScanPluginInvalid(unittest.TestCase):
+    """Test scan_plugin with invalid inputs."""
+
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_raises_on_missing_plugin_json(
+        self, _mock_git
+    ):
+        """Should raise ValueError when plugin.json absent."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "no-manifest"
+            plugin_dir.mkdir()
+            with self.assertRaises(ValueError) as ctx:
+                scan_plugin(plugin_dir, TEMPLATES_DIR)
+            self.assertIn(
+                "plugin.json", str(ctx.exception)
+            )
+
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_raises_on_nonexistent_path(
+        self, _mock_git
+    ):
+        """Should raise ValueError for nonexistent path."""
+        bogus = Path("/tmp/does-not-exist-scanner-test")
+        with self.assertRaises(ValueError):
+            scan_plugin(bogus, TEMPLATES_DIR)
+
+
+class TestScanPluginDependencyConfig(unittest.TestCase):
+    """Test scan_plugin dependency config handling."""
+
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_pyproject_flagged_manual_review(
+        self, _mock_git
+    ):
+        """Should flag pyproject.toml for manual review."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _create_test_plugin(Path(tmp))
+            report = scan_plugin(
+                plugin_dir, TEMPLATES_DIR
+            )
+            pyp_diffs = [
+                f
+                for f in report.files
+                if f.path == "pyproject.toml"
+            ]
+            self.assertEqual(len(pyp_diffs), 1)
+            self.assertEqual(
+                pyp_diffs[0].strategy,
+                MergeStrategy.MANUAL_REVIEW,
+            )
+            self.assertEqual(
+                pyp_diffs[0].category,
+                FileCategory.DEPENDENCY_CONFIG,
+            )
+            # File exists so should be UP_TO_DATE
+            self.assertEqual(
+                pyp_diffs[0].status,
+                FileStatus.UP_TO_DATE,
+            )
+
+
+class TestScanPluginComposites(unittest.TestCase):
+    """Test scan_plugin composite file handling."""
+
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_gitignore_missing_entries_detected(
+        self, _mock_git
+    ):
+        """Should detect .gitignore with missing entries."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _create_test_plugin(Path(tmp))
+            # Write a minimal .gitignore that's missing
+            # most expected entries
+            (plugin_dir / ".gitignore").write_text(
+                "node_modules/\n"
+            )
+            report = scan_plugin(
+                plugin_dir, TEMPLATES_DIR
+            )
+            gi_diffs = [
+                f
+                for f in report.files
+                if f.path == ".gitignore"
+            ]
+            self.assertEqual(len(gi_diffs), 1)
+            self.assertEqual(
+                gi_diffs[0].status, FileStatus.OUTDATED
+            )
+            self.assertIn(
+                "Missing", gi_diffs[0].diff_summary
+            )
+            self.assertIn(
+                "entries", gi_diffs[0].diff_summary
+            )
+
+    @patch(
+        _GIT_MOCK_PATH,
+        return_value=_GIT_MOCK_RETURN,
+    )
+    def test_makefile_missing_targets_detected(
+        self, _mock_git
+    ):
+        """Should detect Makefile with missing targets."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = _create_test_plugin(Path(tmp))
+            # Write a minimal Makefile missing most targets
+            (plugin_dir / "Makefile").write_text(
+                "help:\n\t@echo help\n"
+            )
+            report = scan_plugin(
+                plugin_dir, TEMPLATES_DIR
+            )
+            mf_diffs = [
+                f
+                for f in report.files
+                if f.path == "Makefile"
+            ]
+            self.assertEqual(len(mf_diffs), 1)
+            self.assertEqual(
+                mf_diffs[0].status, FileStatus.OUTDATED
+            )
+            self.assertIn(
+                "Missing", mf_diffs[0].diff_summary
+            )
+            self.assertIn(
+                "targets", mf_diffs[0].diff_summary
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `/aida plugin update` as a detect-and-patch migration tool that scans existing plugins against current scaffold standards and applies non-destructive patches
- Two-phase API: Phase 1 scans and returns a diff report; Phase 2 applies approved patches with backup, atomic writes, and version tracking
- 8 file categories with distinct merge strategies (skip, overwrite, merge, add, manual_review)
- Extracts shared constants and template variable builder from scaffold for reuse without code coupling

## Architecture

```
operations/
  constants.py          # Shared GENERATOR_VERSION, SUPPORTED_LANGUAGES
  shared.py             # Shared build_template_variables()
  update.py             # Two-phase entry point (get_questions/execute)
  update_ops/
    models.py           # FileCategory, MergeStrategy, DiffReport, etc.
    strategies.py       # File classification registry
    scanner.py          # Read-only plugin scanner
    patcher.py          # File patching with backup + atomic writes
    parsers.py          # Shared gitignore/Makefile parsing
```

**Key design decisions:**
- Templates as shared contract between scaffold and update (no code coupling)
- Append-only merge for `.gitignore` (set-based) and `Makefile` (target-addition)
- Backup at `.aida-backup/{timestamp}/` before any modifications
- Custom content (`CLAUDE.md`, `README.md`, `LICENSE`) never touched
- `generator_version` in `aida-config.json` for version-aware migrations

## Changes

### New files (12)
- `operations/constants.py`, `operations/shared.py`, `operations/update.py`
- `update_ops/` package: `models.py`, `strategies.py`, `scanner.py`, `patcher.py`, `parsers.py`
- `references/update-workflow.md`
- `tests/unit/test_update_scanner.py`, `test_update_patcher.py`, `test_update_integration.py`

### Modified files (6)
- `manage.py` -- Added update operation routing
- `scaffold.py` -- Extracted shared constants/builder to new modules
- `SKILL.md` -- Added update operation docs, file categories, present results
- `aida/SKILL.md` -- Added `update` to plugin command routing
- `schemas.md` -- Added `generator_version` and `required` field docs
- `aida-config.json.jinja2` -- Added `generator_version` field

## Reviews

Four-reviewer team gave unanimous approval on final pass:
- **System Architect**: APPROVE (0 findings)
- **Tech Lead**: APPROVE 9.0/10 (0 findings)
- **Tech Writer**: PASS (0 findings)
- **Claude Code Expert**: APPROVE (0 findings)

## Test plan

- [x] 84 new tests (scanner: 27, patcher: 43, integration: 14)
- [x] 778 total tests passing
- [x] All linters clean (ruff, yamllint, markdownlint, frontmatter)
- [x] Round-trip test: scaffold → modify → update → verify clean
- [x] Idempotency test: double-update reports up-to-date
- [x] Content preservation: CLAUDE.md, README.md, LICENSE survive updates
- [ ] Manual: `/aida plugin update` on a real plugin project

Closes #27