### PR TITLE
docs: update org references after aida-core transfer (1.4.4)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.4] - 2026-04-28
+
+### Changed
+
+- User-facing docs updated to reflect the org rename from `oakensoul/`
+  to `aida-core/`: `README.md`, `docs/GETTING_STARTED.md`,
+  `docs/USER_GUIDE_INSTALL.md`, `docs/DEVELOPMENT.md`,
+  `docs/EXAMPLES.md`, ADRs 006 and 008,
+  `docs/architecture/c4/container-diagram.md`, and the `feedback.md`
+  skill reference. Also normalizes a stale `/Users/oakensoul/...` path
+  example in `config-driven-approach.md`
+- Historical CHANGELOG link footnotes and `.issues/`/`.github/issues/`
+  archives intentionally left untouched (covered by GitHub redirects;
+  preserves accurate historical record)
+
+---
+
 ## [1.4.3] - 2026-04-28
 
 ### Changed
@@ -502,6 +519,7 @@ See git history for details on versions prior to 0.2.0.
 
 ---
 
+[1.4.4]: https://github.com/aida-core/aida-core-plugin/releases/tag/v1.4.4
 [1.4.3]: https://github.com/aida-core/aida-core-plugin/releases/tag/v1.4.3
 [1.4.2]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.4.2
 [1.4.1]: https://github.com/oakensoul/aida-core-plugin/releases/tag/v1.4.1

