### PR TITLE
chore: update internal references after org transfer to aida-core (1.4.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"
   },
-  "repository": "https://github.com/oakensoul/aida-core-plugin"
+  "repository": "https://github.com/aida-core/aida-core-plugin"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.3] - 2026-04-28
+
+### Changed
+
+- Updated internal references from `oakensoul/` to `aida-core/` after
+  the GitHub org transfer on 2026-04-28: `plugin.json` `repository`
+  field, `gh api` calls in `upgrade.py`, `FEEDBACK_REPO` and
+  user-visible prompts in `feedback.py`, the scaffolded plugin README
+  template, and corresponding test assertions
+- User-facing docs and historical changelog/issue archives are
+  unchanged (covered by GitHub redirects); a separate docs PR will
+  follow
+
+---
+
 ## [1.4.2] - 2026-04-24
 
 ### Changed
@@ -487,6 +502,7 @@ See git history for details on versions prior to 0.2.0.
 
 ---
 
+[1.4.3]: https://github.com/aida-core/aida-core-plugin/releases/tag/v1.4.3
 [1.4.2]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.4.2
 [1.4.1]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.4.1
 [1.4.0]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.4.0

--- a/skills/aida/scripts/feedback.py
+++ b/skills/aida/scripts/feedback.py
@@ -37,7 +37,7 @@ MAX_INPUT_LENGTH = 5000  # Maximum characters for feedback/description
 MIN_INPUT_LENGTH = 10    # Minimum characters to prevent spam
 MIN_SUBMISSION_INTERVAL = 60  # Minimum seconds between submissions
 RATE_LIMIT_FILE = Path.home() / ".claude" / ".aida_feedback_last"
-FEEDBACK_REPO = "oakensoul/aida-marketplace"  # GitHub repository for feedback issues
+FEEDBACK_REPO = "aida-core/aida-marketplace"  # GitHub repository for feedback issues
 
 # Allowed GitHub label characters (alphanumeric, hyphen, space, colon, slash)
 ALLOWED_LABEL_PATTERN = re.compile(r'^[a-zA-Z0-9 \-:\/]+$')
@@ -619,7 +619,7 @@ def submit_feedback() -> int:
     print("Submit Feedback")
     print("="*60 + "\n")
 
-    print("This will create a public GitHub issue in oakensoul/aida-marketplace.")
+    print("This will create a public GitHub issue in aida-core/aida-marketplace.")
     print("Your feedback will be visible to everyone.\n")
 
     confirm = input("Continue? (y/n): ").strip().lower()
@@ -684,7 +684,7 @@ def submit_bug() -> int:
     print("Submit Bug Report")
     print("="*60 + "\n")
 
-    print("This will create a public GitHub issue in oakensoul/aida-marketplace.")
+    print("This will create a public GitHub issue in aida-core/aida-marketplace.")
     print("The issue will include your system information (OS, Python version).\n")
 
     confirm = input("Continue? (y/n): ").strip().lower()
@@ -758,7 +758,7 @@ def submit_feature_request() -> int:
     print("Submit Feature Request")
     print("="*60 + "\n")
 
-    print("This will create a public GitHub issue in oakensoul/aida-marketplace.")
+    print("This will create a public GitHub issue in aida-core/aida-marketplace.")
     print("Your feature request will be visible to everyone.\n")
 
     confirm = input("Continue? (y/n): ").strip().lower()

