### PR TITLE
chore: backfill missing release tags and GitHub releases (1.4.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2026-04-24
+
+### Changed
+
+- Backfilled missing release tags and GitHub releases so the published
+  release history matches the changelog: tagged `v1.2.1` at the PR #58
+  merge commit and `v1.4.1` at the PR #62 merge commit, and published
+  GitHub releases for `v1.2.1`, `v1.4.0`, and `v1.4.1`
+- Added missing CHANGELOG reference links for 1.1.2–1.1.5, 1.4.1, and
+  1.4.2
+
+---
+
 ## [1.4.1] - 2026-04-24
 
 ### Changed
@@ -474,9 +487,15 @@ See git history for details on versions prior to 0.2.0.
 
 ---
 
+[1.4.2]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.4.2
+[1.4.1]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.4.1
 [1.4.0]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.4.0
 [1.2.1]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.2.1
 [1.2.0]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.2.0
+[1.1.5]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.1.5
+[1.1.4]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.1.4
+[1.1.3]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.1.3
+[1.1.2]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.1.2
 [1.1.1]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.1.1
 [1.1.0]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.1.0
 [1.0.0]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary

Cleans up release-history drift between `plugin.json`, `CHANGELOG.md`, git tags, and GitHub releases.

**Drift found:**
| Version | plugin.json | CHANGELOG | Tag | GH Release |
|---|---|---|---|---|
| 1.2.1 | ✓ (`b2effed`) | ✓ | ❌ | ❌ |
| 1.4.0 | ✓ (`46c137e`) | ✓ | ✓ | ❌ |
| 1.4.1 | ✓ (`415e1b7`) | ✓ | ❌ | ❌ |

**This PR:**
- Bumps `plugin.json` to `1.4.2` and adds the matching `[1.4.2]` CHANGELOG entry (required by the version-check workflow).
- Adds missing CHANGELOG reference links for 1.1.2–1.1.5, 1.4.1, and 1.4.2.

**Out-of-band after merge:**
- Tag `v1.2.1` at `b2effed` (PR #58 merge), `v1.4.1` at `415e1b7` (PR #62 merge), and `v1.4.2` at this PR's squash-merge commit.
- Publish GitHub releases for `v1.2.1`, `v1.4.0`, `v1.4.1`, and `v1.4.2` with notes pulled from the CHANGELOG.

## Test plan

- [x] `version-check` workflow passes (1.4.1 → 1.4.2 with matching CHANGELOG entry)
- [ ] After merge: tags pushed for v1.2.1, v1.4.1, v1.4.2
- [ ] After merge: GH releases published for v1.2.1, v1.4.0, v1.4.1, v1.4.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)