### PR TITLE
fix: generated SKILL.md has multiple consecutive blank lines

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.5] - 2026-03-18
+
+### Fixed
+
+#### Generated SKILL.md has multiple consecutive blank lines (#49)
+
+- Added `trim_blocks`, `lstrip_blocks`, and `keep_trailing_newline`
+  to `template_renderer.py` SandboxedEnvironment — this was the
+  actual production renderer used by `configure.py`, which lacked
+  the whitespace settings present in `shared/utils.py`
+- Added post-processing safety net in `render_skill_directory()` to
+  collapse 3+ consecutive newlines to a single blank line
+- Added 5 tests using the production SandboxedEnvironment renderer
+  covering all-true, all-false, and mixed (marketplace-like) inputs
+
+---
+
 ## [1.1.4] - 2026-03-18
 
 ### Fixed

--- a/skills/aida/scripts/utils/template_renderer.py
+++ b/skills/aida/scripts/utils/template_renderer.py
@@ -6,6 +6,7 @@ variable substitution in both file contents and filenames.
 """
 
 import os
+import re
 from pathlib import Path
 from typing import Dict
 
@@ -170,7 +171,10 @@ def render_template(template_path: Path, variables: Dict[str, str]) -> str:
             undefined=StrictUndefined,
             autoescape=False,  # Intentionally disabled for markdown templates
             enable_async=False,
-            auto_reload=False
+            auto_reload=False,
+            trim_blocks=True,
+            lstrip_blocks=True,
+            keep_trailing_newline=True,
         )
 
         # Render template from string
@@ -419,6 +423,11 @@ def _render_directory_recursive(
             try:
                 # Render template content
                 rendered_content = render_template(item, variables)
+
+                # Post-process: collapse 3+ consecutive newlines to 2
+                # (one blank line max) as a safety net for template
+                # whitespace issues
+                rendered_content = re.sub(r'\n{3,}', '\n\n', rendered_content)
 
                 # Write rendered content to output file
                 write_file(output_path, rendered_content)

--- a/tests/unit/test_project_context_template.py
+++ b/tests/unit/test_project_context_template.py
@@ -12,11 +12,14 @@ from pathlib import Path
 # Add shared scripts to path
 _project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(_project_root / "scripts"))
+sys.path.insert(0, str(_project_root / "skills" / "aida" / "scripts"))
 
 from shared.utils import render_template  # noqa: E402
+from utils.template_renderer import render_template as sandbox_render  # noqa: E402
 
 TEMPLATES_DIR = _project_root / "skills" / "aida" / "templates"
 TEMPLATE_NAME = "blueprints/project-context/SKILL.md.jinja2"
+TEMPLATE_PATH = TEMPLATES_DIR / TEMPLATE_NAME
 
 
 def _base_vars(**overrides: str) -> dict[str, str]:
@@ -217,6 +220,72 @@ class TestProjectContextTemplateWhitespace(unittest.TestCase):
                     line,
                     f"Line {i} has trailing whitespace: {line!r}",
                 )
+
+
+class TestSandboxedRenderer(unittest.TestCase):
+    """Test using the production SandboxedEnvironment renderer.
+
+    This is the actual code path used by configure.py via
+    template_renderer.py, which previously lacked trim_blocks
+    and lstrip_blocks settings.
+    """
+
+    def _sandbox_render(self, **overrides: str) -> str:
+        return sandbox_render(TEMPLATE_PATH, _base_vars(**overrides))
+
+    def test_no_triple_blank_lines_all_true(self) -> None:
+        output = self._sandbox_render(
+            has_readme="true",
+            has_license="true",
+            has_gitignore="true",
+            has_changelog="true",
+            changelog_files="CHANGELOG.md",
+            has_contributing="true",
+            has_docs_directory="true",
+            has_tests="true",
+            has_ci_cd="true",
+            has_github_actions="true",
+            uses_docker="true",
+            has_dockerfile="true",
+            readme_length="500",
+            coding_standards="ruff",
+            issue_tracking="GitHub Issues",
+        )
+        self.assertNotRegex(output, r"\n{4,}")
+
+    def test_no_triple_blank_lines_all_false(self) -> None:
+        output = self._sandbox_render()
+        self.assertNotRegex(output, r"\n{4,}")
+
+    def test_no_triple_blank_lines_mixed(self) -> None:
+        """Marketplace-like project: no Docker, no tests, no docs dir."""
+        output = self._sandbox_render(
+            has_readme="true",
+            has_license="true",
+            has_gitignore="true",
+            has_changelog="false",
+            has_contributing="false",
+            has_docs_directory="false",
+            has_tests="false",
+            has_dockerfile="false",
+            has_docker_compose="false",
+            has_ci_cd="true",
+            has_github_actions="true",
+            has_package_json="true",
+            uses_docker="false",
+            issue_tracking="GitHub Issues",
+            readme_length="2500",
+        )
+        self.assertNotRegex(output, r"\n{4,}")
+
+    def test_no_none_literal(self) -> None:
+        output = self._sandbox_render()
+        self.assertNotIn("N, o, n, e", output)
+
+    def test_boolean_false_excluded(self) -> None:
+        output = self._sandbox_render()
+        self.assertNotIn(".gitignore: ✓", output)
+        self.assertNotIn("Contributing guide", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The **root cause** was that `template_renderer.py` (the production renderer used by `configure.py`) used a `SandboxedEnvironment` **without** `trim_blocks`/`lstrip_blocks`, while the template was designed and tested against `shared/utils.py` which had those settings. This made all Jinja2 whitespace control tags ineffective in production.

- Added `trim_blocks=True`, `lstrip_blocks=True`, `keep_trailing_newline=True` to the `SandboxedEnvironment` in `template_renderer.py`
- Added post-processing safety net in `_render_directory_recursive()` to collapse 3+ consecutive newlines
- Added 5 tests using the production `SandboxedEnvironment` renderer (all-true, all-false, mixed/marketplace-like inputs)

Fixes #49

## Test plan

- [x] `make lint` — all linters pass
- [x] `make test` — all 823 tests pass (5 new)
- [x] Verified sandbox renderer now produces identical output to shared/utils renderer
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)