--- a/skills/aida/scripts/upgrade.py
+++ b/skills/aida/scripts/upgrade.py
@@ -42,7 +42,7 @@ def get_latest_version() -> Tuple[Optional[str], Optional[str]]:
     """
     try:
         result = subprocess.run(
-            ["gh", "api", "repos/oakensoul/aida-core-plugin/releases/latest"],
+            ["gh", "api", "repos/aida-core/aida-core-plugin/releases/latest"],
             capture_output=True,
             text=True,
             timeout=10
@@ -108,7 +108,7 @@ def get_release_notes(version: str) -> Tuple[Optional[str], Optional[str]]:
         tag = version if version.startswith('v') else f'v{version}'
 
         result = subprocess.run(
-            ["gh", "api", f"repos/oakensoul/aida-core-plugin/releases/tags/{tag}"],
+            ["gh", "api", f"repos/aida-core/aida-core-plugin/releases/tags/{tag}"],
             capture_output=True,
             text=True,
             timeout=10
@@ -194,13 +194,13 @@ def main() -> int:
                 "success": False,
                 "error": error,
                 "current_version": current,
-                "message": "Unable to check for updates. Please check manually at: https://github.com/oakensoul/aida-core-plugin/releases"
+                "message": "Unable to check for updates. Please check manually at: https://github.com/aida-core/aida-core-plugin/releases"
             })
         else:
             print(f"✗ Error checking for updates: {error}")
             print()
             print("Please check manually at:")
-            print("https://github.com/oakensoul/aida-core-plugin/releases")
+            print("https://github.com/aida-core/aida-core-plugin/releases")
         return 1
 
     if not json_mode:

--- a/skills/plugin-manager/templates/scaffold/shared/readme.md.jinja2
+++ b/skills/plugin-manager/templates/scaffold/shared/readme.md.jinja2
@@ -64,4 +64,4 @@ make clean   # Clean build artifacts
 
 ---
 
-*Scaffolded with [aida-core](https://github.com/oakensoul/aida-core-plugin) v{{ generator_version }}*
+*Scaffolded with [aida-core](https://github.com/aida-core/aida-core-plugin) v{{ generator_version }}*

--- a/tests/unit/test_feedback.py
+++ b/tests/unit/test_feedback.py
@@ -258,7 +258,7 @@ class TestCreateGitHubIssue(unittest.TestCase):
         """Test successful GitHub issue creation."""
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout='https://github.com/oakensoul/aida-marketplace/issues/123\n',
+            stdout='https://github.com/aida-core/aida-marketplace/issues/123\n',
             stderr=''
         )
 
@@ -277,7 +277,7 @@ class TestCreateGitHubIssue(unittest.TestCase):
         self.assertEqual(call_args[1], 'issue')
         self.assertEqual(call_args[2], 'create')
         self.assertIn('--repo', call_args)
-        self.assertIn('oakensoul/aida-marketplace', call_args)
+        self.assertIn('aida-core/aida-marketplace', call_args)
         self.assertIn('--title', call_args)
         self.assertIn('Test Issue', call_args)
         self.assertIn('--label', call_args)
@@ -348,7 +348,7 @@ class TestCreateGitHubIssue(unittest.TestCase):
         """Test that subprocess command has correct structure."""
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout='https://github.com/oakensoul/aida-marketplace/issues/1\n',
+            stdout='https://github.com/aida-core/aida-marketplace/issues/1\n',
             stderr=''
         )
 
@@ -367,7 +367,7 @@ class TestCreateGitHubIssue(unittest.TestCase):
         self.assertEqual(call_args[1], 'issue')
         self.assertEqual(call_args[2], 'create')
         self.assertIn('--repo', call_args)
-        self.assertIn('oakensoul/aida-marketplace', call_args)
+        self.assertIn('aida-core/aida-marketplace', call_args)
         self.assertIn('--title', call_args)
         self.assertIn('Test Title', call_args)
         self.assertIn('--body', call_args)


### PR DESCRIPTION
## Summary

- Functional code + scaffold template portion of #64 — flips remaining `oakensoul/` → `aida-core/` references in the code that actually executes (gh api calls, FEEDBACK_REPO, scaffolded plugin READMEs) so the in-repo references match the new canonical owner after the 2026-04-28 org transfer.
- Bumps version to **1.4.3** with a matching CHANGELOG entry.
- Folds the `feedback.py` change into this PR (rather than deferring) because `aida-core/aida-marketplace` is already live — verified via `gh api repos/aida-core/aida-marketplace`.

## Changes

| File | Change |
|---|---|
| `.claude-plugin/plugin.json` | `repository` URL → `aida-core/aida-core-plugin`; version `1.4.2` → `1.4.3` |
| `skills/aida/scripts/upgrade.py` | 4 hardcoded refs (gh api lines 45, 111; user-visible URLs lines 197, 203) |
| `skills/aida/scripts/feedback.py` | `FEEDBACK_REPO` constant + 3 confirmation prints |
| `tests/unit/test_feedback.py` | 4 assertion literals |
| `skills/plugin-manager/templates/scaffold/shared/readme.md.jinja2` | scaffolded plugin README footer link (high-priority — propagates to every newly scaffolded plugin) |
| `CHANGELOG.md` | `[1.4.3] - 2026-04-28` entry + footnote link |

## Out of scope (per #64)

- User-facing docs (separate, larger PR — README.md, GETTING_STARTED, USER_GUIDE_INSTALL, DEVELOPMENT, EXAMPLES, ADRs, c4 diagram, two skill references)
- Historical CHANGELOG link footnotes (18 refs — covered by GitHub redirects, rewriting is noisier than the benefit)
- `.issues/` and `.github/issues/` archives (preserved as historical records)

## Test plan

- [x] `make test` — 848 passed
- [x] `make lint` — ruff + yamllint clean (markdownlint not installed locally; CI will exercise)
- [x] `grep -rn "oakensoul/aida-core-plugin\|oakensoul/aida-marketplace" --include="*.py" --include="*.json" --include="*.jinja2"` — no remaining functional-code refs
- [x] Confirmed `aida-core/aida-marketplace` exists, so `feedback.py` won't 404 post-merge
- [ ] CI version-check passes (1.4.2 → 1.4.3 + CHANGELOG entry)
- [ ] After merge: `gh api repos/aida-core/aida-core-plugin/releases/latest` works from `upgrade.py`; `/aida feedback` opens issues in `aida-core/aida-marketplace`; scaffolded plugin READMEs link to the new URL

Closes #64 (functional + scaffold portion).