### PR TITLE
chore: add AUTHORS file at repo root (1.4.7)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,16 @@
+# AUTHORS
+
+This file lists substantive contributors to aida-core-plugin.
+
+The collective copyright holder is "The AIDA Core Authors" (as referenced in
+SPDX `SPDX-FileCopyrightText` headers throughout the repo). The roster below
+is the authoritative list of who that collective is.
+
+Substantive contributors are added on first merged PR. Order is by first
+contribution.
+
+## Contributors
+
+- Rob Johnson <github@oakensoul.com> (@oakensoul) — maintainer
+- Eugene Levit <eug.levit@gmail.com>
+- Mark D'Antonio <104436415+markdiantonio@users.noreply.github.com> (@markdiantonio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.7] - 2026-04-30
+
+### Added
+
+- `AUTHORS` file at repo root listing substantive contributors. Per
+  the org-wide convention in
+  [.github/CONTRIBUTING.md](https://github.com/aida-core/.github/blob/main/CONTRIBUTING.md#licensing),
+  SPDX `SPDX-FileCopyrightText` headers attribute copyright to "The
+  AIDA Core Authors" — this file is the authoritative roster of who
+  that collective is. Substantive contributors are added on first
+  merged PR. Unblocks #72 and the org `.github-private` AUTHORS audit
+
+---
+
 ## [1.4.6] - 2026-04-28
 
 ### Added


### PR DESCRIPTION
## Summary

- Adds `AUTHORS` at the repo root with substantive contributors so far. This is the authoritative roster behind the "The AIDA Core Authors" collective copyright holder referenced in SPDX `SPDX-FileCopyrightText` headers.
- Lands first as a small standalone PR — bulk SPDX header pass and scaffolding updates follow in separate PRs to keep diffs reviewable.
- Once merged, the `.github-private` AUTHORS-presence audit run (every 30 min) will close the existing audit ticket automatically.

Refs #72.

## Test plan

- [x] `AUTHORS` exists at repo root and lists actual git contributors
- [x] Version bumped to 1.4.7 in `.claude-plugin/plugin.json`
- [x] CHANGELOG entry under `[1.4.7]` summarizes the change
- [ ] CI green (lint + version-check + check-attribution)