### PR TITLE
fix(plugin-manager): relax scaffold defaults (.gitignore, license)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Scaffold default license is now `UNLICENSED` instead of `MIT`
-- Scaffolded `.gitignore` no longer auto-ignores `.claude/`
+- Scaffolded `.gitignore` no longer auto-ignores the entire
+  `.claude/` directory; only `.claude/settings.local.json` (the
+  one file Claude Code designates as local-only) is ignored
 
 ## [1.4.0] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2026-04-24
+
+### Changed
+
+- Scaffold default license is now `UNLICENSED` instead of `MIT`
+- Scaffolded `.gitignore` no longer auto-ignores `.claude/`
+
 ## [1.4.0] - 2026-04-16
 
 ### Added

--- a/skills/plugin-manager/scripts/operations/scaffold.py
+++ b/skills/plugin-manager/scripts/operations/scaffold.py
@@ -141,7 +141,7 @@ def get_questions(
                 ),
                 "type": "choice",
                 "options": SUPPORTED_LICENSES,
-                "default": "MIT",
+                "default": "UNLICENSED",
             }
         )
 
@@ -321,7 +321,7 @@ def execute(context: dict[str, Any]) -> dict[str, Any]:
             "message": f"Unsupported language: {language}",
         }
 
-    license_id = context.get("license", "MIT")
+    license_id = context.get("license", "UNLICENSED")
     if license_id not in SUPPORTED_LICENSES:
         return {
             "success": False,

--- a/skills/plugin-manager/templates/scaffold/shared/gitignore-shared.jinja2
+++ b/skills/plugin-manager/templates/scaffold/shared/gitignore-shared.jinja2
@@ -8,6 +8,3 @@ Thumbs.db
 *.swp
 *.swo
 *~
-
-# Claude Code
-.claude/

--- a/skills/plugin-manager/templates/scaffold/shared/gitignore-shared.jinja2
+++ b/skills/plugin-manager/templates/scaffold/shared/gitignore-shared.jinja2
@@ -8,3 +8,6 @@ Thumbs.db
 *.swp
 *.swo
 *~
+
+# Claude Code (local-only files)
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

- Remove `.claude/` from the scaffolded `.gitignore` so generated plugins no longer auto-ignore Claude Code configuration.
- Default the scaffold license prompt and fallback to `UNLICENSED` instead of `MIT`.
- Bump plugin version to `1.4.1` with matching CHANGELOG entry.

## Test plan

- [ ] `make test` (816 unit tests pass locally)
- [ ] Confirm scaffolding a new plugin no longer emits `.claude/` in `.gitignore` and defaults the license to `UNLICENSED`