--- a/README.md
+++ b/README.md
@@ -71,20 +71,20 @@ For detailed walkthrough, see the [Getting Started Guide](docs/GETTING_STARTED.m
 
 ## Commands
 
-| Command                 | Description                          |
-| ----------------------- | ------------------------------------ |
-| `/aida config`          | Configure AIDA (global or project)   |
-| `/aida status`          | Check installation and configuration |
-| `/aida doctor`          | Run health diagnostics               |
-| `/aida memento`         | Save/restore session context         |
-| `/aida agent create`    | Create a custom agent                |
-| `/aida skill create`    | Create a custom skill                |
-| `/aida expert list`     | List available experts and status    |
-| `/aida expert list configure`| Select active experts for a project |
-| `/aida expert panel list`| Show named panel compositions       |
-| `/aida feedback`        | Submit feedback via GitHub           |
-| `/aida bug`             | Report a bug                         |
-| `/aida feature-request` | Request a feature                    |
+| Command                       | Description                          |
+| ----------------------------- | ------------------------------------ |
+| `/aida config`                | Configure AIDA (global or project)   |
+| `/aida status`                | Check installation and configuration |
+| `/aida doctor`                | Run health diagnostics               |
+| `/aida memento`               | Save/restore session context         |
+| `/aida agent create`          | Create a custom agent                |
+| `/aida skill create`          | Create a custom skill                |
+| `/aida expert list`           | List available experts and status    |
+| `/aida expert list configure` | Select active experts for a project  |
+| `/aida expert panel list`     | Show named panel compositions        |
+| `/aida feedback`              | Submit feedback via GitHub           |
+| `/aida bug`                   | Report a bug                         |
+| `/aida feature-request`       | Request a feature                    |
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ or your user profile.
 ### Step 1: Add Marketplace
 
 ```bash
-/plugin marketplace add oakensoul/aida-marketplace
+/plugin marketplace add aida-core/aida-marketplace
 ```
 
 ### Step 2: Install
@@ -160,8 +160,8 @@ See [DEVELOPMENT.md](docs/DEVELOPMENT.md) for contributor guidelines.
 
 ## Support
 
-- **Issues**: [GitHub Issues](https://github.com/oakensoul/aida-core-plugin/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/oakensoul/aida-core-plugin/discussions)
+- **Issues**: [GitHub Issues](https://github.com/aida-core/aida-core-plugin/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/aida-core/aida-core-plugin/discussions)
 - **Diagnostics**: `/aida doctor`
 
 ## License

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -44,7 +44,7 @@ gh --version
 
 ```bash
 # Clone the aida-core-plugin repository
-git clone git@github.com:oakensoul/aida-core-plugin.git
+git clone git@github.com:aida-core/aida-core-plugin.git
 cd aida-core-plugin
 ```
 
@@ -726,4 +726,4 @@ See monorepo `scripts/publish.sh` for publishing to separate repositories.
 
 ---
 
-**Ready to contribute?** Check out [good first issues](https://github.com/oakensoul/aida-core-plugin/labels/good-first-issue)
+**Ready to contribute?** Check out [good first issues](https://github.com/aida-core/aida-core-plugin/labels/good-first-issue)

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -232,7 +232,7 @@ cd ~/my-monorepo
 
 # AIDA creates GitHub issue
 # Output: ✓ Bug report submitted!
-#         Issue: https://github.com/oakensoul/aida-core-plugin/issues/123
+#         Issue: https://github.com/aida-core/aida-core-plugin/issues/123
 ```
 
 **Result**: Bug reported with all necessary context included automatically.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -22,7 +22,7 @@ Before installing AIDA, ensure you have:
 ### Step 1: Add AIDA Marketplace
 
 ```bash
-/plugin marketplace add oakensoul/aida-marketplace
+/plugin marketplace add aida-core/aida-marketplace
 ```
 
 This is a one-time setup that adds the AIDA plugin registry to your Claude Code.
@@ -172,8 +172,8 @@ See real-world usage scenarios in [EXAMPLES.md](EXAMPLES.md).
 
 ### Community
 
-- [GitHub Issues](https://github.com/oakensoul/aida-core-plugin/issues)
-- [GitHub Discussions](https://github.com/oakensoul/aida-core-plugin/discussions)
+- [GitHub Issues](https://github.com/aida-core/aida-core-plugin/issues)
+- [GitHub Discussions](https://github.com/aida-core/aida-core-plugin/discussions)
 
 ---
 

--- a/docs/USER_GUIDE_INSTALL.md
+++ b/docs/USER_GUIDE_INSTALL.md
@@ -93,13 +93,13 @@ git --version
 Open Claude Code and add the AIDA marketplace (one-time setup):
 
 ```bash
-/plugin marketplace add oakensoul/aida-marketplace
+/plugin marketplace add aida-core/aida-marketplace
 ```
 
 **Expected output:**
 
 ```text
-Adding marketplace oakensoul/aida-marketplace...
+Adding marketplace aida-core/aida-marketplace...
 ✓ Fetched marketplace registry
 ✓ Added marketplace "aida"
 
@@ -720,7 +720,7 @@ Understand how AIDA works:
 
 ### 5. Join the Community
 
-- **GitHub**: [aida-core-plugin](https://github.com/oakensoul/aida-core-plugin)
+- **GitHub**: [aida-core-plugin](https://github.com/aida-core/aida-core-plugin)
 - **Issues**: Report bugs and request features
 - **Discussions**: Share skills and get help
 

--- a/docs/architecture/adr/006-gh-cli-feedback.md
+++ b/docs/architecture/adr/006-gh-cli-feedback.md
@@ -130,7 +130,7 @@ def create_bug_report(
     """Create GitHub issue via gh CLI"""
     cmd = [
         "gh", "issue", "create",
-        "--repo", "oakensoul/aida-core-plugin",
+        "--repo", "aida-core/aida-core-plugin",
         "--title", title,
         "--body", body,
         "--label", ",".join(labels)
@@ -269,7 +269,7 @@ To report this bug, please:
 3. Run: /aida bug
 
 Or manually create an issue:
-https://github.com/oakensoul/aida-core-plugin/issues/new
+https://github.com/aida-core/aida-core-plugin/issues/new
 ```
 
 ## Future Considerations

--- a/docs/architecture/adr/008-marketplace-centric-distribution.md
+++ b/docs/architecture/adr/008-marketplace-centric-distribution.md
@@ -38,7 +38,7 @@ Use a **Marketplace-Centric** distribution model where:
 
 ```bash
 # One-time: Add the AIDA marketplace
-/plugin marketplace add oakensoul/aida-marketplace
+/plugin marketplace add aida-core/aida-marketplace
 
 # Install plugins by short name
 /plugin install core@aida
@@ -48,10 +48,10 @@ Use a **Marketplace-Centric** distribution model where:
 
 | Component                    | Name                           |
 | ---------------------------- | ------------------------------ |
-| Marketplace repo             | `oakensoul/aida-marketplace`   |
+| Marketplace repo             | `aida-core/aida-marketplace`   |
 | Marketplace name             | `aida`                         |
 | Core plugin (in marketplace) | `core`                         |
-| Core plugin repo             | `oakensoul/aida-core-plugin`   |
+| Core plugin repo             | `aida-core/aida-core-plugin`   |
 | Install command              | `/plugin install core@aida`    |
 
 ## Rationale
@@ -66,7 +66,7 @@ Use a **Marketplace-Centric** distribution model where:
 
 #### 2. Simplified Installation
 
-- Short, memorable names: `core@aida` vs `oakensoul/aida-core-plugin`
+- Short, memorable names: `core@aida` vs `aida-core/aida-core-plugin`
 - Consistent pattern for all plugins
 - No need to remember GitHub paths
 
@@ -100,7 +100,7 @@ Use a **Marketplace-Centric** distribution model where:
 
 **Against:**
 
-- Verbose installation: `/plugin install oakensoul/aida-core-plugin`
+- Verbose installation: `/plugin install aida-core/aida-core-plugin`
 - No central discovery
 - Version management per-repo
 - Issues scattered across repos
@@ -192,7 +192,7 @@ aida-marketplace/
       "name": "core",
       "source": {
         "type": "github",
-        "repo": "oakensoul/aida-core-plugin"
+        "repo": "aida-core/aida-core-plugin"
       },
       "description": "Core AIDA functionality",
       "version": "0.5.0",
@@ -212,7 +212,7 @@ Each plugin repo must have:
 
 ### Feedback Flow
 
-All user feedback goes to `oakensoul/aida-marketplace`:
+All user feedback goes to `aida-core/aida-marketplace`:
 
 - Bug reports
 - Feature requests

--- a/docs/architecture/c4/container-diagram.md
+++ b/docs/architecture/c4/container-diagram.md
@@ -735,7 +735,7 @@ Exit with appropriate code
 
 ```bash
 # Add AIDA marketplace (one-time)
-/plugin marketplace add oakensoul/aida-marketplace
+/plugin marketplace add aida-core/aida-marketplace
 
 # Install core plugin
 /plugin install core@aida

--- a/skills/aida/references/config-driven-approach.md
+++ b/skills/aida/references/config-driven-approach.md
@@ -89,7 +89,7 @@ config_complete: false  # true when all required fields filled
 
 # Basic Info (auto-detected)
 project_name: "feature-53-create-aida-dispatcher-command"
-project_root: "/Users/oakensoul/Developer/..."
+project_root: "/Users/alice/Developer/..."
 
 # Version Control (auto-detected)
 vcs:

--- a/skills/aida/references/feedback.md
+++ b/skills/aida/references/feedback.md
@@ -124,7 +124,7 @@ Where `{action}` is: `feedback`, `bug`, or `feature-request`
 {
   "success": true,
   "message": "Feedback submitted successfully",
-  "issue_url": "https://github.com/oakensoul/aida-marketplace/issues/123",
+  "issue_url": "https://github.com/aida-core/aida-marketplace/issues/123",
   "issue_number": 123
 }
 ```
@@ -137,7 +137,7 @@ Where `{action}` is: `feedback`, `bug`, or `feature-request`
 ✅ Feedback submitted successfully!
 
 Your feedback has been created as issue #123:
-https://github.com/oakensoul/aida-marketplace/issues/123
+https://github.com/aida-core/aida-marketplace/issues/123
 
 Thank you for helping improve AIDA!
 ```
@@ -156,7 +156,7 @@ Adjust message based on action:
 Error: {error message from script}
 
 You can try again or report this issue at:
-https://github.com/oakensoul/aida-marketplace/issues
+https://github.com/aida-core/aida-marketplace/issues
 ```
 
 ### Level 5: Error Handling


### PR DESCRIPTION
## Summary

Docs portion of #64. Was originally PR #67 (stacked on the #66 functional+scaffold PR); when #66 squash-merged with `--delete-branch`, the source branch went away and #67 auto-closed. This is the same content rebased onto `main`.

Flips remaining `oakensoul/` → `aida-core/` references in user-facing documentation. Bumps to **1.4.4** with matching CHANGELOG entry.

## Files updated

| File | # refs |
|---|---|
| `README.md` | 3 + commands-table whitespace fix |
| `docs/GETTING_STARTED.md` | 3 |
| `docs/USER_GUIDE_INSTALL.md` | 3 |
| `docs/DEVELOPMENT.md` | 2 |
| `docs/EXAMPLES.md` | 1 |
| `docs/architecture/adr/008-marketplace-centric-distribution.md` | 7 |
| `docs/architecture/adr/006-gh-cli-feedback.md` | 2 |
| `docs/architecture/c4/container-diagram.md` | 1 |
| `skills/aida/references/feedback.md` | 3 |
| `skills/aida/references/config-driven-approach.md` | 1 (stale `/Users/oakensoul/...` path example normalized to `/Users/alice/...`) |

## Out of scope (per #64)

- Historical `CHANGELOG.md` release-tag link footnotes (covered by GitHub redirects).
- `.issues/` and `.github/issues/` archives (preserved as historical records).

## Test plan

- [x] `grep -rn "oakensoul/aida-core-plugin\|oakensoul/aida-marketplace" README.md docs/ skills/ tests/ .claude-plugin/` returns nothing
- [x] `make lint` clean (ruff + yamllint)
- [x] `markdownlint-cli@0.43.0` (CI's pinned version) clean on changed files
- [ ] CI version-check passes (1.4.3 → 1.4.4 + matching CHANGELOG entry)

Closes #64.