### PR TITLE
feat: require version + CHANGELOG bump on every PR

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,45 @@
+---
+name: Version & Changelog Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify version bump and matching CHANGELOG entry
+        run: |
+          set -euo pipefail
+
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          git fetch origin "${BASE_REF}" --depth=1
+
+          BASE_VERSION=$(git show "origin/${BASE_REF}:.claude-plugin/plugin.json" | jq -r '.version')
+          HEAD_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
+
+          echo "Base version: ${BASE_VERSION}"
+          echo "Head version: ${HEAD_VERSION}"
+
+          if [[ "${BASE_VERSION}" == "${HEAD_VERSION}" ]]; then
+            echo "::error file=.claude-plugin/plugin.json::Version not bumped. Every PR must update the version field (patch for fixes/docs/typos, minor for features, major for breaking changes)."
+            exit 1
+          fi
+
+          HIGHER=$(printf '%s\n%s\n' "${BASE_VERSION}" "${HEAD_VERSION}" | sort -V | tail -n1)
+          if [[ "${HIGHER}" != "${HEAD_VERSION}" ]]; then
+            echo "::error file=.claude-plugin/plugin.json::Version must increase (base ${BASE_VERSION} -> head ${HEAD_VERSION})."
+            exit 1
+          fi
+
+          if ! grep -qE "^## \[${HEAD_VERSION}\] - " CHANGELOG.md; then
+            echo "::error file=CHANGELOG.md::Missing CHANGELOG entry for version ${HEAD_VERSION}. Add a '## [${HEAD_VERSION}] - YYYY-MM-DD' section summarizing this PR's changes."
+            exit 1
+          fi
+
+          echo "OK: version bumped ${BASE_VERSION} -> ${HEAD_VERSION} with matching CHANGELOG entry."

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -20,26 +20,36 @@ jobs:
           BASE_REF="${{ github.event.pull_request.base.ref }}"
           git fetch origin "${BASE_REF}" --depth=1
 
-          BASE_VERSION=$(git show "origin/${BASE_REF}:.claude-plugin/plugin.json" | jq -r '.version')
+          BASE_VERSION=$(git show "origin/${BASE_REF}:.claude-plugin/plugin.json" \
+            | jq -r '.version')
           HEAD_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
 
           echo "Base version: ${BASE_VERSION}"
           echo "Head version: ${HEAD_VERSION}"
 
           if [[ "${BASE_VERSION}" == "${HEAD_VERSION}" ]]; then
-            echo "::error file=.claude-plugin/plugin.json::Version not bumped. Every PR must update the version field (patch for fixes/docs/typos, minor for features, major for breaking changes)."
+            msg="Version not bumped. Every PR must update the version field"
+            msg="${msg} (patch for fixes/docs/typos, minor for features,"
+            msg="${msg} major for breaking changes)."
+            echo "::error file=.claude-plugin/plugin.json::${msg}"
             exit 1
           fi
 
-          HIGHER=$(printf '%s\n%s\n' "${BASE_VERSION}" "${HEAD_VERSION}" | sort -V | tail -n1)
+          HIGHER=$(printf '%s\n%s\n' "${BASE_VERSION}" "${HEAD_VERSION}" \
+            | sort -V | tail -n1)
           if [[ "${HIGHER}" != "${HEAD_VERSION}" ]]; then
-            echo "::error file=.claude-plugin/plugin.json::Version must increase (base ${BASE_VERSION} -> head ${HEAD_VERSION})."
+            msg="Version must increase (base ${BASE_VERSION}"
+            msg="${msg} -> head ${HEAD_VERSION})."
+            echo "::error file=.claude-plugin/plugin.json::${msg}"
             exit 1
           fi
 
           if ! grep -qE "^## \[${HEAD_VERSION}\] - " CHANGELOG.md; then
-            echo "::error file=CHANGELOG.md::Missing CHANGELOG entry for version ${HEAD_VERSION}. Add a '## [${HEAD_VERSION}] - YYYY-MM-DD' section summarizing this PR's changes."
+            msg="Missing CHANGELOG entry for version ${HEAD_VERSION}."
+            msg="${msg} Add a '## [${HEAD_VERSION}] - YYYY-MM-DD' section"
+            msg="${msg} summarizing this PR's changes."
+            echo "::error file=CHANGELOG.md::${msg}"
             exit 1
           fi
 
