### PR TITLE
fix: split aida-project-context.yml into committable + .local overlay (1.4.5)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"
   },
-  "repository": "https://github.com/oakensoul/aida-core-plugin"
+  "repository": "https://github.com/aida-core/aida-core-plugin"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.4] - 2026-04-28
+
+### Changed
+
+- User-facing docs updated to reflect the org rename from `oakensoul/`
+  to `aida-core/`: `README.md`, `docs/GETTING_STARTED.md`,
+  `docs/USER_GUIDE_INSTALL.md`, `docs/DEVELOPMENT.md`,
+  `docs/EXAMPLES.md`, ADRs 006 and 008,
+  `docs/architecture/c4/container-diagram.md`, and the `feedback.md`
+  skill reference. Also normalizes a stale `/Users/oakensoul/...` path
+  example in `config-driven-approach.md`
+- Historical CHANGELOG link footnotes and `.issues/`/`.github/issues/`
+  archives intentionally left untouched (covered by GitHub redirects;
+  preserves accurate historical record)
+
+---
+
 ## [1.4.3] - 2026-04-28
 
 ### Changed
@@ -502,6 +519,7 @@ See git history for details on versions prior to 0.2.0.
 
 ---
 
+[1.4.4]: https://github.com/aida-core/aida-core-plugin/releases/tag/v1.4.4
 [1.4.3]: https://github.com/aida-core/aida-core-plugin/releases/tag/v1.4.3
 [1.4.2]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.4.2
 [1.4.1]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.5] - 2026-04-28
+
+### Changed
+
+- `/aida config` now writes the project context as **two files**: the
+  committable `.claude/aida-project-context.yml` (project-level facts:
+  vcs.type, languages, tools, preferences, etc.) and the gitignored
+  `.claude/aida-project-context.local.yml` (user/environment overlay:
+  `project_root`, `vcs.remote_url`, `last_updated`, `config_complete`).
+  Fixes #65 — previously the single file mixed both, making it
+  impractical to commit
+- Phase 2 of `/aida config` appends `.claude/aida-project-context.local.yml`
+  to the project's `.gitignore` (if one exists and the entry is missing).
+  No `.gitignore` is created — that decision stays with the project
+- New `utils.project_context` module (`load_project_context`,
+  `write_project_context`, `split_context`, `merge_context`,
+  `ensure_gitignore_entry`) for consumers that need to read the merged
+  view
+
+### Migration
+
+- Legacy single-file projects continue to read correctly via
+  `load_project_context()`. The split happens automatically on the next
+  `/aida config` run; no manual migration is required
+- Existing committed `aida-project-context.yml` files with stale paths
+  from another contributor will be cleaned up on next config run
+
+---
+
 ## [1.4.4] - 2026-04-28
 
 ### Changed
@@ -519,6 +548,7 @@ See git history for details on versions prior to 0.2.0.
 
 ---
 
+[1.4.5]: https://github.com/aida-core/aida-core-plugin/releases/tag/v1.4.5
 [1.4.4]: https://github.com/aida-core/aida-core-plugin/releases/tag/v1.4.4
 [1.4.3]: https://github.com/aida-core/aida-core-plugin/releases/tag/v1.4.3
 [1.4.2]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.3] - 2026-04-28
+
+### Changed
+
+- Updated internal references from `oakensoul/` to `aida-core/` after
+  the GitHub org transfer on 2026-04-28: `plugin.json` `repository`
+  field, `gh api` calls in `upgrade.py`, `FEEDBACK_REPO` and
+  user-visible prompts in `feedback.py`, the scaffolded plugin README
+  template, and corresponding test assertions
+- User-facing docs and historical changelog/issue archives are
+  unchanged (covered by GitHub redirects); a separate docs PR will
+  follow
+
+---
+
 ## [1.4.2] - 2026-04-24
 
 ### Changed
@@ -487,6 +502,7 @@ See git history for details on versions prior to 0.2.0.
 
 ---
 
+[1.4.3]: https://github.com/aida-core/aida-core-plugin/releases/tag/v1.4.3
 [1.4.2]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.4.2
 [1.4.1]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.4.1
 [1.4.0]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.4.0

