### PR TITLE
feat: add /aida about command and version in help text

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-03-18
+
+### Added
+
+#### `/aida about` command and version in help text (#51)
+
+- Added `/aida about` command to display plugin version, author, and
+  repository from `plugin.json`
+- Updated `/aida help` to include version footer
+- Reorganized help text "Info" section with `help`, `about`, `status`
+
+---
+
 ## [1.1.5] - 2026-03-18
 
 ### Fixed

--- a/skills/aida/SKILL.md
+++ b/skills/aida/SKILL.md
@@ -91,6 +91,7 @@ For `help` or no arguments:
 For `about`:
 
 - Read `{base_directory}/../../.claude-plugin/plugin.json`
+- Resolve the installed path from `{base_directory}/../..`
 - Display plugin metadata:
 
 ```markdown
@@ -99,6 +100,8 @@ For `about`:
 - **Version:** {version from plugin.json}
 - **Author:** {author.name from plugin.json}
 - **Repository:** {repository from plugin.json}
+- **Installed at:** {resolved path to plugin root}
+- **Marketplace:** {owner.name from marketplace.json, if .claude-plugin/marketplace.json exists}
 ```
 
 ### Agent Management Commands

--- a/skills/aida/SKILL.md
+++ b/skills/aida/SKILL.md
@@ -101,7 +101,6 @@ For `about`:
 - **Author:** {author.name from plugin.json}
 - **Repository:** {repository from plugin.json}
 - **Installed at:** {resolved path to plugin root}
-- **Marketplace:** {owner.name from marketplace.json, if .claude-plugin/marketplace.json exists}
 ```
 
 ### Agent Management Commands

--- a/skills/aida/SKILL.md
+++ b/skills/aida/SKILL.md
@@ -5,7 +5,7 @@ description: This skill routes /aida commands to appropriate handlers - configur
   diagnostics, feedback, extension management (agent-manager, skill-manager,
   plugin-manager, hook-manager, claude-md-manager), and session persistence
   (memento).
-version: 0.8.0
+version: 0.9.0
 tags:
   - core
 user-invocable: true
@@ -82,7 +82,24 @@ For `feedback`, `bug`, or `feature-request` commands:
 For `help` or no arguments:
 
 - Display the help text inline (see Help Text section below)
-- No additional files need to be loaded
+- Read the plugin version from `{base_directory}/../../.claude-plugin/plugin.json`
+  (the `"version"` field) and include it in the footer
+- No additional reference files need to be loaded
+
+### About Command
+
+For `about`:
+
+- Read `{base_directory}/../../.claude-plugin/plugin.json`
+- Display plugin metadata:
+
+```markdown
+**AIDA Core Plugin**
+
+- **Version:** {version from plugin.json}
+- **Author:** {author.name from plugin.json}
+- **Repository:** {repository from plugin.json}
+```
 
 ### Agent Management Commands
 
@@ -320,8 +337,10 @@ When displaying help (for `help` command or no arguments), show:
 - `/aida claude validate` - Validate CLAUDE.md structure
 - `/aida claude list` - List all CLAUDE.md files in hierarchy
 
-### Help
+### Info
 - `/aida help` or `/aida` - Show this help message
+- `/aida about` - Show plugin version and metadata
+- `/aida status` - Show installation status and version
 
 ## Getting Started
 
@@ -333,6 +352,9 @@ To save work context: `/aida memento create "description"`
 To optimize your CLAUDE.md: `/aida claude optimize`
 To list hooks: `/aida hook list`
 To add a hook: `/aida hook add "auto-format on write"`
+
+---
+aida-core v{version from plugin.json}
 ```
 
 ## Resources


### PR DESCRIPTION
## Summary

- Added `/aida about` command routing in SKILL.md — reads `plugin.json` and displays version, author, repository
- Updated `/aida help` to include a version footer (`aida-core v{version}`)
- Reorganized help text with "Info" section grouping `help`, `about`, and `status`
- Bumped SKILL.md version to 0.9.0, plugin version to 1.2.0

Fixes #51

## Test plan

- [x] `make lint` — all linters pass
- [x] `make test` — all 823 tests pass
- [ ] CI passes
- [ ] Manual: run `/aida help` and verify version appears in footer
- [ ] Manual: run `/aida about` and verify plugin metadata displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)