### PR TITLE
fix: generated project-context SKILL.md fails markdown linting

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2026-03-18
+
+### Fixed
+
+#### Generated project-context SKILL.md fails markdown linting (#41)
+
+- Changed 9 `'None'` string fallbacks to `''` in `configure.py` so
+  Jinja2 conditionals correctly skip missing values
+- Fixed all `{% if has_xxx %}` boolean checks to use
+  `{% if has_xxx == 'true' %}` since values are strings
+- Removed `| join()` and `[0]` indexing on string values that were
+  incorrectly treated as lists
+- Restructured template whitespace control to eliminate MD012
+  (multiple blank lines) and MD032 (blanks around lists)
+- Changed footer emphasis lines to HTML comments (fixes MD036)
+- Fixed `tools` default to handle empty strings
+- Added 19 unit tests for template rendering
+
+---
+
 ## [1.1.1] - 2026-03-18
 
 ### Fixed

--- a/skills/aida/scripts/configure.py
+++ b/skills/aida/scripts/configure.py
@@ -870,8 +870,8 @@ def configure(responses: Dict[str, Any], inferred: Dict[str, Any] = None) -> Dic
             'license_file': 'LICENSE',
             'has_gitignore': 'true' if config['files']['has_gitignore'] else 'false',
             'has_changelog': 'true' if config['files']['has_changelog'] else 'false',
-            'changelog_files': 'None',
-            'changelog_intent': 'None',
+            'changelog_files': '',
+            'changelog_intent': '',
             'has_contributing': 'true' if config['files']['has_contributing'] else 'false',
             'has_docs_directory': 'true' if config['files']['has_docs_directory'] else 'false',
             'docs_directory': 'docs',
@@ -907,12 +907,12 @@ def configure(responses: Dict[str, Any], inferred: Dict[str, Any] = None) -> Dic
             'has_cargo_toml': 'true' if (project_root / "Cargo.toml").exists() else 'false',
 
             # Preferences
-            'issue_tracking': config['preferences']['issue_tracking'] or 'None',
-            'project_conventions': config['preferences']['project_conventions'] or 'None',
-            'api_docs_intent': config['preferences'].get('api_docs_approach') or 'None',
-            'github_project_config': config['preferences'].get('github_project_board') or 'None',
-            'jira_config': config['preferences'].get('jira_config') or 'None',
-            'confluence_config': config['preferences'].get('confluence_spaces') or 'None',
+            'issue_tracking': config['preferences']['issue_tracking'] or '',
+            'project_conventions': config['preferences']['project_conventions'] or '',
+            'api_docs_intent': config['preferences'].get('api_docs_approach') or '',
+            'github_project_config': config['preferences'].get('github_project_board') or '',
+            'jira_config': config['preferences'].get('jira_config') or '',
+            'confluence_config': config['preferences'].get('confluence_spaces') or '',
 
             # Docker & CI/CD intents
             'uses_docker': 'true' if config['files']['has_dockerfile'] or config['files']['has_docker_compose'] else 'false',
@@ -921,7 +921,7 @@ def configure(responses: Dict[str, Any], inferred: Dict[str, Any] = None) -> Dic
             'uses_confluence': 'true' if config['preferences'].get('confluence_spaces') else 'false',
 
             # Coding standards
-            'coding_standards': 'None',
+            'coding_standards': '',
 
             # Timestamp
             'timestamp': datetime.now().isoformat(),

--- a/skills/aida/templates/blueprints/project-context/SKILL.md.jinja2
+++ b/skills/aida/templates/blueprints/project-context/SKILL.md.jinja2
@@ -1,7 +1,9 @@
 ---
 type: skill
 name: project-context
-description: Auto-triggered skill for project-specific facts, structure, and conventions
+description: >-
+  Auto-triggered skill for project-specific facts, structure,
+  and conventions
 version: 0.2.0
 tags:
   - project
@@ -11,9 +13,9 @@ tags:
 
 # Project Context: {{ project_name }}
 
-This skill provides factual information about {{ project_name }}'s structure,
-tooling, and conventions. All information here is either auto-detected or
-explicitly configured for this project.
+This skill provides factual information about {{ project_name }}'s
+structure, tooling, and conventions. All information here is either
+auto-detected or explicitly configured for this project.
 
 ## Project Facts
 
