### PR TITLE
ci: block AI co-authorship trailers on PR (1.4.6)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,25 @@ jobs:
 
       - name: Run all linters
         run: make lint
+
+  check-attribution:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Block AI co-authorship trailers
+        run: |
+          MERGE_BASE=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+          PATTERN='^Co-Authored-By:.*\b(claude|anthropic|openai|chatgpt|copilot|gemini|ai\b)'
+          if git log "$MERGE_BASE..HEAD" --format='%B' | grep -iE "$PATTERN"; then
+            msg="Found AI co-authorship attribution. Remove Co-Authored-By"
+            msg="$msg trailers referencing AI tools (claude, anthropic, etc.)."
+            echo "::error::${msg}"
+            exit 1
+          fi
+          echo "No AI attribution found — clean."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.6] - 2026-04-28
+
+### Added
+
+- CI workflow `check-attribution` that scans PR commit messages for
+  `Co-Authored-By` trailers referencing AI tools (Claude, Anthropic,
+  OpenAI, ChatGPT, Copilot, Gemini, generic `ai`) and fails the build
+  if any are found. AGPL/copyright concern: AI co-authorship trailers
+  create copyright ownership ambiguity. Closes #54
+
+### Changed
+
+- Rewrote commit `4c80c92` (the v1.4.2 backfill commit) to remove a
+  pre-existing `Co-Authored-By: Claude` trailer; force-updated `main`
+  and re-pointed tags v1.4.2/v1.4.3/v1.4.4/v1.4.5 at their new SHAs.
+  GitHub releases follow the moved tags. Old SHAs remain reachable as
+  orphans for anyone with stale clones — `git fetch && git reset --hard
+  origin/main` will catch them up
+
+---
+
 ## [1.4.5] - 2026-04-28
 
 ### Changed
@@ -548,6 +569,7 @@ See git history for details on versions prior to 0.2.0.
 
 ---
 
+[1.4.6]: https://github.com/aida-core/aida-core-plugin/releases/tag/v1.4.6
 [1.4.5]: https://github.com/aida-core/aida-core-plugin/releases/tag/v1.4.5
 [1.4.4]: https://github.com/aida-core/aida-core-plugin/releases/tag/v1.4.4
 [1.4.3]: https://github.com/aida-core/aida-core-plugin/releases/tag/v1.4.3


### PR DESCRIPTION
## Summary

Closes #54. Adds a `check-attribution` job that fails any PR introducing a `Co-Authored-By` trailer naming an AI tool (Claude, Anthropic, OpenAI, ChatGPT, Copilot, Gemini, or generic `ai`).

The check is scoped to commits **in the PR** (`git merge-base` + `git log $BASE..HEAD`), so historical commits on main never re-trigger it.

## Motivation

Per #54: AI co-authorship trailers create copyright ownership / AGPL licensing ambiguity. Now that the one historical commit with such a trailer was rewritten out (`4c80c92` → `b0f62f6`, see CHANGELOG entry for 1.4.6), `main` is clean — this gate keeps it that way.

## Implementation

Drop-in from the reference job in `oakensoul/loadout`:

```yaml
check-attribution:
  if: github.event_name == 'pull_request'
  runs-on: ubuntu-latest
  permissions:
    contents: read
  steps:
    - uses: actions/checkout@v4
      with:
        fetch-depth: 0
    - name: Block AI co-authorship trailers
      run: |
        MERGE_BASE=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
        PATTERN='^Co-Authored-By:.*\b(claude|anthropic|openai|chatgpt|copilot|gemini|ai\b)'
        if git log "$MERGE_BASE..HEAD" --format='%B' | grep -iE "$PATTERN"; then
          # ...emit error and exit 1
        fi
```

Added as a job inside `ci.yml` (alongside `unit-test`, `integration-test`, `lint`) rather than a new workflow file — keeps related CI in one place.

## Test plan

- [x] yamllint + ruff clean (markdownlint via CI)
- [x] CHANGELOG entry for 1.4.6 + footnote link
- [ ] CI itself runs `check-attribution` on this PR — should pass (no AI trailers in this branch's commits)
- [ ] Negative test: locally simulated a PR with a `Co-Authored-By: Claude ...` trailer, confirmed grep matches

Closes #54.