### PR TITLE
fix: use AIDA-managed venv for all script invocations

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.4] - 2026-03-18
+
+### Fixed
+
+#### Scripts invoked with bare python3 instead of AIDA venv (#47)
+
+- Updated all reference docs to invoke scripts via
+  `~/.aida/venv/bin/python3` instead of bare `python3`
+- Fixed Makefile `lint-frontmatter` target to use `$(VENV_BIN)/python3`
+- Updated troubleshooting docs to reference venv Python path
+- Affected files: `config.md`, `diagnostics.md`, `feedback.md`,
+  `permissions-workflow.md`, `troubleshooting.md`, `Makefile`
+
+---
+
 ## [1.1.3] - 2026-03-18
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ lint-md: ## Run markdownlint on Markdown files
 	markdownlint '**/*.md' --ignore node_modules
 
 lint-frontmatter: ## Validate frontmatter in SKILL.md files
-	python3 scripts/validate_frontmatter.py
+	$(VENV_BIN)/python3 scripts/validate_frontmatter.py
 
 lint-fix: ## Run ruff linter with auto-fix
 	$(VENV_BIN)/ruff check skills/ tests/ scripts/ --fix

--- a/agents/aida/knowledge/troubleshooting.md
+++ b/agents/aida/knowledge/troubleshooting.md
@@ -184,7 +184,7 @@ sudo apt install python3-venv
 chmod +x scripts/*.py
 
 # Use explicit Python path if needed
-/usr/bin/python3 scripts/status.py
+~/.aida/venv/bin/python3 scripts/status.py
 ```
 
 ## Diagnostic Commands

--- a/skills/aida/references/config.md
+++ b/skills/aida/references/config.md
@@ -25,7 +25,7 @@ Three-step flow:
 #### Step 1: Detect State
 
 ```bash
-python3 {base_directory}/scripts/detect.py
+~/.aida/venv/bin/python3 {base_directory}/scripts/detect.py
 ```
 
 Parse JSON response:
@@ -130,7 +130,7 @@ Global installation is completely automatic. It detects environment facts and in
 ##### Phase 1: Detect Environment
 
 ```bash
-python3 {base_directory}/scripts/install.py --get-questions --context '{context_json}'
+~/.aida/venv/bin/python3 {base_directory}/scripts/install.py --get-questions --context '{context_json}'
 ```
 
 Context JSON:
@@ -156,7 +156,7 @@ Returns:
 Since there are no questions, proceed directly to installation:
 
 ```bash
-python3 {base_directory}/scripts/install.py --install \
+~/.aida/venv/bin/python3 {base_directory}/scripts/install.py --install \
   --responses '{}' \
   --inferred '{inferred_json}'
 ```
@@ -180,7 +180,7 @@ Project configuration uses a **config-driven approach** with YAML as single sour
 ##### Phase 1: Detect Facts & Save to YAML
 
 ```bash
-python3 {base_directory}/scripts/configure.py --get-questions --context '{context_json}'
+~/.aida/venv/bin/python3 {base_directory}/scripts/configure.py --get-questions --context '{context_json}'
 ```
 
 Context JSON:
@@ -228,7 +228,7 @@ preferences: {branching_model: null, issue_tracking: "GitHub Issues", ...}
 Collect user responses with `AskUserQuestion`, then:
 
 ```bash
-python3 {base_directory}/scripts/configure.py --configure \
+~/.aida/venv/bin/python3 {base_directory}/scripts/configure.py --configure \
   --responses '{responses_json}'
 ```
 

--- a/skills/aida/references/diagnostics.md
+++ b/skills/aida/references/diagnostics.md
@@ -15,7 +15,7 @@ These are non-interactive commands - just run the script and display output.
 ### /aida status
 
 ```bash
-python3 {base_directory}/scripts/status.py
+~/.aida/venv/bin/python3 {base_directory}/scripts/status.py
 ```
 
 Display the output directly to the user.
@@ -23,7 +23,7 @@ Display the output directly to the user.
 ### /aida doctor
 
 ```bash
-python3 {base_directory}/scripts/doctor.py
+~/.aida/venv/bin/python3 {base_directory}/scripts/doctor.py
 ```
 
 Display the diagnostic results and any recommendations.
@@ -31,7 +31,7 @@ Display the diagnostic results and any recommendations.
 ### /aida upgrade
 
 ```bash
-python3 {base_directory}/scripts/upgrade.py
+~/.aida/venv/bin/python3 {base_directory}/scripts/upgrade.py
 ```
 
 Display upgrade information and follow any instructions provided.
@@ -44,7 +44,7 @@ Display upgrade information and follow any instructions provided.
 
 1. Get the base directory from skill context
 2. Construct the full path to the script
-3. Run `python3 {path_to_script}`
+3. Run `~/.aida/venv/bin/python3 {path_to_script}`
 4. Capture output (stdout and stderr)
 5. Display to user
 

--- a/skills/aida/references/feedback.md
+++ b/skills/aida/references/feedback.md
@@ -28,7 +28,7 @@ All feedback commands follow the same pattern:
 ```text
 1. Use AskUserQuestion to collect required fields
 2. Format collected data as JSON
-3. Run: python3 {base_directory}/scripts/feedback.py {command} --json='{...}'
+3. Run: ~/.aida/venv/bin/python3 {base_directory}/scripts/feedback.py {command} --json='{...}'
 4. Parse response and display success message
 ```
 
@@ -107,7 +107,7 @@ Format as:
 #### Command format
 
 ```bash
-python3 {base_directory}/scripts/feedback.py {action} --json='{json_data}'
+~/.aida/venv/bin/python3 {base_directory}/scripts/feedback.py {action} --json='{json_data}'
 ```
 
 Where `{action}` is: `feedback`, `bug`, or `feature-request`
@@ -115,7 +115,7 @@ Where `{action}` is: `feedback`, `bug`, or `feature-request`
 #### Example
 
 ```bash
-python3 /path/to/scripts/feedback.py feedback --json='{"message": "Great tool!", "category": "User Experience", "context": "Love the CLI"}'
+~/.aida/venv/bin/python3 /path/to/scripts/feedback.py feedback --json='{"message": "Great tool!", "category": "User Experience", "context": "Love the CLI"}'
 ```
 
 #### Script returns JSON

--- a/skills/permissions/references/permissions-workflow.md
+++ b/skills/permissions/references/permissions-workflow.md
@@ -23,7 +23,7 @@ Two-phase interactive flow:
 ### Phase 1: Get Questions
 
 ```bash
-python3 {base_directory}/scripts/permissions.py \
+~/.aida/venv/bin/python3 {base_directory}/scripts/permissions.py \
   --get-questions \
   --context '{"operation": "setup"}'
 ```
@@ -92,7 +92,7 @@ Returns:
 ### Phase 2: Execute
 
 ```bash
-python3 {base_directory}/scripts/permissions.py \
+~/.aida/venv/bin/python3 {base_directory}/scripts/permissions.py \
   --execute '{"preset": "developer-workstation", "scope": "user"}' \
   --context '{"categories": {"file-edit": {"label": "File Edit", "rules": ["Edit"], "suggested": "allow"}}}'
 ```
@@ -162,7 +162,7 @@ Returns:
 ### Audit Mode
 
 ```bash
-python3 {base_directory}/scripts/permissions.py \
+~/.aida/venv/bin/python3 {base_directory}/scripts/permissions.py \
   --audit \
   --context '{"operation": "audit"}'
 ```


### PR DESCRIPTION
## Summary

- Updated all reference docs to invoke scripts via `~/.aida/venv/bin/python3` instead of bare `python3`, ensuring third-party deps (PyYAML, jsonschema) are available
- Fixed Makefile `lint-frontmatter` target to use `$(VENV_BIN)/python3`
- Updated troubleshooting docs to reference venv Python path

### Files changed

- `skills/aida/references/config.md` — detect.py, install.py, configure.py (5 occurrences)
- `skills/aida/references/diagnostics.md` — status.py, doctor.py, upgrade.py (4 occurrences)
- `skills/aida/references/feedback.md` — feedback.py (3 occurrences)
- `skills/permissions/references/permissions-workflow.md` — permissions.py (3 occurrences)
- `agents/aida/knowledge/troubleshooting.md` — status.py fallback path
- `Makefile` — lint-frontmatter target

Fixes #47

## Test plan

- [x] `make lint` — all linters pass
- [x] `make test` — all 818 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)