@@ -23,128 +25,161 @@ explicitly configured for this project.
 
 **Primary Language(s):** {{ languages | default("Unknown") }}
 
-**Version Control:** {{ vcs | default("None") }}{% if vcs == "git" %}
-{% if has_gitignore %}- .gitignore: ✓{% endif %}
-{% if uses_worktrees %}- **Worktree workflow:** {{ uses_worktrees }}{% endif %}
-{% if branching_model %}- **Branching model:** {{ branching_model }}{% endif %}
+**Version Control:** {{ vcs | default("None") }}
+{% if vcs == "git" %}
+
+{% if has_gitignore == 'true' %}
+- .gitignore: ✓
+{% endif %}
+{% if uses_worktrees %}
+- **Worktree workflow:** {{ uses_worktrees }}
+{% endif %}
+{% if branching_model %}
+- **Branching model:** {{ branching_model }}
+{% endif %}
 {% endif %}
 
 ## Project Structure
 
 ### Source Code Organization
-{% if src_directories | default([]) %}
-**Source directories:** {{ src_directories | join(", ") }}
+{% if src_directories %}
+
+**Source directories:** {{ src_directories }}
 {% else %}
+
 **Source organization:** Flat structure (no src/ directory)
 {% endif %}
 
 **Code organization pattern:** {{ code_organization | default("Follow existing pattern") }}
 
 ### Documentation
-{% if has_docs_directory %}
+{% if has_docs_directory == 'true' %}
+
 **Documentation directory:** `{{ docs_directory }}`
 {% else %}
-**Documentation:** {% if docs_directory_intent %}{{ docs_directory_intent }}{% else %}README.md only{% endif %}
-{% endif %}
 
-{% if has_readme %}
+**Documentation:**
+{%- if docs_directory_intent %} {{ docs_directory_intent }}{% else %} README.md only{% endif %}
+
+{% endif %}
+{% if has_readme == 'true' %}
+
 **README:** `{{ readme_file }}` ({{ readme_length }} chars - {{ documentation_level | default("Standard") }})
 {% else %}
+
 **README:** Not found - consider creating one
 {% endif %}
+{% if has_changelog == 'true' %}
 
-{% if has_changelog %}
-**Changelog:** {{ changelog_files | join(", ") }}
+**Changelog:** {{ changelog_files }}
 {% elif changelog_intent %}
+
 **Changelog:** {{ changelog_intent }}
 {% else %}
+
 **Changelog:** None (changes tracked in git commits)
 {% endif %}
+{% if has_contributing == 'true' %}
 
-{% if has_contributing %}
 **Contributing guide:** Present
 {% endif %}
+{% if has_license == 'true' %}
 
-{% if has_license %}
 **License:** `{{ license_file }}`
 {% else %}
+
 **License:** None detected
 {% endif %}
 
 ### Testing
-{% if has_tests %}
-**Test directories:** {{ test_directories | join(", ") }}
+{% if has_tests == 'true' %}
+
+**Test directories:** {{ test_directories }}
 
 **Testing approach:** {{ testing_approach | default("Unit tests for critical paths") }}
 {% elif testing_framework_intent %}
+
 **Testing framework:** {{ testing_framework_intent }}
 
 **Tests:** Not yet set up
 {% else %}
+
 **Testing:** No automated tests planned
 {% endif %}
 
 ### Tools & Infrastructure
 
 **Build/Package Management:**
-{%- if has_package_json %} package.json (Node/npm){% endif %}
-{%- if has_requirements_txt %} requirements.txt (Python/pip){% endif %}
-{%- if has_pyproject_toml %} pyproject.toml (Python){% endif %}
-{%- if has_gemfile %} Gemfile (Ruby){% endif %}
-{%- if has_go_mod %} go.mod (Go){% endif %}
-{%- if has_cargo_toml %} Cargo.toml (Rust){% endif %}
-{%- if not (has_package_json or has_requirements_txt or has_pyproject_toml or has_gemfile or has_go_mod or has_cargo_toml) %} None detected{% endif %}
+{%- if has_package_json == 'true' %} package.json (Node/npm){% endif %}
+{%- if has_requirements_txt == 'true' %} requirements.txt (Python/pip){% endif %}
+{%- if has_pyproject_toml == 'true' %} pyproject.toml (Python){% endif %}
+{%- if has_gemfile == 'true' %} Gemfile (Ruby){% endif %}
+{%- if has_go_mod == 'true' %} go.mod (Go){% endif %}
+{%- if has_cargo_toml == 'true' %} Cargo.toml (Rust){% endif %}
+{%- if not (has_package_json == 'true' or has_requirements_txt == 'true' or has_pyproject_toml == 'true' or has_gemfile == 'true' or has_go_mod == 'true' or has_cargo_toml == 'true') %} None detected{% endif %}
 