--- a/README.md
+++ b/README.md
@@ -71,20 +71,20 @@ For detailed walkthrough, see the [Getting Started Guide](docs/GETTING_STARTED.m
 
 ## Commands
 
-| Command                 | Description                          |
-| ----------------------- | ------------------------------------ |
-| `/aida config`          | Configure AIDA (global or project)   |
-| `/aida status`          | Check installation and configuration |
-| `/aida doctor`          | Run health diagnostics               |
-| `/aida memento`         | Save/restore session context         |
-| `/aida agent create`    | Create a custom agent                |
-| `/aida skill create`    | Create a custom skill                |
-| `/aida expert list`     | List available experts and status    |
-| `/aida expert list configure`| Select active experts for a project |
-| `/aida expert panel list`| Show named panel compositions       |
-| `/aida feedback`        | Submit feedback via GitHub           |
-| `/aida bug`             | Report a bug                         |
-| `/aida feature-request` | Request a feature                    |
+| Command                       | Description                          |
+| ----------------------------- | ------------------------------------ |
+| `/aida config`                | Configure AIDA (global or project)   |
+| `/aida status`                | Check installation and configuration |
+| `/aida doctor`                | Run health diagnostics               |
+| `/aida memento`               | Save/restore session context         |
+| `/aida agent create`          | Create a custom agent                |
+| `/aida skill create`          | Create a custom skill                |
+| `/aida expert list`           | List available experts and status    |
+| `/aida expert list configure` | Select active experts for a project  |
+| `/aida expert panel list`     | Show named panel compositions        |
+| `/aida feedback`              | Submit feedback via GitHub           |
+| `/aida bug`                   | Report a bug                         |
+| `/aida feature-request`       | Request a feature                    |
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ or your user profile.
 ### Step 1: Add Marketplace
 
 ```bash
-/plugin marketplace add oakensoul/aida-marketplace
+/plugin marketplace add aida-core/aida-marketplace
 ```
 
 ### Step 2: Install
@@ -160,8 +160,8 @@ See [DEVELOPMENT.md](docs/DEVELOPMENT.md) for contributor guidelines.
 
 ## Support
 
-- **Issues**: [GitHub Issues](https://github.com/oakensoul/aida-core-plugin/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/oakensoul/aida-core-plugin/discussions)
+- **Issues**: [GitHub Issues](https://github.com/aida-core/aida-core-plugin/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/aida-core/aida-core-plugin/discussions)
 - **Diagnostics**: `/aida doctor`
 
 ## License

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -44,7 +44,7 @@ gh --version
 
 ```bash
 # Clone the aida-core-plugin repository
-git clone git@github.com:oakensoul/aida-core-plugin.git
+git clone git@github.com:aida-core/aida-core-plugin.git
 cd aida-core-plugin
 ```
 
@@ -726,4 +726,4 @@ See monorepo `scripts/publish.sh` for publishing to separate repositories.
 
 ---
 
-**Ready to contribute?** Check out [good first issues](https://github.com/oakensoul/aida-core-plugin/labels/good-first-issue)
+**Ready to contribute?** Check out [good first issues](https://github.com/aida-core/aida-core-plugin/labels/good-first-issue)

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -232,7 +232,7 @@ cd ~/my-monorepo
 
 # AIDA creates GitHub issue
 # Output: ✓ Bug report submitted!
-#         Issue: https://github.com/oakensoul/aida-core-plugin/issues/123
+#         Issue: https://github.com/aida-core/aida-core-plugin/issues/123
 ```
 
 **Result**: Bug reported with all necessary context included automatically.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -22,7 +22,7 @@ Before installing AIDA, ensure you have:
 ### Step 1: Add AIDA Marketplace
 
 ```bash
-/plugin marketplace add oakensoul/aida-marketplace
+/plugin marketplace add aida-core/aida-marketplace
 ```
 
 This is a one-time setup that adds the AIDA plugin registry to your Claude Code.
@@ -172,8 +172,8 @@ See real-world usage scenarios in [EXAMPLES.md](EXAMPLES.md).
 
 ### Community
 
-- [GitHub Issues](https://github.com/oakensoul/aida-core-plugin/issues)
-- [GitHub Discussions](https://github.com/oakensoul/aida-core-plugin/discussions)
+- [GitHub Issues](https://github.com/aida-core/aida-core-plugin/issues)
+- [GitHub Discussions](https://github.com/aida-core/aida-core-plugin/discussions)
 
 ---
 

--- a/docs/USER_GUIDE_INSTALL.md
+++ b/docs/USER_GUIDE_INSTALL.md
@@ -93,13 +93,13 @@ git --version
 Open Claude Code and add the AIDA marketplace (one-time setup):
 
 ```bash
-/plugin marketplace add oakensoul/aida-marketplace
+/plugin marketplace add aida-core/aida-marketplace
 ```
 
 **Expected output:**
 
 ```text
-Adding marketplace oakensoul/aida-marketplace...
+Adding marketplace aida-core/aida-marketplace...
 ✓ Fetched marketplace registry
 ✓ Added marketplace "aida"
 
@@ -720,7 +720,7 @@ Understand how AIDA works:
 
 ### 5. Join the Community
 
-- **GitHub**: [aida-core-plugin](https://github.com/oakensoul/aida-core-plugin)
+- **GitHub**: [aida-core-plugin](https://github.com/aida-core/aida-core-plugin)
 - **Issues**: Report bugs and request features
 - **Discussions**: Share skills and get help
 

--- a/docs/architecture/adr/006-gh-cli-feedback.md
+++ b/docs/architecture/adr/006-gh-cli-feedback.md
@@ -130,7 +130,7 @@ def create_bug_report(
     """Create GitHub issue via gh CLI"""
     cmd = [
         "gh", "issue", "create",
-        "--repo", "oakensoul/aida-core-plugin",
+        "--repo", "aida-core/aida-core-plugin",
         "--title", title,
         "--body", body,
         "--label", ",".join(labels)
@@ -269,7 +269,7 @@ To report this bug, please:
 3. Run: /aida bug
 
 Or manually create an issue:
-https://github.com/oakensoul/aida-core-plugin/issues/new
+https://github.com/aida-core/aida-core-plugin/issues/new
 ```
 
 ## Future Considerations

--- a/docs/architecture/adr/008-marketplace-centric-distribution.md
+++ b/docs/architecture/adr/008-marketplace-centric-distribution.md
@@ -38,7 +38,7 @@ Use a **Marketplace-Centric** distribution model where:
 
 ```bash
 # One-time: Add the AIDA marketplace
-/plugin marketplace add oakensoul/aida-marketplace
+/plugin marketplace add aida-core/aida-marketplace
 
 # Install plugins by short name
 /plugin install core@aida
@@ -48,10 +48,10 @@ Use a **Marketplace-Centric** distribution model where:
 
 | Component                    | Name                           |
 | ---------------------------- | ------------------------------ |
-| Marketplace repo             | `oakensoul/aida-marketplace`   |
+| Marketplace repo             | `aida-core/aida-marketplace`   |
 | Marketplace name             | `aida`                         |
 | Core plugin (in marketplace) | `core`                         |
-| Core plugin repo             | `oakensoul/aida-core-plugin`   |
+| Core plugin repo             | `aida-core/aida-core-plugin`   |
 | Install command              | `/plugin install core@aida`    |
 
 ## Rationale
@@ -66,7 +66,7 @@ Use a **Marketplace-Centric** distribution model where:
 
 #### 2. Simplified Installation
 
-- Short, memorable names: `core@aida` vs `oakensoul/aida-core-plugin`
+- Short, memorable names: `core@aida` vs `aida-core/aida-core-plugin`
 - Consistent pattern for all plugins
 - No need to remember GitHub paths
 
@@ -100,7 +100,7 @@ Use a **Marketplace-Centric** distribution model where:
 
 **Against:**
 
-- Verbose installation: `/plugin install oakensoul/aida-core-plugin`
+- Verbose installation: `/plugin install aida-core/aida-core-plugin`
 - No central discovery
 - Version management per-repo
 - Issues scattered across repos
@@ -192,7 +192,7 @@ aida-marketplace/
       "name": "core",
       "source": {
         "type": "github",
-        "repo": "oakensoul/aida-core-plugin"
+        "repo": "aida-core/aida-core-plugin"
       },
       "description": "Core AIDA functionality",
       "version": "0.5.0",
@@ -212,7 +212,7 @@ Each plugin repo must have:
 
 ### Feedback Flow
 
-All user feedback goes to `oakensoul/aida-marketplace`:
+All user feedback goes to `aida-core/aida-marketplace`:
 
 - Bug reports
 - Feature requests

--- a/docs/architecture/c4/container-diagram.md
+++ b/docs/architecture/c4/container-diagram.md
@@ -735,7 +735,7 @@ Exit with appropriate code
 
 ```bash
 # Add AIDA marketplace (one-time)
-/plugin marketplace add oakensoul/aida-marketplace
+/plugin marketplace add aida-core/aida-marketplace
 
 # Install core plugin
 /plugin install core@aida

--- a/skills/aida/references/config-driven-approach.md
+++ b/skills/aida/references/config-driven-approach.md
@@ -89,7 +89,7 @@ config_complete: false  # true when all required fields filled
 
 # Basic Info (auto-detected)
 project_name: "feature-53-create-aida-dispatcher-command"
-project_root: "/Users/oakensoul/Developer/..."
+project_root: "/Users/alice/Developer/..."
 
 # Version Control (auto-detected)
 vcs:

--- a/skills/aida/references/config.md
+++ b/skills/aida/references/config.md
@@ -196,7 +196,11 @@ Context JSON:
 ##### What happens in Phase 1
 
 1. Detects all project facts (VCS, files, languages, tools)
-2. **Saves to `.claude/aida-project-context.yml`** with nulls for unknown preferences
+2. **Saves to two files:**
+   - `.claude/aida-project-context.yml` — committed; project-level facts
+     (vcs.type, languages, tools, preferences, etc.)
+   - `.claude/aida-project-context.local.yml` — gitignored; user/environment
+     overlay (project_root, vcs.remote_url, last_updated, config_complete)
 3. Identifies null preference fields
 4. Returns only 0-3 questions for those gaps
 
@@ -210,18 +214,32 @@ Returns:
 }
 ```
 
-##### YAML Config Created (`.claude/aida-project-context.yml`)
+##### YAML Config Created — committed (`.claude/aida-project-context.yml`)
 
 ```yaml
 version: 0.2.0
-config_complete: false
-vcs: {type: git, uses_worktrees: true, ...}
+project_name: my-project
+vcs: {type: git, has_vcs: true, uses_worktrees: true, is_github: true, ...}
 files: {has_readme: true, has_license: true, ...}
 languages: {primary: Python, all: [...]}
 tools: {detected: [Git], ...}
 inferred: {project_type: Unknown, team_collaboration: Solo, ...}
 preferences: {branching_model: null, issue_tracking: "GitHub Issues", ...}
 ```
+
+##### Local Overlay — gitignored (`.claude/aida-project-context.local.yml`)
+
+```yaml
+project_root: /Users/alice/Developer/my-project
+config_complete: false
+last_updated: '2026-04-28T...'
+vcs:
+  remote_url: git@github.com:alice/my-project.git
+```
+
+Consumers always read via `load_project_context()`, which merges both
+files (local overrides project). The split keeps the committed file
+identical across contributors so it can live in version control.
 
 ##### Phase 2: Update YAML & Render Skill
 
@@ -234,12 +252,16 @@ Collect user responses with `AskUserQuestion`, then:
 
 ##### What happens in Phase 2
 
-1. Loads `.claude/aida-project-context.yml`
+1. Loads merged config from `.claude/aida-project-context.yml` plus the
+   gitignored `.local.yml` overlay (legacy single-file projects still
+   load transparently)
 2. Updates preferences with user responses
 3. Marks `config_complete: true`
-4. Saves updated YAML
-5. Maps YAML → template variables
-6. Renders `.claude/skills/project-context/SKILL.md`
+4. Saves updated config — splits into committed + `.local` files
+5. Appends `.claude/aida-project-context.local.yml` to project
+   `.gitignore` if it has one and the entry is missing
+6. Maps merged config → template variables
+7. Renders `.claude/skills/project-context/SKILL.md`
 
 Returns:
 

--- a/skills/aida/references/feedback.md
+++ b/skills/aida/references/feedback.md
@@ -124,7 +124,7 @@ Where `{action}` is: `feedback`, `bug`, or `feature-request`
 {
   "success": true,
   "message": "Feedback submitted successfully",
-  "issue_url": "https://github.com/oakensoul/aida-marketplace/issues/123",
+  "issue_url": "https://github.com/aida-core/aida-marketplace/issues/123",
   "issue_number": 123
 }
 ```
@@ -137,7 +137,7 @@ Where `{action}` is: `feedback`, `bug`, or `feature-request`
 ✅ Feedback submitted successfully!
 
 Your feedback has been created as issue #123:
-https://github.com/oakensoul/aida-marketplace/issues/123
+https://github.com/aida-core/aida-marketplace/issues/123
 
 Thank you for helping improve AIDA!
 ```
@@ -156,7 +156,7 @@ Adjust message based on action:
 Error: {error message from script}
 
 You can try again or report this issue at:
-https://github.com/oakensoul/aida-marketplace/issues
+https://github.com/aida-core/aida-marketplace/issues
 ```
 
 ### Level 5: Error Handling

--- a/skills/aida/scripts/configure.py
+++ b/skills/aida/scripts/configure.py
@@ -48,7 +48,6 @@ import _paths  # noqa: F401
 from utils import (
     get_claude_dir,
     ensure_directory,
-    write_yaml,
     load_questionnaire,
     detect_languages,
     detect_tools,
@@ -56,6 +55,9 @@ from utils import (
     detect_testing_approach,
     render_skill_directory,
     safe_json_load,
+    load_project_context,
+    write_project_context,
+    ensure_gitignore_entry,
     FileOperationError,
     ConfigurationError,
     InstallationError,
@@ -578,11 +580,12 @@ def get_questions(context: Dict[str, Any]) -> Dict[str, Any]:
     # Detect all project information (comprehensive)
     project_config = detect_project_info(project_root)
 
-    # Save to .claude/aida-project-context.yml
-    config_path = project_root / ".claude" / PROJECT_CONTEXT_FILE
+    # Save to .claude/aida-project-context.yml + aida-project-context.local.yml
+    # (split: project-level facts in the committed file, user-specific
+    # data in the gitignored .local overlay — see issue #65)
     try:
-        write_yaml(config_path, project_config)
-        logger.info(f"Saved project configuration to {config_path}")
+        project_path, _ = write_project_context(project_root, project_config)
+        logger.info(f"Saved project configuration to {project_path}")
     except (OSError, PermissionError) as e:
         logger.warning(f"Could not save project config: {e}")
         # Continue anyway - not critical for this phase
@@ -794,15 +797,17 @@ def configure(responses: Dict[str, Any], inferred: Dict[str, Any] = None) -> Dic
         project_root = Path.cwd()
         config_path = project_root / ".claude" / PROJECT_CONTEXT_FILE
 
-        # Load existing YAML config (should exist from Phase 1)
+        # Load existing YAML config (should exist from Phase 1).
+        # load_project_context merges aida-project-context.yml with the
+        # gitignored .local overlay so we operate on a single dict,
+        # then re-split on write.
         if not config_path.exists():
             raise FileOperationError(
                 f"Project config not found: {config_path}",
                 "Run 'python configure.py --get-questions' first to detect project facts"
             )
 
-        with open(config_path) as f:
-            config = yaml.safe_load(f)
+        config = load_project_context(project_root)
 
         # Update preferences with user responses
         for key, value in responses.items():
@@ -855,10 +860,20 @@ def configure(responses: Dict[str, Any], inferred: Dict[str, Any] = None) -> Dic
         config["config_complete"] = True
         config["last_updated"] = datetime.now(timezone.utc).isoformat()
 
-        # Save updated config
-        write_yaml(config_path, config)
-        files_created.append(str(config_path))
-        logger.info(f"Updated {config_path}")
+        # Save updated config — split into committed + .local overlay.
+        project_path, local_path = write_project_context(project_root, config)
+        files_created.append(str(project_path))
+        files_created.append(str(local_path))
+        logger.info(f"Updated {project_path} and {local_path}")
+
+        # Add the .local file to .gitignore so contributors don't accidentally
+        # commit each other's paths/timestamps. No-op if the entry is already
+        # present or if the project has no .gitignore.
+        try:
+            if ensure_gitignore_entry(project_root):
+                logger.info("Added aida-project-context.local.yml to .gitignore")
+        except (OSError, PermissionError) as e:
+            logger.warning(f"Could not update .gitignore: {e}")
 
         # Map YAML config to template variables (all strings for Jinja2)
         template_vars = {

--- a/skills/aida/scripts/feedback.py
+++ b/skills/aida/scripts/feedback.py
@@ -37,7 +37,7 @@ MAX_INPUT_LENGTH = 5000  # Maximum characters for feedback/description
 MIN_INPUT_LENGTH = 10    # Minimum characters to prevent spam
 MIN_SUBMISSION_INTERVAL = 60  # Minimum seconds between submissions
 RATE_LIMIT_FILE = Path.home() / ".claude" / ".aida_feedback_last"
-FEEDBACK_REPO = "oakensoul/aida-marketplace"  # GitHub repository for feedback issues
+FEEDBACK_REPO = "aida-core/aida-marketplace"  # GitHub repository for feedback issues
 
 # Allowed GitHub label characters (alphanumeric, hyphen, space, colon, slash)
 ALLOWED_LABEL_PATTERN = re.compile(r'^[a-zA-Z0-9 \-:\/]+$')
@@ -619,7 +619,7 @@ def submit_feedback() -> int:
     print("Submit Feedback")
     print("="*60 + "\n")
 
-    print("This will create a public GitHub issue in oakensoul/aida-marketplace.")
+    print("This will create a public GitHub issue in aida-core/aida-marketplace.")
     print("Your feedback will be visible to everyone.\n")
 
     confirm = input("Continue? (y/n): ").strip().lower()
@@ -684,7 +684,7 @@ def submit_bug() -> int:
     print("Submit Bug Report")
     print("="*60 + "\n")
 
-    print("This will create a public GitHub issue in oakensoul/aida-marketplace.")
+    print("This will create a public GitHub issue in aida-core/aida-marketplace.")
     print("The issue will include your system information (OS, Python version).\n")
 
     confirm = input("Continue? (y/n): ").strip().lower()
@@ -758,7 +758,7 @@ def submit_feature_request() -> int:
     print("Submit Feature Request")
     print("="*60 + "\n")
 
-    print("This will create a public GitHub issue in oakensoul/aida-marketplace.")
+    print("This will create a public GitHub issue in aida-core/aida-marketplace.")
     print("Your feature request will be visible to everyone.\n")
 
     confirm = input("Continue? (y/n): ").strip().lower()

--- a/skills/aida/scripts/upgrade.py
+++ b/skills/aida/scripts/upgrade.py
@@ -42,7 +42,7 @@ def get_latest_version() -> Tuple[Optional[str], Optional[str]]:
     """
     try:
         result = subprocess.run(
-            ["gh", "api", "repos/oakensoul/aida-core-plugin/releases/latest"],
+            ["gh", "api", "repos/aida-core/aida-core-plugin/releases/latest"],
             capture_output=True,
             text=True,
             timeout=10
@@ -108,7 +108,7 @@ def get_release_notes(version: str) -> Tuple[Optional[str], Optional[str]]:
         tag = version if version.startswith('v') else f'v{version}'
 
         result = subprocess.run(
-            ["gh", "api", f"repos/oakensoul/aida-core-plugin/releases/tags/{tag}"],
+            ["gh", "api", f"repos/aida-core/aida-core-plugin/releases/tags/{tag}"],
             capture_output=True,
             text=True,
             timeout=10
@@ -194,13 +194,13 @@ def main() -> int:
                 "success": False,
                 "error": error,
                 "current_version": current,
-                "message": "Unable to check for updates. Please check manually at: https://github.com/oakensoul/aida-core-plugin/releases"
+                "message": "Unable to check for updates. Please check manually at: https://github.com/aida-core/aida-core-plugin/releases"
             })
         else:
             print(f"✗ Error checking for updates: {error}")
             print()
             print("Please check manually at:")
-            print("https://github.com/oakensoul/aida-core-plugin/releases")
+            print("https://github.com/aida-core/aida-core-plugin/releases")
         return 1
 
     if not json_mode:

--- a/skills/aida/scripts/utils/__init__.py
+++ b/skills/aida/scripts/utils/__init__.py
@@ -97,6 +97,17 @@ from .template_renderer import (
     get_output_filename,
 )
 
+# Project context (split / merge of aida-project-context.yml and .local.yml)
+from .project_context import (
+    PROJECT_CONTEXT_FILE,
+    PROJECT_CONTEXT_LOCAL_FILE,
+    split_context,
+    merge_context,
+    load_project_context,
+    write_project_context,
+    ensure_gitignore_entry,
+)
+
 # Error classes
 from .errors import (
     AidaError,
@@ -169,6 +180,14 @@ __all__ = [
     "is_binary_file",
     "is_template_file",
     "get_output_filename",
+    # Project context split/merge
+    "PROJECT_CONTEXT_FILE",
+    "PROJECT_CONTEXT_LOCAL_FILE",
+    "split_context",
+    "merge_context",
+    "load_project_context",
+    "write_project_context",
+    "ensure_gitignore_entry",
     # Error classes
     "AidaError",
     "VersionError",

--- a/skills/aida/scripts/utils/project_context.py
+++ b/skills/aida/scripts/utils/project_context.py
@@ -1,0 +1,206 @@
+"""Split/merge helpers for the project-context YAML files.
+
+The project context lives in two files under `.claude/`:
+
+- `aida-project-context.yml` — committed; project-level facts (vcs.type,
+  languages, tools, preferences, etc.). Should be identical across every
+  contributor's working copy.
+- `aida-project-context.local.yml` — gitignored; user/environment overlay
+  (project_root, vcs.remote_url, last_updated, config_complete).
+
+Consumers should always read via `load_project_context()`, which merges
+both files (local overrides project). Writers should always go through
+`write_project_context()`, which splits a merged dict and writes both
+files atomically.
+
+Legacy single-file projects (everything in `aida-project-context.yml`)
+read transparently through `load_project_context()`; the next call to
+`write_project_context()` migrates them by emitting both files.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import yaml
+
+from .errors import ConfigurationError, FileOperationError
+from .files import read_file, write_yaml
+
+PROJECT_CONTEXT_FILE = "aida-project-context.yml"
+PROJECT_CONTEXT_LOCAL_FILE = "aida-project-context.local.yml"
+
+# Top-level keys that belong in the gitignored .local overlay.
+_LOCAL_TOP_LEVEL_KEYS = frozenset(
+    {"project_root", "last_updated", "config_complete"}
+)
+
+# Nested keys that belong in .local. Keyed by parent → child name.
+# Per issue #65, only `vcs.remote_url` is user-specific; the rest of vcs
+# (type, has_vcs, uses_worktrees, is_github, is_gitlab) is project-level.
+_LOCAL_NESTED_KEYS: Dict[str, frozenset] = {
+    "vcs": frozenset({"remote_url"}),
+}
+
+
+def split_context(merged: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Split a merged context dict into (project, local) components.
+
+    Project-level keys go to the committed file; user-specific keys
+    (paths, remote URLs, timestamps) go to the gitignored .local file.
+
+    Empty parent dicts that result from extracting all their children
+    are dropped so `local` doesn't carry stub `vcs: {}` entries.
+    """
+    project: Dict[str, Any] = {}
+    local: Dict[str, Any] = {}
+
+    for key, value in merged.items():
+        if key in _LOCAL_TOP_LEVEL_KEYS:
+            local[key] = value
+            continue
+
+        nested_local_keys = _LOCAL_NESTED_KEYS.get(key)
+        if nested_local_keys and isinstance(value, dict):
+            project_subset = {
+                k: v for k, v in value.items() if k not in nested_local_keys
+            }
+            local_subset = {
+                k: v for k, v in value.items() if k in nested_local_keys
+            }
+            if project_subset:
+                project[key] = project_subset
+            if local_subset:
+                local[key] = local_subset
+            continue
+
+        project[key] = value
+
+    return project, local
+
+
+def merge_context(
+    project: Dict[str, Any], local: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Merge a project + local pair into a single dict.
+
+    Local values override project values at the leaf level. Nested dicts
+    are merged shallowly (one level deep, matching the split semantics).
+    """
+    merged: Dict[str, Any] = {}
+    for key, value in project.items():
+        merged[key] = dict(value) if isinstance(value, dict) else value
+
+    for key, value in local.items():
+        if (
+            key in merged
+            and isinstance(merged[key], dict)
+            and isinstance(value, dict)
+        ):
+            merged[key].update(value)
+        else:
+            merged[key] = value
+
+    return merged
+
+
+def _read_yaml_if_exists(path: Path) -> Optional[Dict[str, Any]]:
+    """Load a YAML mapping from path, returning None if the file is absent.
+
+    Raises ConfigurationError on parse failure or if the document is not
+    a mapping.
+    """
+    if not path.exists():
+        return None
+    try:
+        text = read_file(path)
+    except FileOperationError:
+        raise
+    try:
+        data = yaml.safe_load(text) or {}
+    except yaml.YAMLError as e:
+        raise ConfigurationError(
+            f"Cannot parse {path.name}: {e}",
+            f"Fix the YAML syntax in {path}, or delete the file and rerun"
+            " /aida config to regenerate it.",
+        ) from e
+    if not isinstance(data, dict):
+        raise ConfigurationError(
+            f"{path.name} is not a YAML mapping (got {type(data).__name__})",
+            f"Expected a top-level mapping in {path}.",
+        )
+    return data
+
+
+def load_project_context(project_root: Path) -> Dict[str, Any]:
+    """Load the merged project context from `.claude/`.
+
+    Reads `aida-project-context.yml` and (if present) overlays
+    `aida-project-context.local.yml`. Returns an empty dict if neither
+    file exists.
+
+    Legacy single-file projects (no `.local.yml`) still work — the
+    committed file is returned as-is; the split happens on the next
+    write.
+    """
+    claude_dir = project_root / ".claude"
+    project = _read_yaml_if_exists(claude_dir / PROJECT_CONTEXT_FILE) or {}
+    local = _read_yaml_if_exists(claude_dir / PROJECT_CONTEXT_LOCAL_FILE) or {}
+    return merge_context(project, local)
+
+
+def write_project_context(
+    project_root: Path, merged: Dict[str, Any]
+) -> Tuple[Path, Path]:
+    """Split `merged` and write the project + local files atomically.
+
+    Returns (project_path, local_path). Both files are written even if
+    one of the components is empty — an empty `.local` file is fine and
+    keeps the gitignore expectation stable.
+    """
+    claude_dir = project_root / ".claude"
+    project_path = claude_dir / PROJECT_CONTEXT_FILE
+    local_path = claude_dir / PROJECT_CONTEXT_LOCAL_FILE
+
+    project, local = split_context(merged)
+    write_yaml(project_path, project)
+    write_yaml(local_path, local)
+    return project_path, local_path
+
+
+_GITIGNORE_BLOCK_HEADER = "# AIDA project context (user-specific overlay)"
+
+
+def ensure_gitignore_entry(project_root: Path) -> bool:
+    """Append the AIDA local-overlay block to `.gitignore` if missing.
+
+    Returns True if the gitignore was modified, False if it was already
+    up-to-date or `.gitignore` does not exist (we don't create one — that
+    decision belongs to the project, not /aida config).
+
+    The entry is anchored to the `.claude/` path so it doesn't conflict
+    with similarly-named files elsewhere in the tree.
+    """
+    gitignore_path = project_root / ".gitignore"
+    if not gitignore_path.exists():
+        return False
+
+    entry = f".claude/{PROJECT_CONTEXT_LOCAL_FILE}"
+    try:
+        current = read_file(gitignore_path)
+    except FileOperationError:
+        return False
+
+    # Idempotency: skip if the entry is already present in any non-comment line.
+    for line in current.splitlines():
+        if line.strip() == entry:
+            return False
+
+    block = f"\n{_GITIGNORE_BLOCK_HEADER}\n{entry}\n"
+    if not current.endswith("\n") and current:
+        block = "\n" + block
+    new_content = current + block
+
+    from .files import write_file as _write_file
+
+    _write_file(gitignore_path, new_content, create_parents=False)
+    return True

--- a/skills/plugin-manager/templates/scaffold/shared/readme.md.jinja2
+++ b/skills/plugin-manager/templates/scaffold/shared/readme.md.jinja2
@@ -64,4 +64,4 @@ make clean   # Clean build artifacts
 
 ---
 
-*Scaffolded with [aida-core](https://github.com/oakensoul/aida-core-plugin) v{{ generator_version }}*
+*Scaffolded with [aida-core](https://github.com/aida-core/aida-core-plugin) v{{ generator_version }}*

--- a/tests/unit/test_feedback.py
+++ b/tests/unit/test_feedback.py
@@ -258,7 +258,7 @@ class TestCreateGitHubIssue(unittest.TestCase):
         """Test successful GitHub issue creation."""
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout='https://github.com/oakensoul/aida-marketplace/issues/123\n',
+            stdout='https://github.com/aida-core/aida-marketplace/issues/123\n',
             stderr=''
         )
 
@@ -277,7 +277,7 @@ class TestCreateGitHubIssue(unittest.TestCase):
         self.assertEqual(call_args[1], 'issue')
         self.assertEqual(call_args[2], 'create')
         self.assertIn('--repo', call_args)
-        self.assertIn('oakensoul/aida-marketplace', call_args)
+        self.assertIn('aida-core/aida-marketplace', call_args)
         self.assertIn('--title', call_args)
         self.assertIn('Test Issue', call_args)
         self.assertIn('--label', call_args)
@@ -348,7 +348,7 @@ class TestCreateGitHubIssue(unittest.TestCase):
         """Test that subprocess command has correct structure."""
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout='https://github.com/oakensoul/aida-marketplace/issues/1\n',
+            stdout='https://github.com/aida-core/aida-marketplace/issues/1\n',
             stderr=''
         )
 
@@ -367,7 +367,7 @@ class TestCreateGitHubIssue(unittest.TestCase):
         self.assertEqual(call_args[1], 'issue')
         self.assertEqual(call_args[2], 'create')
         self.assertIn('--repo', call_args)
-        self.assertIn('oakensoul/aida-marketplace', call_args)
+        self.assertIn('aida-core/aida-marketplace', call_args)
         self.assertIn('--title', call_args)
         self.assertIn('Test Title', call_args)
         self.assertIn('--body', call_args)

--- a/tests/unit/test_project_context_split.py
+++ b/tests/unit/test_project_context_split.py
@@ -1,0 +1,267 @@
+"""Unit tests for the project-context split/merge helpers (issue #65)."""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(
+    0, str(Path(__file__).parent.parent.parent / "skills" / "aida" / "scripts")
+)
+
+from utils import (  # noqa: E402
+    PROJECT_CONTEXT_FILE,
+    PROJECT_CONTEXT_LOCAL_FILE,
+    ConfigurationError,
+    ensure_gitignore_entry,
+    load_project_context,
+    merge_context,
+    split_context,
+    write_project_context,
+)
+
+
+def _sample_merged():
+    """Return a representative merged config dict."""
+    return {
+        "version": "0.2.0",
+        "last_updated": "2026-04-28T00:00:00+00:00",
+        "config_complete": True,
+        "project_name": "demo",
+        "project_root": "/Users/alice/Developer/demo",
+        "vcs": {
+            "type": "git",
+            "has_vcs": True,
+            "uses_worktrees": False,
+            "remote_url": "git@github.com:alice/demo.git",
+            "is_github": True,
+            "is_gitlab": False,
+        },
+        "files": {"has_readme": True, "has_license": True},
+        "languages": {"primary": "Python", "all": ["Python"]},
+        "preferences": {
+            "branching_model": "GitHub Flow",
+            "issue_tracking": "GitHub Issues",
+        },
+    }
+
+
+class TestSplitContext(unittest.TestCase):
+    """split_context separates user-specific data from project-level data."""
+
+    def test_user_specific_top_level_keys_go_to_local(self):
+        project, local = split_context(_sample_merged())
+        self.assertIn("project_root", local)
+        self.assertIn("last_updated", local)
+        self.assertIn("config_complete", local)
+        self.assertNotIn("project_root", project)
+        self.assertNotIn("last_updated", project)
+        self.assertNotIn("config_complete", project)
+
+    def test_vcs_remote_url_moves_to_local(self):
+        project, local = split_context(_sample_merged())
+        self.assertEqual(local["vcs"], {"remote_url": "git@github.com:alice/demo.git"})
+        # Project keeps the rest of vcs
+        self.assertEqual(project["vcs"]["type"], "git")
+        self.assertTrue(project["vcs"]["is_github"])
+        self.assertNotIn("remote_url", project["vcs"])
+
+    def test_project_level_keys_stay_in_project(self):
+        project, _ = split_context(_sample_merged())
+        self.assertEqual(project["project_name"], "demo")
+        self.assertEqual(project["languages"]["primary"], "Python")
+        self.assertEqual(project["preferences"]["branching_model"], "GitHub Flow")
+        self.assertEqual(project["files"]["has_readme"], True)
+
+    def test_split_drops_empty_vcs_in_local_when_no_remote(self):
+        merged = _sample_merged()
+        del merged["vcs"]["remote_url"]
+        _, local = split_context(merged)
+        self.assertNotIn("vcs", local)
+
+    def test_split_handles_missing_optional_sections(self):
+        merged = {"project_name": "minimal", "version": "0.2.0"}
+        project, local = split_context(merged)
+        self.assertEqual(project, {"project_name": "minimal", "version": "0.2.0"})
+        self.assertEqual(local, {})
+
+
+class TestMergeContext(unittest.TestCase):
+    """merge_context recombines project + local back into a single dict."""
+
+    def test_round_trip_split_then_merge(self):
+        original = _sample_merged()
+        project, local = split_context(original)
+        merged = merge_context(project, local)
+        self.assertEqual(merged, original)
+
+    def test_local_overrides_project_at_leaf(self):
+        project = {"project_name": "from-project"}
+        local = {"project_name": "from-local"}
+        merged = merge_context(project, local)
+        self.assertEqual(merged["project_name"], "from-local")
+
+    def test_nested_dict_merge_is_shallow(self):
+        project = {"vcs": {"type": "git", "is_github": True}}
+        local = {"vcs": {"remote_url": "git@example.com:x/y.git"}}
+        merged = merge_context(project, local)
+        self.assertEqual(merged["vcs"]["type"], "git")
+        self.assertEqual(merged["vcs"]["is_github"], True)
+        self.assertEqual(merged["vcs"]["remote_url"], "git@example.com:x/y.git")
+
+    def test_merge_does_not_mutate_inputs(self):
+        project = {"vcs": {"type": "git"}}
+        local = {"vcs": {"remote_url": "x"}}
+        merge_context(project, local)
+        self.assertNotIn("remote_url", project["vcs"])
+
+
+class TestLoadProjectContext(unittest.TestCase):
+    """load_project_context reads and merges from disk."""
+
+    def test_reads_both_files_when_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            claude = root / ".claude"
+            claude.mkdir()
+            (claude / PROJECT_CONTEXT_FILE).write_text(
+                yaml.dump({"project_name": "x", "vcs": {"type": "git"}}),
+                encoding="utf-8",
+            )
+            (claude / PROJECT_CONTEXT_LOCAL_FILE).write_text(
+                yaml.dump({"project_root": str(root), "vcs": {"remote_url": "u"}}),
+                encoding="utf-8",
+            )
+            merged = load_project_context(root)
+            self.assertEqual(merged["project_name"], "x")
+            self.assertEqual(merged["project_root"], str(root))
+            self.assertEqual(merged["vcs"]["type"], "git")
+            self.assertEqual(merged["vcs"]["remote_url"], "u")
+
+    def test_legacy_single_file_returns_as_is(self):
+        """Existing projects with everything in .yml still work."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            claude = root / ".claude"
+            claude.mkdir()
+            legacy = _sample_merged()
+            (claude / PROJECT_CONTEXT_FILE).write_text(
+                yaml.dump(legacy), encoding="utf-8"
+            )
+            merged = load_project_context(root)
+            self.assertEqual(merged, legacy)
+
+    def test_no_files_returns_empty_dict(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(load_project_context(Path(tmp)), {})
+
+    def test_malformed_yaml_raises_configuration_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            claude = root / ".claude"
+            claude.mkdir()
+            (claude / PROJECT_CONTEXT_FILE).write_text(
+                "[unclosed list\n", encoding="utf-8"
+            )
+            with self.assertRaises(ConfigurationError):
+                load_project_context(root)
+
+
+class TestWriteProjectContext(unittest.TestCase):
+    """write_project_context writes the split files atomically."""
+
+    def test_writes_both_files_with_correct_split(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".claude").mkdir()
+            project_path, local_path = write_project_context(root, _sample_merged())
+
+            self.assertTrue(project_path.exists())
+            self.assertTrue(local_path.exists())
+
+            committed = yaml.safe_load(project_path.read_text())
+            local = yaml.safe_load(local_path.read_text())
+
+            self.assertNotIn("project_root", committed)
+            self.assertNotIn("last_updated", committed)
+            self.assertNotIn("remote_url", committed["vcs"])
+
+            self.assertIn("project_root", local)
+            self.assertEqual(local["vcs"]["remote_url"], "git@github.com:alice/demo.git")
+
+    def test_round_trip_via_disk(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".claude").mkdir()
+            original = _sample_merged()
+            write_project_context(root, original)
+            reloaded = load_project_context(root)
+            self.assertEqual(reloaded, original)
+
+    def test_legacy_to_split_migration_on_write(self):
+        """A single-file legacy project is split on next write."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".claude").mkdir()
+            (root / ".claude" / PROJECT_CONTEXT_FILE).write_text(
+                yaml.dump(_sample_merged()), encoding="utf-8"
+            )
+            self.assertFalse((root / ".claude" / PROJECT_CONTEXT_LOCAL_FILE).exists())
+
+            merged = load_project_context(root)
+            write_project_context(root, merged)
+
+            committed = yaml.safe_load(
+                (root / ".claude" / PROJECT_CONTEXT_FILE).read_text()
+            )
+            local = yaml.safe_load(
+                (root / ".claude" / PROJECT_CONTEXT_LOCAL_FILE).read_text()
+            )
+            self.assertNotIn("project_root", committed)
+            self.assertIn("project_root", local)
+
+
+class TestEnsureGitignoreEntry(unittest.TestCase):
+    """ensure_gitignore_entry adds the .local file to .gitignore idempotently."""
+
+    def test_appends_entry_when_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".gitignore").write_text("*.pyc\n", encoding="utf-8")
+            modified = ensure_gitignore_entry(root)
+            self.assertTrue(modified)
+            content = (root / ".gitignore").read_text()
+            self.assertIn(".claude/aida-project-context.local.yml", content)
+
+    def test_idempotent_when_entry_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".gitignore").write_text(
+                "*.pyc\n.claude/aida-project-context.local.yml\n",
+                encoding="utf-8",
+            )
+            modified = ensure_gitignore_entry(root)
+            self.assertFalse(modified)
+
+    def test_no_op_when_no_gitignore(self):
+        """Don't create a .gitignore — that's the project's call."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            modified = ensure_gitignore_entry(root)
+            self.assertFalse(modified)
+            self.assertFalse((root / ".gitignore").exists())
+
+    def test_appends_with_newline_when_file_lacks_trailing_newline(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".gitignore").write_text("*.pyc", encoding="utf-8")
+            ensure_gitignore_entry(root)
+            content = (root / ".gitignore").read_text()
+            self.assertTrue(content.startswith("*.pyc\n"))
+            self.assertIn(".claude/aida-project-context.local.yml", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #65. Splits `.claude/aida-project-context.yml` into two files so it can finally be checked in without contributors stepping on each other's paths/timestamps.

- `.claude/aida-project-context.yml` — committed; project-level facts (project_name, `vcs.{type,has_vcs,uses_worktrees,is_github,is_gitlab}`, files, languages, tools, inferred, preferences, plugins, experts).
- `.claude/aida-project-context.local.yml` — gitignored; user/environment overlay (`project_root`, `vcs.remote_url`, `last_updated`, `config_complete`).

**Stacked on #67** (which is stacked on #66). When those merge in order, this PR's base auto-flips to main.

## Key design choices

| Decision | Choice | Why |
|---|---|---|
| Migration timing | **Lazy.** Legacy single-file projects read transparently; split happens on next `/aida config`. | No explicit migrate step. Risk-free for unrelated repos. |
| `.gitignore` handling | **Idempotently append** if `.gitignore` exists; **don't create** if absent. | Decision to use git belongs to the project, not `/aida config`. |
| Expert-registry | **No changes.** | `experts.*` keys are project-level (committable). Adding cross-skill imports for the merge helper would be a smell — it works correctly post-split because it reads the committed file directly and preserves other top-level keys. |
| Schema version bump | **No.** | Out of scope; tracked separately by #39. |
| Field classification | Per the issue's table verbatim | `vcs.has_vcs` / `uses_worktrees` / `is_gitlab` are project-level (the issue's call). Only `vcs.remote_url` moves to `.local`. |

## Surface area

| Area | File | Change |
|---|---|---|
| New module | `skills/aida/scripts/utils/project_context.py` | `split_context`, `merge_context`, `load_project_context`, `write_project_context`, `ensure_gitignore_entry` |
| Public API | `skills/aida/scripts/utils/__init__.py` | Re-export the helpers + file-name constants |
| Writer (Phase 1) | `skills/aida/scripts/configure.py:584` | `write_yaml(...)` → `write_project_context(...)` |
| Writer (Phase 2) | `skills/aida/scripts/configure.py:859` | Load merged via helper, write split, append to `.gitignore` |
| Docs | `skills/aida/references/config.md` | Document both files + merge semantics |
| Version | `.claude-plugin/plugin.json` | 1.4.4 → 1.4.5 |
| CHANGELOG | `CHANGELOG.md` | New `[1.4.5] - 2026-04-28` entry + footnote link |

## Test plan

- [x] 20 new unit tests in `tests/unit/test_project_context_split.py` covering:
  - field classification (top-level + nested)
  - split → merge round trip via in-memory dicts and via disk
  - legacy single-file reads (no `.local.yml` present)
  - empty/missing-file behavior
  - malformed YAML raises `ConfigurationError`
  - `.gitignore` idempotency, no-op when absent, trailing-newline handling
- [x] Full suite: 868 passing (was 848 + 20 new)
- [x] `make lint` clean (ruff + yamllint)
- [x] `markdownlint-cli@0.43.0` (CI's pinned version) clean on changed docs
- [ ] Manual verification post-merge: run `/aida config` on a fresh project; check both files appear and `.gitignore` is updated
- [ ] Manual verification post-merge: run `/aida config` on a legacy project (single-file format); confirm seamless migration
- [ ] CI version-check passes (1.4.4 → 1.4.5 + matching CHANGELOG entry)

## Out of scope

- Schema version compatibility checking / migration logic (#39).
- Fixing already-checked-in `aida-project-context.yml` files in downstream repos (e.g., aida-marketplace) — those clean up automatically on next `/aida config`.

Closes #65.