-          echo "OK: version bumped ${BASE_VERSION} -> ${HEAD_VERSION} with matching CHANGELOG entry."
+          echo "OK: ${BASE_VERSION} -> ${HEAD_VERSION} with CHANGELOG entry."

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Verify version bump and matching CHANGELOG entry
         run: |
@@ -44,10 +42,13 @@ jobs:
             exit 1
           fi
 
-          if ! grep -qE "^## \[${HEAD_VERSION}\] - " CHANGELOG.md; then
-            msg="Missing CHANGELOG entry for version ${HEAD_VERSION}."
+          VERSION_ESCAPED=$(printf '%s' "${HEAD_VERSION}" \
+            | sed 's/[.[\*^$()+?{|]/\\&/g')
+          DATE_RE='[0-9]{4}-[0-9]{2}-[0-9]{2}'
+          if ! grep -qE "^## \[${VERSION_ESCAPED}\] - ${DATE_RE}" CHANGELOG.md; then
+            msg="Missing or invalid CHANGELOG entry for ${HEAD_VERSION}."
             msg="${msg} Add a '## [${HEAD_VERSION}] - YYYY-MM-DD' section"
-            msg="${msg} summarizing this PR's changes."
+            msg="${msg} (date must be ISO 8601) summarizing this PR's changes."
             echo "::error file=CHANGELOG.md::${msg}"
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-04-16
+
+### Added
+
+#### Version & Changelog CI check
+
+- Added `.github/workflows/version-check.yml` that runs on every PR to
+  `main` and fails the build if `.claude-plugin/plugin.json` version
+  was not bumped or if `CHANGELOG.md` lacks a matching
+  `## [<version>] - YYYY-MM-DD` entry
+- Enforces semver bump direction (head version must be greater than base)
+- Intent: every change — including typo fixes — updates the version so
+  the release history stays aligned with the code, even when a version
+  is not separately tagged
+
+---
+
+## [1.2.1] - 2026-04-16
+
+### Fixed
+
+#### Replace pinned model versions with family aliases (#56)
+
+- Replaced version-pinned model identifiers (`claude-opus-4-6`,
+  `claude-sonnet-4-6`, `claude-haiku-4-5`) with family aliases (`opus`,
+  `sonnet`, `haiku`) across knowledge docs, reference schemas, and tests
+- Ensures model references stay valid as new Claude versions ship without
+  requiring downstream doc updates
+
+---
+
 ## [1.2.0] - 2026-03-18
 
 ### Added
@@ -418,6 +449,9 @@ See git history for details on versions prior to 0.2.0.
 
 ---
 
+[1.3.0]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.3.0
+[1.2.1]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.2.1
+[1.2.0]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.2.0
 [1.1.1]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.1.1
 [1.1.0]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.1.0
 [1.0.0]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary

Adds a CI check that fails any PR to \`main\` which doesn't bump \`.claude-plugin/plugin.json\` and add a matching \`CHANGELOG.md\` entry.

**Rule enforced:**

- \`version\` field in \`plugin.json\` must be higher than base (semver-wise)
- \`CHANGELOG.md\` must contain a \`## [<new-version>] - YYYY-MM-DD\` heading for the new version

**Rationale:** every change — even typo fixes — should update the version so the release history stays aligned with the code. Not every version needs to be tagged as a GitHub release, but the file-level history is always current.

## Changes

- New workflow: \`.github/workflows/version-check.yml\`
- Bumps \`plugin.json\` to \`1.3.0\` (minor — new functionality, not a bugfix)
- Adds \`[1.3.0]\` CHANGELOG entry so this PR passes its own rule

## Merge ordering

Depends on #58 landing first (\`1.2.0 -> 1.2.1\`). After that, this branch will need a quick conflict resolve on \`plugin.json\` / \`CHANGELOG.md\` (both touch the same lines). Keep \`1.3.0\` in plugin.json and both changelog entries.