-**Development Tools:** {{ tools | default("None detected") }}
+**Development Tools:** {{ tools or "None detected" }}
 
 ### Docker
-{% if uses_docker %}
+{% if uses_docker == 'true' %}
+
 **Docker:**
-- Dockerfile: {% if has_dockerfile %}✓{% else %}✗{% endif %}
-- docker-compose: {% if has_docker_compose %}✓{% else %}{% if docker_compose_intent %}{{ docker_compose_intent }}{% else %}✗{% endif %}{% endif %}
+
+- Dockerfile: {% if has_dockerfile == 'true' %}✓{% else %}✗{% endif %}
+
+- docker-compose: {% if has_docker_compose == 'true' %}✓{% else %}{% if docker_compose_intent %}{{ docker_compose_intent }}{% else %}✗{% endif %}{% endif %}
+
 {% else %}
+
 **Docker:** Not used
 {% endif %}
 
 ### CI/CD
-{% if has_ci_cd %}
+{% if has_ci_cd == 'true' %}
+
 **CI/CD:**
-{%- if has_github_actions %} GitHub Actions{% endif %}
-{%- if has_gitlab_ci %} GitLab CI{% endif %}
+{%- if has_github_actions == 'true' %} GitHub Actions{% endif %}
+{%- if has_gitlab_ci == 'true' %} GitLab CI{% endif %}
+
 {% elif ci_cd_intent %}
+
 **CI/CD:** {{ ci_cd_intent }}
 {% else %}
+
 **CI/CD:** Manual testing and deployment
 {% endif %}
 
 ### Issue Tracking
 {% if issue_tracking %}
-**Issue Tracking System:** {{ issue_tracking }}
 
+**Issue Tracking System:** {{ issue_tracking }}
 {% if "GitHub Projects" in issue_tracking and github_project_config %}
+
 **GitHub Projects Configuration:**
 {{ github_project_config }}
 
 **MCP Integration:** ✅ GitHub MCP (official)
 
 Claude should:
+
 - Reference issues using #issue-number format
 - Update project board status when working on issues via MCP
 - Link commits to issues automatically
 - Include "Fixes #123" or "Closes #123" in commit messages
 - Use GitHub MCP for automated project board updates
 - Suggest issue labels and milestones
-
 {% elif "GitHub Issues" in issue_tracking %}
+
 **MCP Integration:** ✅ GitHub MCP (official)
 
 Claude should:
+
 - Reference issues using #issue-number format
 - Include "Fixes #123" or "Closes #123" in commit messages
 - Suggest issue labels and milestones
 - Use GitHub MCP for issue management
-
 {% elif "JIRA" in issue_tracking and jira_config %}
+
 **JIRA Configuration:**
 {{ jira_config }}
 
@@ -152,57 +187,64 @@ Claude should:
 **MCP Endpoint:** https://mcp.atlassian.com/v1/sse
 
 Claude should:
+
 - Reference issues using PROJ-123 format
 - Include JIRA issue keys in commit messages
 - Suggest issue status transitions
 - Use Atlassian MCP for automated issue updates
+{% if uses_confluence == 'true' and confluence_config %}
 
-{% if uses_confluence and confluence_config %}
 **Confluence Integration:**
 {{ confluence_config }}
 
 Claude should:
+
 - Suggest Confluence documentation for:
-  * Architecture decisions and diagrams
-  * API documentation and guides
-  * User guides and tutorials
-  * Team processes and workflows
-  * Meeting notes and RFCs
+  - Architecture decisions and diagrams
+  - API documentation and guides
+  - User guides and tutorials
+  - Team processes and workflows
+  - Meeting notes and RFCs
 - Suggest local documentation (in repo) for:
-  * README and setup instructions
-  * Code-level documentation
-  * Developer guides
-  * API reference (technical)
+  - README and setup instructions
+  - Code-level documentation
+  - Developer guides
+  - API reference (technical)
 - Use Confluence MCP to create/update pages
 - Link JIRA issues to relevant Confluence pages
 - Keep project space updated with latest documentation
 {% endif %}
