### PR TITLE
fix: hardcoded version and missing project marker file

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2026-03-18
+
+### Fixed
+
+#### Config bugs: hardcoded version and missing project marker (#45)
+
+- Replaced hardcoded `AIDA_VERSION = "0.7.0"` with dynamic version
+  read from `plugin.json`, so `aida-project-context.yml` reflects
+  the actual plugin version
+- Added call to `render_aida_project_marker()` at the end of the
+  configure flow, writing `.claude/aida.yml` so `detect.py` correctly
+  reports `project_configured: true` after configuration
+
+---
+
 ## [1.1.2] - 2026-03-18
 
 ### Fixed

--- a/skills/aida/scripts/configure.py
+++ b/skills/aida/scripts/configure.py
@@ -73,7 +73,17 @@ logger = logging.getLogger(__name__)
 
 
 # Constants
-AIDA_VERSION = "0.7.0"
+def _read_plugin_version() -> str:
+    """Read version from plugin.json."""
+    plugin_json = Path(__file__).parent.parent.parent.parent / ".claude-plugin" / "plugin.json"
+    try:
+        data = json.loads(plugin_json.read_text(encoding="utf-8"))
+        return data.get("version", "0.0.0")
+    except (FileNotFoundError, json.JSONDecodeError, KeyError):
+        return "0.0.0"
+
+
+AIDA_VERSION = _read_plugin_version()
 AIDA_MARKER_FILE = "aida.yml"
 PROJECT_CONTEXT_FILE = "aida-project-context.yml"
 PROJECT_CONTEXT_SKILL_DIR = "skills/project-context"
@@ -981,6 +991,16 @@ def configure(responses: Dict[str, Any], inferred: Dict[str, Any] = None) -> Dic
                 " (non-critical): %s",
                 e,
             )
+
+        # Write aida.yml marker so detect.py reports project_configured: true
+        marker_path = project_root / ".claude" / AIDA_MARKER_FILE
+        marker_content = render_aida_project_marker(
+            preferences=config.get("preferences", {}),
+            project_name=config["project_name"],
+        )
+        atomic_write(marker_path, marker_content)
+        files_created.append(str(marker_path))
+        logger.info(f"Created project marker: {marker_path}")
 
         message = (
             "Project configuration complete! "


### PR DESCRIPTION
## Summary

- Replaced hardcoded `AIDA_VERSION = "0.7.0"` with dynamic version read from `plugin.json`
- Added call to `render_aida_project_marker()` at end of configure flow, writing `.claude/aida.yml` so `detect.py` correctly reports `project_configured: true`

Fixes #45

## Test plan

- [x] `make lint` — all linters pass
- [x] `make test` — all 818 tests pass
- [x] Verified `AIDA_VERSION` reads `1.1.2` dynamically from `plugin.json`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)