### PR TITLE
fix: replace pinned model versions with family aliases

### DIFF
--- a/agents/claude-code-expert/knowledge/hooks.md
+++ b/agents/claude-code-expert/knowledge/hooks.md
@@ -68,7 +68,7 @@ evaluation. The model returns a yes/no decision as JSON.
 {
   "type": "prompt",
   "prompt": "Evaluate if this action is safe: $ARGUMENTS",
-  "model": "claude-haiku-4-5",
+  "model": "haiku",
   "timeout": 30
 }
 ```
@@ -103,7 +103,7 @@ up to 50 turns of tool use.
 {
   "type": "agent",
   "prompt": "Verify all tests pass and code follows conventions. $ARGUMENTS",
-  "model": "claude-haiku-4-5",
+  "model": "haiku",
   "timeout": 60
 }
 ```

--- a/agents/claude-code-expert/knowledge/settings.md
+++ b/agents/claude-code-expert/knowledge/settings.md
@@ -89,15 +89,15 @@ Override the default Claude model:
 
 ```json
 {
-  "model": "claude-sonnet-4-6"
+  "model": "sonnet"
 }
 ```
 
 Current model identifiers:
 
-- `claude-opus-4-6` -- Most capable model
-- `claude-sonnet-4-6` -- Balanced performance and speed
-- `claude-haiku-4-5` -- Fastest model
+- `opus` -- Most capable model
+- `sonnet` -- Balanced performance and speed
+- `haiku` -- Fastest model
 
 ### Available Models
 
@@ -752,7 +752,7 @@ Claude Code recognizes these environment variables.
 | `ANTHROPIC_MODEL` | Model name to use |
 | `CLAUDE_CODE_USE_BEDROCK` | Use AWS Bedrock |
 | `CLAUDE_CODE_USE_VERTEX` | Use Google Vertex AI |
-| `CLAUDE_CODE_EFFORT_LEVEL` | `low`, `medium`, `high` (Opus 4.6) |
+| `CLAUDE_CODE_EFFORT_LEVEL` | `low`, `medium`, `high` (Opus) |
 | `CLAUDE_CODE_DISABLE_AUTO_MEMORY` | Disable auto memory (0/1) |
 | `ENABLE_TOOL_SEARCH` | MCP tool search (`auto`, `true`, `false`, `auto:N`) |
 
@@ -776,7 +776,7 @@ Claude Code recognizes these environment variables.
 | `ANTHROPIC_DEFAULT_SONNET_MODEL` | Override Sonnet model |
 | `ANTHROPIC_DEFAULT_OPUS_MODEL` | Override Opus model |
 | `CLAUDE_CODE_SUBAGENT_MODEL` | Model for subagents |
-| `CLAUDE_CODE_EFFORT_LEVEL` | `low`, `medium`, `high` (Opus 4.6) |
+| `CLAUDE_CODE_EFFORT_LEVEL` | `low`, `medium`, `high` (Opus) |
 | `MAX_THINKING_TOKENS` | Override extended thinking budget |
 
 ### Sandbox and Security
@@ -892,7 +892,7 @@ Personal settings for a developer (`~/.claude/settings.json`):
 ```json
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "model": "claude-sonnet-4-6",
+  "model": "sonnet",
   "env": {
     "EDITOR": "code"
   },
@@ -980,7 +980,7 @@ Sandbox-enabled configuration with network restrictions:
 ```json
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "model": "claude-sonnet-4-6",
+  "model": "sonnet",
   "sandbox": {
     "enabled": true,
     "autoAllowBashIfSandboxed": true,

--- a/agents/claude-code-expert/knowledge/skills.md
+++ b/agents/claude-code-expert/knowledge/skills.md
@@ -136,7 +136,7 @@ Only `description` is recommended so Claude knows when to use the skill.
 | Field | Type | Default | Description |
 | ----- | ---- | ------- | ----------- |
 | `allowed-tools` | string (space/comma) | all tools | Tools Claude can use without permission prompts when this skill is active. Example: `Read, Grep, Glob`. |
-| `model` | string | session model | Override the model used when this skill is active. Example: `claude-haiku-4-5`. |
+| `model` | string | session model | Override the model used when this skill is active. Example: `haiku`. |
 | `context` | string | none | Set to `fork` to run in a forked subagent context (isolated from conversation history). |
 | `agent` | string | `general-purpose` | Which subagent type to use when `context: fork` is set. Options: `Explore`, `Plan`, `general-purpose`, or any custom agent name from `.claude/agents/`. |
 | `hooks` | object | none | Hooks scoped to this skill's lifecycle. Same format as hooks in settings.json. |

--- a/skills/agent-manager/references/schemas.md
+++ b/skills/agent-manager/references/schemas.md
@@ -43,7 +43,7 @@ version: 0.1.0
 tags:
   - core
   - domain-specific
-model: claude-sonnet-4.5
+model: sonnet
 color: purple
 skills:
   - skill-name

--- a/skills/skill-manager/references/schemas.md
+++ b/skills/skill-manager/references/schemas.md
@@ -68,7 +68,7 @@ agent: devops-expert
 hooks:
   - PreToolUse
   - PostToolUse
-model: claude-sonnet-4
+model: sonnet
 user-invocable: true
 argument-hint: "[deploy|rollback|status] [target]"
 allowed-tools: "Bash,Read,Write"

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -52,7 +52,7 @@ tags:
 skills:
   - skill-one
   - skill-two
-model: claude-sonnet-4.5
+model: sonnet
 ---
 
 # {name}


### PR DESCRIPTION
## Summary
- Replace version-pinned model identifiers (`claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`) with family aliases (`opus`, `sonnet`, `haiku`) across knowledge docs, reference schemas, and tests
- Ensures model references stay valid as new versions are released without requiring doc updates

## Test plan
- [ ] Verify `make test` passes with updated test fixture
- [ ] Verify `make lint` passes
- [ ] Spot-check knowledge docs render correctly