-
 {% elif issue_tracking and "Other" not in issue_tracking and issue_tracking != "None - informal tracking only" %}
+
 **MCP Integration:** ❌ Not supported (manual issue tracking only)
 
 Claude should:
+
 - Ask about issue tracking when working on features
 - Suggest linking work to issues in commit messages
 - Note: No automated MCP integration available
 {% endif %}
 {% else %}
+
 **Issue Tracking:** None configured
 {% endif %}
 
 ## Project Conventions
-
 {% if project_conventions %}
+
 {{ project_conventions }}
 {% else %}
-No specific conventions documented. Follow general best practices for {{ languages | default("this tech stack") }}.
+
+No specific conventions documented. Follow general best practices
+for {{ languages | default("this tech stack") }}.
 {% endif %}
 
 ## API Documentation
-
 {% if api_docs_intent %}
+
 **API documentation style:** {{ api_docs_intent }}
 {% elif project_type in ["Web application (backend)", "Library or framework", "CLI tool or utility"] %}
+
 **API documentation:** Inline docstrings/comments
 {% endif %}
 
@@ -211,37 +253,72 @@ No specific conventions documented. Follow general best practices for {{ languag
 When working in this project:
 
 **Code Structure:**
+
 - Place new files following the "{{ code_organization | default("existing") }}" organization pattern
-- {% if src_directories %}Use {{ src_directories | join(" or ") }} for source code{% else %}Follow flat project structure{% endif %}
-- {% if test_directories %}Put tests in {{ test_directories | join(" or ") }}{% elif testing_framework_intent %}Create tests directory when adding first test{% endif %}
+{% if src_directories %}
+- Use {{ src_directories }} for source code
+{% else %}
+- Follow flat project structure
+{% endif %}
+{% if test_directories %}
+- Put tests in {{ test_directories }}
+{% elif testing_framework_intent %}
+- Create tests directory when adding first test
+{% endif %}
 
 **Documentation:**
-- {% if has_docs_directory %}Add documentation files to {{ docs_directory }}{% elif docs_directory_intent %}{{ docs_directory_intent }}{% else %}Update README.md with new documentation{% endif %}
-- {% if has_changelog %}Update {{ changelog_files[0] }} for significant changes{% elif changelog_intent %}Update changelog when making releases{% endif %}
-- {% if api_docs_intent %}Document APIs using {{ api_docs_intent }}{% endif %}
+{% if has_docs_directory == 'true' %}
+
+- Add documentation files to {{ docs_directory }}
+{% elif docs_directory_intent %}
+
+- {{ docs_directory_intent }}
+{% else %}
+
+- Update README.md with new documentation
+{% endif %}
+{% if has_changelog == 'true' and changelog_files %}
+- Update {{ changelog_files }} for significant changes
+{% elif changelog_intent %}
+- Update changelog when making releases
+{% endif %}
+{% if api_docs_intent %}
+- Document APIs using {{ api_docs_intent }}
+{% endif %}
 
 **Testing:**
-- {% if testing_approach %}Follow {{ testing_approach }} approach{% elif testing_framework_intent %}Use {{ testing_framework_intent }} for tests{% endif %}
-- {% if has_tests %}Maintain test coverage for new features{% endif %}
+{% if testing_approach %}
+
+- Follow {{ testing_approach }} approach
+{% elif testing_framework_intent %}
+
+- Use {{ testing_framework_intent }} for tests
+{% endif %}
+{% if has_tests == 'true' %}
+- Maintain test coverage for new features
+{% endif %}
 
 **Conventions:**
 {% if project_conventions %}
+
 - Follow project-specific conventions documented above
 {% else %}
+
 - Follow language/framework best practices
 {% endif %}
 
 **Quality:**
 {% if coding_standards %}
+
 - Maintain {{ coding_standards }} standards
 {% endif %}
-{% if has_ci_cd or ci_cd_intent %}
+{% if has_ci_cd == 'true' or ci_cd_intent %}
+
 - Ensure CI/CD checks pass before committing
 {% endif %}
 
 ---
-*Auto-generated by AIDA configure for {{ project_name }}*
 
-*Detected facts: {{ timestamp | default("unknown") }}*
-
-*This skill is automatically activated when working in {{ project_name }}*
+<!-- Auto-generated by AIDA configure for {{ project_name }} -->
+<!-- Detected facts: {{ timestamp | default("unknown") }} -->
+<!-- This skill is automatically activated when working in {{ project_name }} -->

--- a/tests/unit/test_project_context_template.py
+++ b/tests/unit/test_project_context_template.py
@@ -1,0 +1,223 @@
+"""Unit tests for the project-context SKILL.md.jinja2 template.
+
+Verifies that the rendered template produces clean markdown output
+without lint violations (no 'None' literals, no consecutive blank
+lines, correct conditional section handling).
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+# Add shared scripts to path
+_project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(_project_root / "scripts"))
+
+from shared.utils import render_template  # noqa: E402
+
+TEMPLATES_DIR = _project_root / "skills" / "aida" / "templates"
+TEMPLATE_NAME = "blueprints/project-context/SKILL.md.jinja2"
+
+
+def _base_vars(**overrides: str) -> dict[str, str]:
+    """Return a complete set of template variables with sensible defaults.
+
+    All values are strings, matching the contract enforced by
+    validate_template_variables() in configure.py.
+    """
+    base: dict[str, str] = {
+        "project_name": "test-project",
+        "project_type": "CLI tool or utility",
+        "languages": "Python",
+        "vcs": "git",
+        "uses_worktrees": "",
+        "branching_model": "GitHub Flow",
+        "has_readme": "false",
+        "readme_file": "README.md",
+        "readme_length": "0",
+        "has_license": "false",
+        "license_file": "LICENSE",
+        "has_gitignore": "false",
+        "has_changelog": "false",
+        "changelog_files": "",
+        "changelog_intent": "",
+        "has_contributing": "false",
+        "has_docs_directory": "false",
+        "docs_directory": "docs",
+        "docs_directory_intent": "README.md only",
+        "has_tests": "false",
+        "test_directories": "",
+        "src_directories": "",
+        "has_dockerfile": "false",
+        "has_docker_compose": "false",
+        "has_ci_cd": "false",
+        "has_github_actions": "false",
+        "has_gitlab_ci": "false",
+        "has_package_json": "false",
+        "has_requirements_txt": "false",
+        "has_pyproject_toml": "false",
+        "has_gemfile": "false",
+        "has_go_mod": "false",
+        "has_cargo_toml": "false",
+        "tools": "ruff, pytest",
+        "testing_framework": "pytest",
+        "testing_framework_intent": "pytest",
+        "testing_approach": "Unit tests",
+        "issue_tracking": "",
+        "project_conventions": "",
+        "api_docs_intent": "",
+        "github_project_config": "",
+        "jira_config": "",
+        "confluence_config": "",
+        "uses_docker": "false",
+        "docker_compose_intent": "Not configured",
+        "ci_cd_intent": "Not configured",
+        "uses_confluence": "false",
+        "coding_standards": "",
+        "code_organization": "Modular",
+        "documentation_level": "Standard",
+        "timestamp": "2026-01-01T00:00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+def _render(**overrides: str) -> str:
+    """Render the project-context template with optional overrides."""
+    return render_template(TEMPLATES_DIR, TEMPLATE_NAME, _base_vars(**overrides))
+
+
+class TestProjectContextTemplateAllTrue(unittest.TestCase):
+    """Test rendering with all has_* flags set to 'true'."""
+
+    def setUp(self) -> None:
+        self.output = _render(
+            has_readme="true",
+            has_license="true",
+            has_gitignore="true",
+            has_changelog="true",
+            changelog_files="CHANGELOG.md",
+            has_contributing="true",
+            has_docs_directory="true",
+            has_tests="true",
+            test_directories="tests",
+            src_directories="src",
+            has_dockerfile="true",
+            has_docker_compose="true",
+            has_ci_cd="true",
+            has_github_actions="true",
+            has_package_json="true",
+            uses_docker="true",
+            coding_standards="ruff",
+            issue_tracking="GitHub Issues",
+            project_conventions="Follow PEP 8",
+            api_docs_intent="Inline docstrings",
+            readme_length="1500",
+        )
+
+    def test_no_none_literal(self) -> None:
+        """Output must not contain the string literal 'None' as a value."""
+        # Allow 'None' inside phrases like "None detected" or "None configured"
+        # but not standalone or as "N, o, n, e" (the join-over-chars bug)
+        self.assertNotIn("N, o, n, e", self.output)
+
+    def test_has_project_name(self) -> None:
+        self.assertIn("test-project", self.output)
+
+    def test_has_changelog_entry(self) -> None:
+        self.assertIn("CHANGELOG.md", self.output)
+
+    def test_has_readme_entry(self) -> None:
+        self.assertIn("README.md", self.output)
+        self.assertIn("1500 chars", self.output)
+
+    def test_has_license_entry(self) -> None:
+        self.assertIn("`LICENSE`", self.output)
+
+    def test_has_contributing_entry(self) -> None:
+        self.assertIn("Contributing guide", self.output)
+
+    def test_has_docker_section(self) -> None:
+        self.assertIn("Dockerfile: ✓", self.output)
+
+    def test_has_github_actions(self) -> None:
+        self.assertIn("GitHub Actions", self.output)
+
+    def test_has_issue_tracking(self) -> None:
+        self.assertIn("GitHub Issues", self.output)
+
+    def test_has_conventions(self) -> None:
+        self.assertIn("Follow PEP 8", self.output)
+
+
+class TestProjectContextTemplateAllFalse(unittest.TestCase):
+    """Test rendering with all has_* flags set to 'false'."""
+
+    def setUp(self) -> None:
+        self.output = _render()
+
+    def test_no_none_literal_as_chars(self) -> None:
+        self.assertNotIn("N, o, n, e", self.output)
+
+    def test_conditional_sections_excluded(self) -> None:
+        """Sections guarded by 'false' flags must not appear."""
+        self.assertNotIn("Contributing guide", self.output)
+        self.assertNotIn(".gitignore: ✓", self.output)
+
+    def test_license_none_detected(self) -> None:
+        self.assertIn("License:** None detected", self.output)
+
+    def test_readme_not_found(self) -> None:
+        self.assertIn("README:** Not found", self.output)
+
+    def test_docker_not_used(self) -> None:
+        self.assertIn("Docker:** Not used", self.output)
+
+    def test_issue_tracking_none_configured(self) -> None:
+        self.assertIn("Issue Tracking:** None configured", self.output)
+
+
+class TestProjectContextTemplateWhitespace(unittest.TestCase):
+    """Test markdown whitespace rules (MD012)."""
+
+    def test_no_triple_blank_lines_all_true(self) -> None:
+        output = _render(
+            has_readme="true",
+            has_license="true",
+            has_gitignore="true",
+            has_changelog="true",
+            changelog_files="CHANGELOG.md",
+            has_contributing="true",
+            has_docs_directory="true",
+            has_tests="true",
+            has_ci_cd="true",
+            has_github_actions="true",
+            uses_docker="true",
+            has_dockerfile="true",
+            readme_length="500",
+        )
+        self.assertNotRegex(output, r"\n{4,}")
+
+    def test_no_triple_blank_lines_all_false(self) -> None:
+        output = _render()
+        self.assertNotRegex(output, r"\n{4,}")
+
+    def test_no_trailing_whitespace_lines(self) -> None:
+        """Lines should not have trailing spaces (MD009)."""
+        output = _render(
+            has_readme="true",
+            has_license="true",
+            readme_length="500",
+        )
+        for i, line in enumerate(output.split("\n"), 1):
+            # Skip empty lines
+            if line.strip():
+                self.assertEqual(
+                    line.rstrip(),
+                    line,
+                    f"Line {i} has trailing whitespace: {line!r}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Changed 9 `'None'` string fallbacks to `''` in `configure.py` so Jinja2 conditionals correctly skip missing values (fixes `N, o, n, e` join bug)
- Fixed all `{% if has_xxx %}` boolean checks to `{% if has_xxx == 'true' %}` since string `'false'` is truthy in Jinja2
- Removed `| join()` and `[0]` indexing on string values incorrectly treated as lists
- Restructured template whitespace control to eliminate MD012 (multiple blank lines), MD032 (blanks around lists), and MD036 (emphasis as headings)
- Added 19 unit tests for template rendering (all-true, all-false, whitespace checks)

Fixes #41

## Test plan

- [x] `make lint` — ruff and yamllint pass
- [x] `make test` — all 818 tests pass (including 19 new template tests)
- [x] Rendered template with all-true vars passes markdownlint with 0 errors
- [x] Rendered template with all-false vars passes markdownlint with 0 errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)