### PR TITLE
chore: adopt SPDX headers + REUSE compliance (1.4.8)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.4.6",
+  "version": "1.4.8",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 # CODEOWNERS - defines who must review changes to specific files/paths
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 

--- a/.github/issues/completed/issue-19/README.md
+++ b/.github/issues/completed/issue-19/README.md
@@ -9,6 +9,9 @@ actual_effort: 4
 estimated_effort: 4
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Issue #19: Merge Commands into Skills - align with Anthropic's upstream changes
 
 **Status**: COMPLETED

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 ---
 name: CI
 

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 ---
 name: Version & Changelog Check
 

--- a/.issues/completed/issue-12/README.md
+++ b/.issues/completed/issue-12/README.md
@@ -9,6 +9,9 @@ pr: 15
 actual_effort: 2
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Issue #12: Auto-generate agent routing directives in CLAUDE.md during config
 
 **Status**: COMPLETED

--- a/.issues/completed/issue-13/README.md
+++ b/.issues/completed/issue-13/README.md
@@ -9,6 +9,9 @@ actual_effort: 2
 estimated_effort: 2
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Issue #13: Move config and recommendedPermissions from plugin.json to aida-config.json
 
 **Status**: Completed

--- a/.issues/completed/issue-3-memento-user-level-storage/PLAN.md
+++ b/.issues/completed/issue-3-memento-user-level-storage/PLAN.md
@@ -3,6 +3,9 @@ type: reference
 title: "Plan: Move Memento Storage to User-Level (Issue #3)"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Plan: Move Memento Storage to User-Level (Issue #3)
 
 ## Context

--- a/.issues/completed/issue-3-memento-user-level-storage/README.md
+++ b/.issues/completed/issue-3-memento-user-level-storage/README.md
@@ -11,6 +11,9 @@ started: "2026-02-15"
 assignee: "@me"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Issue #3: Move memento storage from project-level to user-level
 
 **Status**: Completed (PR #10)

--- a/.issues/completed/issue-3-memento-user-level-storage/TEAM-PROMPT.md
+++ b/.issues/completed/issue-3-memento-user-level-storage/TEAM-PROMPT.md
@@ -3,6 +3,9 @@ type: reference
 title: "Team Prompt: Issue #3 - Move Memento Storage to User-Level"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Team Prompt: Issue #3 - Move Memento Storage to User-Level
 
 ## How to Use

--- a/.issues/completed/issue-4-plugin-config-and-permissions/README.md
+++ b/.issues/completed/issue-4-plugin-config-and-permissions/README.md
@@ -13,6 +13,9 @@ actual_effort: "3h"
 pr: 11
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Issue #4: Plugin configuration discovery and permissions management
 
 **Status**: Done

--- a/.issues/completed/issue-4-plugin-config-and-permissions/team-prompt.md
+++ b/.issues/completed/issue-4-plugin-config-and-permissions/team-prompt.md
@@ -3,6 +3,9 @@ type: reference
 title: "Team Prompt for Issue #4: Plugin Config Discovery & Permissions Management"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Team Prompt for Issue #4: Plugin Config Discovery & Permissions Management
 
 ## How to Use

--- a/.issues/completed/issue-5-project-permissions/README.md
+++ b/.issues/completed/issue-5-project-permissions/README.md
@@ -10,6 +10,9 @@ started: "2026-02-15"
 assignee: "@me"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Issue #5: Add project-level permissions for team workflows
 
 **Status**: In Progress

--- a/.issues/completed/issue-7/README.md
+++ b/.issues/completed/issue-7/README.md
@@ -7,6 +7,9 @@ created: "2026-02-15"
 completed: "2026-02-16"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Issue #7: Launch preparedness: documentation, marketing, and code quality review
 
 **Status**: OPEN

--- a/.issues/in-progress/issue-27/README.md
+++ b/.issues/in-progress/issue-27/README.md
@@ -11,6 +11,9 @@ github_url: "https://github.com/oakensoul/aida-core-plugin/issues/27"
 assignee: "@me"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Issue #27: Plugin upgrade - /aida plugin update
 
 **Status**: In Progress

--- a/.issues/in-progress/issue-27/workplan.md
+++ b/.issues/in-progress/issue-27/workplan.md
@@ -11,6 +11,9 @@ reviewers:
 status: draft
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Workplan: /aida plugin update (Issue #27)
 
 ## Executive Summary

--- a/.issues/in-progress/issue-31/README.md
+++ b/.issues/in-progress/issue-31/README.md
@@ -11,6 +11,9 @@ github_url: "https://github.com/oakensoul/aida-core-plugin/issues/31"
 assignee: "@me"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Issue #31: Decompose claude-code-management into entity-focused manager skills
 
 **Status**: In Progress

--- a/.issues/in-progress/issue-31/research-architecture.md
+++ b/.issues/in-progress/issue-31/research-architecture.md
@@ -6,6 +6,9 @@ date: "2026-02-24"
 issue: 31
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Architecture Analysis: Decomposing claude-code-management
 
 ## Executive Summary

--- a/.issues/in-progress/issue-31/research-briefing.md
+++ b/.issues/in-progress/issue-31/research-briefing.md
@@ -16,6 +16,9 @@ sources:
   - research-user-perspective.md (shell-systems-ux-designer)
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Issue #31 Research Briefing
 
 ## Part 1: Executive Summary

--- a/.issues/in-progress/issue-31/research-codebase.md
+++ b/.issues/in-progress/issue-31/research-codebase.md
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Codebase Deep Dive: claude-code-management Decomposition Analysis
 
 ## 1. Current Architecture Overview

--- a/.issues/in-progress/issue-31/research-docs.md
+++ b/.issues/in-progress/issue-31/research-docs.md
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Claude Code Documentation Research Findings
 
 Research conducted: 2026-02-24

--- a/.issues/in-progress/issue-31/research-framework.md
+++ b/.issues/in-progress/issue-31/research-framework.md
@@ -10,6 +10,9 @@ author: claude-code-expert
 date: 2026-02-24
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Extension Framework Review: Issue #31
 
 ## Summary

--- a/.issues/in-progress/issue-31/research-user-perspective.md
+++ b/.issues/in-progress/issue-31/research-user-perspective.md
@@ -6,6 +6,9 @@ date: 2026-02-24
 status: complete
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # User Perspective Analysis: Decomposing claude-code-management
 
 Evaluation of the proposed decomposition from the standpoint of real AIDA users

--- a/.issues/in-progress/issue-31/review-claude-code-expert-decomposition.md
+++ b/.issues/in-progress/issue-31/review-claude-code-expert-decomposition.md
@@ -11,6 +11,9 @@ date: 2026-02-24
 issue: "31"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Claude Code Expert Review: Decomposition of claude-code-management
 
 **Reviewer:** claude-code-expert (Extension Architecture)

--- a/.issues/in-progress/issue-31/review-end-user-validation.md
+++ b/.issues/in-progress/issue-31/review-end-user-validation.md
@@ -7,6 +7,9 @@ scope: functional validation of the 5 decomposed manager skills
 verdict: ready for PR with minor findings
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # End-User Validation: Decomposed Manager Skills
 
 Validation of the decomposition of the monolithic `claude-code-management`

--- a/.issues/in-progress/issue-31/review-final-end-user.md
+++ b/.issues/in-progress/issue-31/review-final-end-user.md
@@ -10,6 +10,9 @@ description: >
 verdict: PASS - Ready for PR
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Final End-User Validation
 
 ## Overview

--- a/.issues/in-progress/issue-31/review-final-expert.md
+++ b/.issues/in-progress/issue-31/review-final-expert.md
@@ -13,6 +13,9 @@ date: 2026-02-24
 issue: "31"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Final Expert Review: Decomposition Complete
 
 **Reviewer:** claude-code-expert (Extension Architecture)

--- a/.issues/in-progress/issue-31/review-final-tech-lead.md
+++ b/.issues/in-progress/issue-31/review-final-tech-lead.md
@@ -17,6 +17,9 @@ test_suite: 688 passed, 0 failures
 lint: all checks passed (ruff, yamllint, markdownlint, frontmatter)
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Final Tech Lead Code Review: Backlog Items Addressed
 
 ## Review Scope

--- a/.issues/in-progress/issue-31/review-lead-engineer.md
+++ b/.issues/in-progress/issue-31/review-lead-engineer.md
@@ -9,6 +9,9 @@ date: 2026-02-24
 status: complete
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Tech Lead Review: Knowledge Base Updates
 
 **Scope:** 7 knowledge files for the `claude-code-expert` agent

--- a/.issues/in-progress/issue-31/review-system-architect-decomposition.md
+++ b/.issues/in-progress/issue-31/review-system-architect-decomposition.md
@@ -8,6 +8,9 @@ status: complete
 files-reviewed: 62
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # System Architect Review: Decomposition of claude-code-management
 
 ## Executive Summary

--- a/.issues/in-progress/issue-31/review-tech-lead-decomposition.md
+++ b/.issues/in-progress/issue-31/review-tech-lead-decomposition.md
@@ -15,6 +15,9 @@ severity_breakdown:
   test_gap: 3
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Tech Lead Code Review: Decomposition of claude-code-management
 
 ## Review Scope

--- a/.issues/in-progress/issue-31/review-tech-writer.md
+++ b/.issues/in-progress/issue-31/review-tech-writer.md
@@ -8,6 +8,9 @@ status: "published"
 audience: "developers"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Technical Writer Review: Claude Code Expert Knowledge Files
 
 **Reviewer:** Technical Writer Agent

--- a/.issues/in-progress/issue-34-aida-managed-venv/README.md
+++ b/.issues/in-progress/issue-34-aida-managed-venv/README.md
@@ -8,6 +8,9 @@ estimated_effort: 5
 github_url: "https://github.com/oakensoul/aida-core-plugin/issues/34"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Issue #34: AIDA-managed virtual environment for Python dependencies
 
 **Status**: In Progress

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 ---
 # YAML Lint Configuration
 # https://yamllint.readthedocs.io/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,50 @@ type: changelog
 title: "AIDA Core Plugin Changelog"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Changelog
 
 All notable changes to AIDA Core Plugin.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.4.8] - 2026-04-30
+
+### Added
+
+- SPDX copyright/license headers on every hand-authored source file
+  (markdown, Python, YAML, shell, Makefiles, Dockerfiles,
+  requirements files): copyright "The AIDA Core Authors" / license
+  MPL-2.0. Inserted via the new `scripts/add_spdx_headers.py`
+  (idempotent, dry-run by default), which respects skip categories
+  from
+  [.github/CONTRIBUTING.md#licensing](https://github.com/aida-core/.github/blob/main/CONTRIBUTING.md#licensing):
+  JSON, lockfiles, fixtures, scaffolding templates, and `LICENSE`
+  itself. Refs #72, #73
+- `REUSE.toml` at the repo root licensing the skip categories that
+  cannot carry inline headers (JSON, dotfiles, scaffolding templates,
+  integration test fixtures). Copyright is attributed to "The AIDA
+  Core Authors" with the contributor roster in `AUTHORS`
+- `LICENSES/MPL-2.0.txt` (REUSE-required canonical license text;
+  `LICENSE` at repo root remains for GitHub display)
+- `lint-reuse` Makefile target running `reuse lint`; wired into
+  `make lint` so the existing CI lint job becomes the blocking gate
+  for REUSE compliance. Project is REUSE 3.3 compliant
+- `reuse>=4.0` dev dependency
+
+### Notes
+
+- Scaffolding tools (`plugin-manager`, `agent-manager`,
+  `skill-manager`, `claude-md-manager`, `hook-manager`) do **not**
+  emit SPDX headers in generated artifacts yet — that's the next PR
+  on #73. Templates themselves are intentionally header-free
+  (`REUSE.toml` covers them) so the renderer controls the year and
+  copyright holder per generated artifact
+
+---
 
 ## [1.4.6] - 2026-04-28
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,9 @@ type: readme
 title: AIDA Core Plugin
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # AIDA Core Plugin
 
 Claude Code plugin providing smart configuration, GitHub integration, and context

--- a/LICENSES/MPL-2.0.txt
+++ b/LICENSES/MPL-2.0.txt
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 # AIDA Core Plugin Makefile
 # Run `make help` for available targets
 
@@ -6,7 +9,7 @@ PLUGIN_NAME := aida-core
 VENV := $(HOME)/.aida/venv
 VENV_BIN := $(VENV)/bin
 
-.PHONY: help dev-mode-enable dev-mode-disable dev-mode test lint lint-py lint-yaml lint-md lint-frontmatter lint-fix install clean \
+.PHONY: help dev-mode-enable dev-mode-disable dev-mode test lint lint-py lint-yaml lint-md lint-frontmatter lint-reuse lint-fix install clean \
         docker-build docker-build-base docker-build-all docker-shell-% docker-clean docker-clean-all \
         docker-test-% docker-test-all
 
@@ -60,7 +63,7 @@ docker-clean-all: ## Remove containers, volumes, and images
 	cd tests/integration && docker-compose down -v --rmi all
 
 # Linting
-lint: lint-py lint-yaml lint-md lint-frontmatter ## Run all linters (Python, YAML, Markdown, Frontmatter)
+lint: lint-py lint-yaml lint-md lint-frontmatter lint-reuse ## Run all linters (Python, YAML, Markdown, Frontmatter, REUSE)
 
 lint-py: ## Run ruff linter on Python files
 	$(VENV_BIN)/ruff check skills/ tests/ scripts/
@@ -73,6 +76,9 @@ lint-md: ## Run markdownlint on Markdown files
 
 lint-frontmatter: ## Validate frontmatter in SKILL.md files
 	$(VENV_BIN)/python3 scripts/validate_frontmatter.py
+
+lint-reuse: ## Verify REUSE / SPDX compliance (every file has copyright + license info)
+	$(VENV_BIN)/reuse lint
 
 lint-fix: ## Run ruff linter with auto-fix
 	$(VENV_BIN)/ruff check skills/ tests/ scripts/ --fix

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ title: "AIDA Core Plugin"
 description: "Foundation plugin for AIDA"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # AIDA Core Plugin
 
 > The foundation for building your custom Claude Code experience.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,41 @@
+version = 1
+SPDX-PackageName = "aida-core-plugin"
+SPDX-PackageSupplier = "oakensoul <github@oakensoul.com>"
+SPDX-PackageDownloadLocation = "https://github.com/aida-core/aida-core-plugin"
+SPDX-PackageComment = "Copyright is held by 'The AIDA Core Authors'; the roster lives in the AUTHORS file at the repo root. This file licenses paths that cannot carry inline SPDX headers (no comment syntax) or that should not carry one (scaffolding templates, integration test fixtures simulating downstream projects). Files that can carry inline headers should — see scripts/add_spdx_headers.py."
+
+# JSON has no comment syntax, so it cannot carry an inline SPDX header.
+[[annotations]]
+path = ["**.json", "**/**.json"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 The AIDA Core Authors"
+SPDX-License-Identifier = "MPL-2.0"
+
+# Top-level config files without inline headers.
+[[annotations]]
+path = [".gitignore", "**/.gitignore", "**/.gitkeep"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 The AIDA Core Authors"
+SPDX-License-Identifier = "MPL-2.0"
+
+# Scaffolding templates. These are hand-authored MPL-2.0 source files,
+# but their content is rendered into downstream artifacts; the
+# scaffolding tools inject per-file headers into the rendered output
+# (see plugin-manager / agent-manager / etc.). Keeping headers out of
+# the template body avoids accidental double-headers and lets the
+# renderer set the year and copyright holder per generated artifact.
+[[annotations]]
+path = "skills/**/templates/**"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 The AIDA Core Authors"
+SPDX-License-Identifier = "MPL-2.0"
+
+# Integration test fixtures simulating downstream user projects. These
+# files are intentionally minimal stand-ins (package.json, sample
+# sources, READMEs) and are not the project's own copyrightable
+# content, but REUSE still needs an attribution.
+[[annotations]]
+path = "tests/integration/**/sample-project/**"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 The AIDA Core Authors"
+SPDX-License-Identifier = "MPL-2.0"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,7 +6,7 @@ SPDX-PackageComment = "Copyright is held by 'The AIDA Core Authors'; the roster 
 
 # JSON has no comment syntax, so it cannot carry an inline SPDX header.
 [[annotations]]
-path = ["**.json", "**/**.json"]
+path = "**.json"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2026 The AIDA Core Authors"
 SPDX-License-Identifier = "MPL-2.0"

--- a/agents/aida/aida.md
+++ b/agents/aida/aida.md
@@ -13,6 +13,9 @@ skills:
   - memento
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # AIDA Expert
 
 You are an expert on AIDA (Agentic Intelligence Digital Assistant). You receive complete

--- a/agents/aida/knowledge/config-schema.md
+++ b/agents/aida/knowledge/config-schema.md
@@ -4,6 +4,9 @@ title: AIDA Configuration Schema
 description: Schema and validation rules for aida-project-context.yml
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Configuration Schema
 
 AIDA uses YAML configuration files to store project context and user preferences.

--- a/agents/aida/knowledge/feedback-templates.md
+++ b/agents/aida/knowledge/feedback-templates.md
@@ -4,6 +4,9 @@ title: Feedback Templates
 description: Templates for bug reports, feature requests, and feedback
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Feedback Templates
 
 How to structure issues for the AIDA repository.

--- a/agents/aida/knowledge/index.md
+++ b/agents/aida/knowledge/index.md
@@ -4,6 +4,9 @@ title: AIDA Expert Knowledge Index
 description: Catalog of knowledge documents for the aida agent
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Knowledge Index
 
 This directory contains reference documentation for the AIDA expert agent.

--- a/agents/aida/knowledge/memento-format.md
+++ b/agents/aida/knowledge/memento-format.md
@@ -4,6 +4,9 @@ title: Memento Format
 description: Structure and best practices for AIDA mementos
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Memento Format
 
 Mementos capture session context for later resumption. A good memento lets you

--- a/agents/aida/knowledge/troubleshooting.md
+++ b/agents/aida/knowledge/troubleshooting.md
@@ -4,6 +4,9 @@ title: AIDA Troubleshooting Guide
 description: Common issues, root causes, and fixes for AIDA
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Troubleshooting Guide
 
 Common AIDA issues and how to resolve them.

--- a/agents/claude-code-expert/claude-code-expert.md
+++ b/agents/claude-code-expert/claude-code-expert.md
@@ -10,6 +10,9 @@ tags:
 model: sonnet
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Claude Code Expert
 
 You are an expert consultant on Claude Code extensions. You receive complete context

--- a/agents/claude-code-expert/knowledge/claude-md-files.md
+++ b/agents/claude-code-expert/knowledge/claude-md-files.md
@@ -6,6 +6,9 @@ description: Understanding Claude Code memory files for persistent context and i
 version: "1.0.0"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # CLAUDE.md Memory Files
 
 CLAUDE.md files are **memory files** - persistent context that Claude loads at

--- a/agents/claude-code-expert/knowledge/design-patterns.md
+++ b/agents/claude-code-expert/knowledge/design-patterns.md
@@ -6,6 +6,9 @@ description: Best practices and common patterns for Claude Code extensions
 version: "1.0.0"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Design Patterns
 
 This document covers best practices and common patterns for designing

--- a/agents/claude-code-expert/knowledge/extension-types.md
+++ b/agents/claude-code-expert/knowledge/extension-types.md
@@ -6,6 +6,9 @@ description: How to choose between agents, skills, plugins, and hooks
 version: "1.0.0"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Extension Types
 
 Claude Code supports multiple extension types, each designed for different

--- a/agents/claude-code-expert/knowledge/framework-design-principles.md
+++ b/agents/claude-code-expert/knowledge/framework-design-principles.md
@@ -6,6 +6,9 @@ description: Architecture, quality standards, and design principles for Claude C
 version: "1.0.0"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Claude Code Extension Design Principles
 
 <!--

--- a/agents/claude-code-expert/knowledge/hooks.md
+++ b/agents/claude-code-expert/knowledge/hooks.md
@@ -6,6 +6,9 @@ description: Understanding hooks for deterministic control in Claude Code
 version: "1.0.0"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Claude Code Hooks
 
 Hooks are **user-defined handlers** that execute at specific points in Claude

--- a/agents/claude-code-expert/knowledge/index.md
+++ b/agents/claude-code-expert/knowledge/index.md
@@ -6,6 +6,9 @@ description: Catalog of knowledge documents for the claude-code-expert agent
 version: "1.0.0"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Knowledge Index
 
 This directory contains reference documentation for the claude-code-expert

--- a/agents/claude-code-expert/knowledge/plugin-development.md
+++ b/agents/claude-code-expert/knowledge/plugin-development.md
@@ -6,6 +6,9 @@ description: Comprehensive guide to creating, structuring, and distributing Clau
 version: "1.0.0"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Plugin Development
 
 Plugins are the unit of distribution for Claude Code extensions. They package

--- a/agents/claude-code-expert/knowledge/settings.md
+++ b/agents/claude-code-expert/knowledge/settings.md
@@ -6,6 +6,9 @@ description: Understanding settings.json configuration for Claude Code behavior
 version: "1.0.0"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Claude Code Settings
 
 Claude Code uses `settings.json` files to configure behavior, permissions, and

--- a/agents/claude-code-expert/knowledge/skills.md
+++ b/agents/claude-code-expert/knowledge/skills.md
@@ -6,6 +6,9 @@ description: Comprehensive reference for creating and configuring skills in Clau
 version: "1.0.0"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Claude Code Skills
 
 Skills are **process definitions with execution capabilities** that extend what

--- a/agents/claude-code-expert/knowledge/subagents.md
+++ b/agents/claude-code-expert/knowledge/subagents.md
@@ -6,6 +6,9 @@ description: Comprehensive reference for creating and configuring subagents in C
 version: "1.0.0"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Claude Code Subagents
 
 Subagents are **specialized AI assistants** that handle specific types of tasks.

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,6 +5,9 @@ description: "Complete API documentation for AIDA Python utilities module"
 audience: developers
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # AIDA Core Plugin - API Reference
 
 ## Complete API documentation for AIDA Python utilities module

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,6 +5,9 @@ description: "System architecture and design decisions for AIDA"
 audience: developers
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # AIDA Core Plugin - Architecture
 
 ## System architecture and design decisions for AIDA

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -5,6 +5,9 @@ description: "For contributors and developers working on AIDA"
 audience: contributors
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # AIDA Core Plugin - Development Guide
 
 ## For contributors and developers working on AIDA

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -5,6 +5,9 @@ description: "Real-world examples of using AIDA skills in different scenarios"
 audience: users
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # AIDA Examples
 
 Real-world examples of using AIDA skills in different scenarios.

--- a/docs/EXTENSION_FRAMEWORK.md
+++ b/docs/EXTENSION_FRAMEWORK.md
@@ -4,6 +4,9 @@ title: Claude Code Extension Design Principles
 description: Architecture and quality standards for Claude Code extensions
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Claude Code Extension Design Principles
 
 This document defines the architecture and quality standards for Claude Code extensions.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -5,6 +5,9 @@ description: "Quick onboarding guide for new AIDA users"
 audience: users
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Getting Started with AIDA
 
 Go from zero to productive in under 10 minutes.

--- a/docs/HOWTO_CREATE_AGENT.md
+++ b/docs/HOWTO_CREATE_AGENT.md
@@ -5,6 +5,9 @@ description: "Step-by-step guide to creating custom Claude Code agents"
 audience: users
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # How to Create an Agent
 
 Agents are expert personas that Claude can become. Use them when you need specialized

--- a/docs/HOWTO_CREATE_SKILL.md
+++ b/docs/HOWTO_CREATE_SKILL.md
@@ -5,6 +5,9 @@ description: "Step-by-step guide to creating custom Claude Code skills"
 audience: users
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # How to Create a Skill
 
 Skills provide execution capabilities - scripts, templates, and reference materials that

--- a/docs/HOWTO_HOOKS.md
+++ b/docs/HOWTO_HOOKS.md
@@ -5,6 +5,9 @@ description: "Step-by-step guide to using Claude Code hooks for automation"
 audience: users
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # How to Use Hooks
 
 Hooks are shell commands that run automatically at specific points in Claude Code's

--- a/docs/HOWTO_MEMENTO.md
+++ b/docs/HOWTO_MEMENTO.md
@@ -5,6 +5,9 @@ description: "Step-by-step guide to saving and restoring session context"
 audience: users
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # How to Use Mementos
 
 Mementos are context snapshots that help you resume work after `/clear`, `/compact`,

--- a/docs/USER_GUIDE_CONFIGURE.md
+++ b/docs/USER_GUIDE_CONFIGURE.md
@@ -4,6 +4,9 @@ title: "Configuration Guide"
 audience: users
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # AIDA Configuration Guide
 
 Complete walkthrough for configuring AIDA for your projects

--- a/docs/USER_GUIDE_INSTALL.md
+++ b/docs/USER_GUIDE_INSTALL.md
@@ -4,6 +4,9 @@ title: "Installation Guide"
 audience: users
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # AIDA Installation Guide
 
 Complete walkthrough for installing and setting up AIDA Core Plugin

--- a/docs/architecture/adr/001-skills-first-architecture.md
+++ b/docs/architecture/adr/001-skills-first-architecture.md
@@ -7,6 +7,9 @@ deciders:
   - "@oakensoul"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # ADR-001: Skills-First Architecture
 
 ## Context

--- a/docs/architecture/adr/002-python-for-scripts.md
+++ b/docs/architecture/adr/002-python-for-scripts.md
@@ -7,6 +7,9 @@ deciders:
   - "@oakensoul"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # ADR-002: Python for Installation Scripts
 
 ## Context

--- a/docs/architecture/adr/003-jinja2-templates.md
+++ b/docs/architecture/adr/003-jinja2-templates.md
@@ -7,6 +7,9 @@ deciders:
   - "@oakensoul"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # ADR-003: Jinja2 for Template Rendering
 
 ## Context

--- a/docs/architecture/adr/004-yaml-questionnaires.md
+++ b/docs/architecture/adr/004-yaml-questionnaires.md
@@ -7,6 +7,9 @@ deciders:
   - "@oakensoul"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # ADR-004: YAML for Questionnaire Definitions
 
 ## Context

--- a/docs/architecture/adr/005-local-first-storage.md
+++ b/docs/architecture/adr/005-local-first-storage.md
@@ -7,6 +7,9 @@ deciders:
   - "@oakensoul"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # ADR-005: Local-First Storage
 
 ## Context

--- a/docs/architecture/adr/006-gh-cli-feedback.md
+++ b/docs/architecture/adr/006-gh-cli-feedback.md
@@ -7,6 +7,9 @@ deciders:
   - "@oakensoul"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # ADR-006: GitHub CLI for Feedback System
 
 ## Context

--- a/docs/architecture/adr/007-yaml-config-single-source-truth.md
+++ b/docs/architecture/adr/007-yaml-config-single-source-truth.md
@@ -8,6 +8,9 @@ deciders:
 supersedes: "Complex conditional questionnaire logic"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # ADR-007: YAML Configuration as Single Source of Truth
 
 ## Context

--- a/docs/architecture/adr/008-marketplace-centric-distribution.md
+++ b/docs/architecture/adr/008-marketplace-centric-distribution.md
@@ -7,6 +7,9 @@ deciders:
   - "@oakensoul"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # ADR-008: Marketplace-Centric Distribution
 
 ## Context

--- a/docs/architecture/adr/009-input-validation-path-security.md
+++ b/docs/architecture/adr/009-input-validation-path-security.md
@@ -7,6 +7,9 @@ deciders:
   - "@oakensoul"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # ADR-009: Input Validation and Path Security
 
 ## Context

--- a/docs/architecture/adr/010-two-phase-api-pattern.md
+++ b/docs/architecture/adr/010-two-phase-api-pattern.md
@@ -7,6 +7,9 @@ deciders:
   - "@oakensoul"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # ADR-010: Two-Phase API Pattern for LLM Integration
 
 ## Context

--- a/docs/architecture/adr/011-user-level-memento-storage.md
+++ b/docs/architecture/adr/011-user-level-memento-storage.md
@@ -7,6 +7,9 @@ deciders:
   - "@oakensoul"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # ADR-011: User-Level Memento Storage with Project Namespacing
 
 ## Context

--- a/docs/architecture/c4/component-diagram.md
+++ b/docs/architecture/c4/component-diagram.md
@@ -4,6 +4,9 @@ title: "C4 Component Diagram - AIDA Core Plugin"
 diagram-type: c4-component
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # C4 Component Diagram - AIDA Core Plugin
 
 **Component Level**: Detailed view of Python scripts and utilities module

--- a/docs/architecture/c4/container-diagram.md
+++ b/docs/architecture/c4/container-diagram.md
@@ -4,6 +4,9 @@ title: "C4 Container Diagram - AIDA Core Plugin"
 diagram-type: c4-container
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # C4 Container Diagram - AIDA Core Plugin
 
 **Container Level**: Internal structure of AIDA and its major components

--- a/docs/architecture/c4/context-diagram.md
+++ b/docs/architecture/c4/context-diagram.md
@@ -4,6 +4,9 @@ title: "C4 Context Diagram - AIDA Core Plugin"
 diagram-type: c4-context
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # C4 Context Diagram - AIDA Core Plugin
 
 **System Context**: How AIDA fits into the larger ecosystem

--- a/docs/superpowers/plans/2026-04-16-expert-registry.md
+++ b/docs/superpowers/plans/2026-04-16-expert-registry.md
@@ -3,6 +3,9 @@ type: documentation
 title: "Expert Registry Implementation Plan"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Expert Registry Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use

--- a/docs/superpowers/specs/2026-04-16-expert-registry-design.md
+++ b/docs/superpowers/specs/2026-04-16-expert-registry-design.md
@@ -3,6 +3,9 @@ type: documentation
 title: "Expert Registry Design Spec"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Expert Registry Design Spec
 
 **Date:** 2026-04-16

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 # AIDA Core Plugin Development Dependencies
 #
 # Installed into ~/.aida/venv/ alongside runtime deps.
@@ -10,3 +13,4 @@ pytest-cov>=4.0
 # Linting
 ruff>=0.4.0
 yamllint>=1.35
+reuse>=4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 # AIDA Core Plugin Dependencies
 #
 # This file lists all Python dependencies required for AIDA core functionality.

--- a/scripts/add_spdx_headers.py
+++ b/scripts/add_spdx_headers.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+"""Add SPDX-FileCopyrightText/SPDX-License-Identifier headers to source files.
+
+Idempotent: files that already contain ``SPDX-License-Identifier`` are skipped.
+Operates on tracked files only (``git ls-files``) and respects a built-in
+skip list for fixtures, JSON, lockfiles, generated artifacts, and
+scaffolding templates (those are covered by ``.reuse/dep5`` instead).
+
+Run from repo root::
+
+    python3 scripts/add_spdx_headers.py        # dry-run; prints planned changes
+    python3 scripts/add_spdx_headers.py --apply # actually write changes
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+COPYRIGHT_HOLDER = "The AIDA Core Authors"
+LICENSE_ID = "MPL-2.0"
+YEAR = "2026"
+
+# Substrings that indicate a header is already present.
+SENTINEL = "SPDX-License-Identifier"
+
+# fnmatch patterns evaluated against POSIX-style relative paths.
+# Files matching any of these are NOT touched. dep5 covers the licensing.
+SKIP_PATTERNS: tuple[str, ...] = (
+    # Skip list documented in CONTRIBUTING.md#licensing
+    "LICENSE",
+    "AUTHORS",
+    ".gitignore",
+    "**/.gitignore",
+    "**/.gitkeep",
+    # JSON has no comment syntax
+    "*.json",
+    "**/*.json",
+    "*.json.template",
+    "**/*.json.template",
+    # Test fixtures (sample-project trees simulate user repos)
+    "tests/fixtures/**",
+    "tests/integration/*/sample-project/**",
+    # Scaffolding templates — covered by dep5 so renderers control output
+    "**/*.jinja2",
+    "**/*.template",
+)
+
+
+@dataclass(frozen=True)
+class CommentStyle:
+    line_prefix: str          # what each header line starts with
+    line_suffix: str = ""     # what each header line ends with
+    blank_line: str = ""      # blank line representation (with suffix if needed)
+
+
+HASH = CommentStyle(line_prefix="# ")
+HTML = CommentStyle(line_prefix="<!-- ", line_suffix=" -->")
+
+
+def comment_style_for(path: Path) -> CommentStyle | None:
+    """Return the comment style for a path, or None if it should be skipped.
+
+    Caller must already have applied SKIP_PATTERNS.
+    """
+    name = path.name
+    suffix = path.suffix.lower()
+
+    if suffix == ".md":
+        return HTML
+    if suffix in {".py", ".sh", ".yml", ".yaml", ".toml"}:
+        return HASH
+    if suffix == ".txt" and name.startswith("requirements"):
+        return HASH
+    if name in {"Makefile", "Dockerfile"} or name.startswith("Makefile."):
+        return HASH
+    if path.as_posix().endswith(".github/CODEOWNERS"):
+        return HASH
+    return None
+
+
+def should_skip(rel_path: str) -> bool:
+    return any(fnmatch.fnmatch(rel_path, pat) for pat in SKIP_PATTERNS)
+
+
+def render_header(style: CommentStyle) -> list[str]:
+    # REUSE-IgnoreStart
+    return [
+        f"{style.line_prefix}SPDX-FileCopyrightText: {YEAR} {COPYRIGHT_HOLDER}{style.line_suffix}",
+        f"{style.line_prefix}SPDX-License-Identifier: {LICENSE_ID}{style.line_suffix}",
+    ]
+    # REUSE-IgnoreEnd
+
+
+def find_insertion_point(lines: list[str], style: CommentStyle) -> int:
+    """Return the line index at which the header should be inserted.
+
+    For HASH style, skip a leading shebang. For HTML style (markdown), skip a
+    leading YAML frontmatter block delimited by ``---`` on the first line.
+    """
+    if not lines:
+        return 0
+
+    if style is HASH and lines[0].startswith("#!"):
+        return 1
+
+    if style is HTML and lines[0].rstrip() == "---":
+        # Find the closing --- of frontmatter
+        for idx in range(1, len(lines)):
+            if lines[idx].rstrip() == "---":
+                return idx + 1
+        # Malformed frontmatter (no close): bail to top
+        return 0
+
+    return 0
+
+
+def insert_header(lines: list[str], style: CommentStyle) -> list[str]:
+    """Return new file lines with the SPDX header inserted at the right spot."""
+    insertion = find_insertion_point(lines, style)
+    header = render_header(style)
+
+    # Build the inserted block: blank line if needed before header, then
+    # header lines, then blank line before the rest of the content.
+    block: list[str] = []
+
+    needs_leading_blank = (
+        insertion > 0 and lines[insertion - 1].strip() != ""
+    )
+    if needs_leading_blank:
+        block.append("")
+
+    block.extend(header)
+
+    if insertion < len(lines) and lines[insertion].strip() != "":
+        block.append("")
+
+    return lines[:insertion] + block + lines[insertion:]
+
+
+def already_has_header(text: str) -> bool:
+    return SENTINEL in text
+
+
+def tracked_files() -> list[str]:
+    out = subprocess.check_output(["git", "ls-files"], text=True)
+    return [line for line in out.splitlines() if line]
+
+
+def process(repo_root: Path, apply: bool) -> int:
+    changed: list[str] = []
+    skipped_no_style: list[str] = []
+    skipped_pattern: list[str] = []
+    already: list[str] = []
+
+    for rel in tracked_files():
+        if should_skip(rel):
+            skipped_pattern.append(rel)
+            continue
+        path = repo_root / rel
+        if not path.is_file():
+            continue
+        style = comment_style_for(path)
+        if style is None:
+            skipped_no_style.append(rel)
+            continue
+        text = path.read_text(encoding="utf-8")
+        if already_has_header(text):
+            already.append(rel)
+            continue
+
+        # Preserve final newline status by working with split lines.
+        ends_with_newline = text.endswith("\n")
+        lines = text.split("\n")
+        if ends_with_newline:
+            # split leaves a trailing empty string for the final newline; drop it
+            lines = lines[:-1]
+
+        new_lines = insert_header(lines, style)
+        new_text = "\n".join(new_lines) + ("\n" if ends_with_newline else "")
+
+        if apply:
+            path.write_text(new_text, encoding="utf-8")
+        changed.append(rel)
+
+    print(f"Files that would be updated: {len(changed)}")
+    for rel in changed:
+        print(f"  + {rel}")
+    print(f"Already had headers: {len(already)}")
+    print(f"Skipped (no comment style for type): {len(skipped_no_style)}")
+    print(f"Skipped (matches skip pattern): {len(skipped_pattern)}")
+    if not apply:
+        print("\nDry run — re-run with --apply to write changes.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true",
+                        help="actually write changes (default: dry run)")
+    args = parser.parse_args()
+    repo_root = Path(__file__).resolve().parent.parent
+    return process(repo_root, apply=args.apply)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/add_spdx_headers.py
+++ b/scripts/add_spdx_headers.py
@@ -17,11 +17,10 @@ Run from repo root::
 from __future__ import annotations
 
 import argparse
-import fnmatch
 import subprocess
 import sys
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 COPYRIGHT_HOLDER = "The AIDA Core Authors"
 LICENSE_ID = "MPL-2.0"
@@ -30,26 +29,23 @@ YEAR = "2026"
 # Substrings that indicate a header is already present.
 SENTINEL = "SPDX-License-Identifier"
 
-# fnmatch patterns evaluated against POSIX-style relative paths.
-# Files matching any of these are NOT touched. dep5 covers the licensing.
-SKIP_PATTERNS: tuple[str, ...] = (
-    # Skip list documented in CONTRIBUTING.md#licensing
+# Skip rules per CONTRIBUTING.md#licensing. We match by explicit
+# basename / suffix / path-prefix checks rather than glob patterns
+# because fnmatch's `*` matches `/` (so `*.json` and `**/*.json`
+# behave identically) and PurePath.match only learned proper `**`
+# semantics in Python 3.13. Explicit logic is cheaper than a custom
+# globber and clearer than relying on either quirk.
+_SKIP_BASENAMES: frozenset[str] = frozenset({
     "LICENSE",
     "AUTHORS",
     ".gitignore",
-    "**/.gitignore",
-    "**/.gitkeep",
-    # JSON has no comment syntax
-    "*.json",
-    "**/*.json",
-    "*.json.template",
-    "**/*.json.template",
-    # Test fixtures (sample-project trees simulate user repos)
-    "tests/fixtures/**",
-    "tests/integration/*/sample-project/**",
-    # Scaffolding templates — covered by dep5 so renderers control output
-    "**/*.jinja2",
-    "**/*.template",
+    ".gitkeep",
+})
+_SKIP_SUFFIXES: tuple[str, ...] = (
+    ".json",            # No comment syntax
+    ".json.template",   # JSON template — same constraint
+    ".jinja2",          # Scaffolding templates; REUSE.toml covers
+    ".template",        # Scaffolding templates; REUSE.toml covers
 )
 
 
@@ -67,7 +63,8 @@ HTML = CommentStyle(line_prefix="<!-- ", line_suffix=" -->")
 def comment_style_for(path: Path) -> CommentStyle | None:
     """Return the comment style for a path, or None if it should be skipped.
 
-    Caller must already have applied SKIP_PATTERNS.
+    Caller must already have applied ``should_skip`` to honor the
+    repo's skip list.
     """
     name = path.name
     suffix = path.suffix.lower()
@@ -86,7 +83,36 @@ def comment_style_for(path: Path) -> CommentStyle | None:
 
 
 def should_skip(rel_path: str) -> bool:
-    return any(fnmatch.fnmatch(rel_path, pat) for pat in SKIP_PATTERNS)
+    """Return True if this tracked file should not get an inline SPDX header.
+
+    REUSE.toml is responsible for licensing the skipped paths.
+    """
+    p = PurePosixPath(rel_path)
+    name = p.name
+
+    if name in _SKIP_BASENAMES:
+        return True
+    if any(name.endswith(suffix) for suffix in _SKIP_SUFFIXES):
+        return True
+
+    parts = p.parts
+    # LICENSES/<id>.txt — REUSE-required canonical license texts
+    if len(parts) >= 1 and parts[0] == "LICENSES":
+        return True
+    # tests/fixtures/** — fixture trees
+    if len(parts) >= 2 and parts[0] == "tests" and parts[1] == "fixtures":
+        return True
+    # tests/integration/<lang>/sample-project/** — fixtures simulating
+    # downstream user projects
+    if (
+        len(parts) >= 4
+        and parts[0] == "tests"
+        and parts[1] == "integration"
+        and parts[3] == "sample-project"
+    ):
+        return True
+
+    return False
 
 
 def render_header(style: CommentStyle) -> list[str]:

--- a/scripts/dev-mode.sh
+++ b/scripts/dev-mode.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 # Switch Claude Code to use local development version
 
 PLUGIN_PATH="$(cd "$(dirname "$0")/.." && pwd)"

--- a/scripts/dev_mode.py
+++ b/scripts/dev_mode.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Developer mode management for AIDA Core Plugin.
 
 This script manages the local plugin installation for development,

--- a/scripts/shared/__init__.py
+++ b/scripts/shared/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 # Shared utilities package for AIDA Core Plugin scripts

--- a/scripts/shared/bootstrap.py
+++ b/scripts/shared/bootstrap.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """AIDA environment bootstrap.
 
 Ensures Python dependencies are available in an AIDA-managed virtual

--- a/scripts/shared/extension_utils.py
+++ b/scripts/shared/extension_utils.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Shared extension utilities for manager skills.
 
 Provides parameterized functions that agent-manager, skill-manager,

--- a/scripts/shared/utils.py
+++ b/scripts/shared/utils.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Shared utilities for AIDA Core Plugin scripts.
 
 Common functions used across multiple manager skills including

--- a/scripts/validate_frontmatter.py
+++ b/scripts/validate_frontmatter.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Validate YAML frontmatter in markdown files against a JSON schema.
 
 All markdown files must have frontmatter with a 'type' field that determines

--- a/skills/agent-manager/SKILL.md
+++ b/skills/agent-manager/SKILL.md
@@ -13,6 +13,9 @@ tags:
   - agents
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Agent Manager
 
 Focused management interface for Claude Code agent (subagent)

--- a/skills/agent-manager/references/create-workflow.md
+++ b/skills/agent-manager/references/create-workflow.md
@@ -6,6 +6,9 @@ description: >-
   (subagent) definitions
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Agent Create Workflow
 
 This document describes the workflow for creating new

--- a/skills/agent-manager/references/schemas.md
+++ b/skills/agent-manager/references/schemas.md
@@ -6,6 +6,9 @@ description: >-
   agent definitions
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Agent Frontmatter Schema
 
 This document provides a complete reference for YAML

--- a/skills/agent-manager/references/validate-workflow.md
+++ b/skills/agent-manager/references/validate-workflow.md
@@ -6,6 +6,9 @@ description: >-
   against schema rules
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Agent Validate Workflow
 
 This document describes the workflow for validating

--- a/skills/agent-manager/scripts/_paths.py
+++ b/skills/agent-manager/scripts/_paths.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Path configuration for agent-manager scripts.
 
 Sets up sys.path so that shared utilities can be imported

--- a/skills/agent-manager/scripts/manage.py
+++ b/skills/agent-manager/scripts/manage.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Agent Manager Script - Two-Phase API
 
 Entry point for managing Claude Code agent (subagent) definitions.

--- a/skills/agent-manager/scripts/operations/__init__.py
+++ b/skills/agent-manager/scripts/operations/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 # Operations package for Agent Manager

--- a/skills/agent-manager/scripts/operations/extensions.py
+++ b/skills/agent-manager/scripts/operations/extensions.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Agent management operations for Claude Code.
 
 Handles create, validate, version, and list operations

--- a/skills/agent-manager/scripts/operations/utils.py
+++ b/skills/agent-manager/scripts/operations/utils.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Shared utilities for agent-manager operations.
 
 Re-exports from scripts/shared/utils.py so that operation

--- a/skills/aida/SKILL.md
+++ b/skills/aida/SKILL.md
@@ -13,6 +13,9 @@ allowed-tools: "*"
 argument-hint: "[command] [subcommand] [options]"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # AIDA Dispatch
 
 Routes `/aida` commands to appropriate action handlers, managing AIDA's configuration,

--- a/skills/aida/references/config-driven-approach.md
+++ b/skills/aida/references/config-driven-approach.md
@@ -4,6 +4,9 @@ title: "Config-Driven Configuration Approach"
 description: "Detect facts, save to config file with nulls, ask about gaps, and update"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Config-Driven Configuration Approach
 
 ## Overview

--- a/skills/aida/references/config.md
+++ b/skills/aida/references/config.md
@@ -4,6 +4,9 @@ title: "Config Action"
 description: "Handles /aida config - Smart configuration flow with progressive disclosure"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Config Action
 
 Handles `/aida config` - Smart configuration flow with progressive disclosure.

--- a/skills/aida/references/diagnostics.md
+++ b/skills/aida/references/diagnostics.md
@@ -4,6 +4,9 @@ title: "Diagnostics Actions"
 description: "Handles /aida status, /aida doctor, and /aida upgrade commands"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Diagnostics Actions
 
 Handles `/aida status`, `/aida doctor`, and `/aida upgrade` commands.

--- a/skills/aida/references/feedback.md
+++ b/skills/aida/references/feedback.md
@@ -4,6 +4,9 @@ title: "Feedback Actions"
 description: "Handles /aida feedback, /aida bug, and /aida feature-request commands"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Feedback Actions
 
 Handles `/aida feedback`, `/aida bug`, and `/aida feature-request` commands.

--- a/skills/aida/references/project-facts.md
+++ b/skills/aida/references/project-facts.md
@@ -4,6 +4,9 @@ title: "Project Configuration Facts"
 description: "All facts AIDA needs for project configuration, categorized by detection method"
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Project Configuration Facts
 
 This document defines all facts AIDA needs for project configuration, categorized by detection method.

--- a/skills/aida/scripts/_paths.py
+++ b/skills/aida/scripts/_paths.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Path configuration for aida scripts.
 
 Sets up sys.path so that shared utilities can be imported

--- a/skills/aida/scripts/configure.py
+++ b/skills/aida/scripts/configure.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """AIDA Project Configuration Script - Two-Phase API
 
 This script provides a two-phase project configuration API designed for integration

--- a/skills/aida/scripts/detect.py
+++ b/skills/aida/scripts/detect.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """AIDA Installation Detection Script
 
 Detects AIDA installation state and returns structured JSON output.

--- a/skills/aida/scripts/doctor.py
+++ b/skills/aida/scripts/doctor.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """AIDA Doctor Script
 
 Run comprehensive health check and diagnostics.

--- a/skills/aida/scripts/feedback.py
+++ b/skills/aida/scripts/feedback.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """AIDA Feedback System
 
 This script handles user feedback submission to GitHub:

--- a/skills/aida/scripts/install.py
+++ b/skills/aida/scripts/install.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """AIDA Global Installation Script - Fact-Based Two-Phase API
 
 This script provides a two-phase fact-based installation API for global

--- a/skills/aida/scripts/status.py
+++ b/skills/aida/scripts/status.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """AIDA Status Script
 
 Display current AIDA configuration state.

--- a/skills/aida/scripts/upgrade.py
+++ b/skills/aida/scripts/upgrade.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """AIDA Upgrade Script
 
 Check for and upgrade to latest AIDA version.

--- a/skills/aida/scripts/utils/__init__.py
+++ b/skills/aida/scripts/utils/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """AIDA Utilities - Foundation module for AIDA installation scripts.
 
 This package provides common utilities for version checking, path resolution,

--- a/skills/aida/scripts/utils/agents.py
+++ b/skills/aida/scripts/utils/agents.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Agent discovery and CLAUDE.md routing generation.
 
 Scans installed agents from project, user, and plugin sources,

--- a/skills/aida/scripts/utils/errors.py
+++ b/skills/aida/scripts/utils/errors.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Custom exception classes for AIDA.
 
 This module provides AIDA-specific exception classes for consistent error

--- a/skills/aida/scripts/utils/files.py
+++ b/skills/aida/scripts/utils/files.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """File operation utilities for AIDA.
 
 This module provides safe file operations with proper error handling,

--- a/skills/aida/scripts/utils/inference.py
+++ b/skills/aida/scripts/utils/inference.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Project context inference utilities for AIDA.
 
 This module provides functionality to analyze project files and infer

--- a/skills/aida/scripts/utils/json_utils.py
+++ b/skills/aida/scripts/utils/json_utils.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """JSON utilities for AIDA with security validation.
 
 This module provides safe JSON operations with size and depth validation

--- a/skills/aida/scripts/utils/paths.py
+++ b/skills/aida/scripts/utils/paths.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Path resolution utilities for AIDA.
 
 This module provides cross-platform path resolution for Claude Code and AIDA

--- a/skills/aida/scripts/utils/plugins.py
+++ b/skills/aida/scripts/utils/plugins.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Plugin discovery and configuration utilities.
 
 Scans installed plugins for configuration sections and generates

--- a/skills/aida/scripts/utils/project_context.py
+++ b/skills/aida/scripts/utils/project_context.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Split/merge helpers for the project-context YAML files.
 
 The project context lives in two files under `.claude/`:

--- a/skills/aida/scripts/utils/questionnaire.py
+++ b/skills/aida/scripts/utils/questionnaire.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Interactive questionnaire system for AIDA.
 
 This module provides functionality to load questionnaires from YAML files

--- a/skills/aida/scripts/utils/template_renderer.py
+++ b/skills/aida/scripts/utils/template_renderer.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Template rendering utilities using Jinja2.
 
 This module provides template rendering functionality for AIDA skill generation,

--- a/skills/aida/scripts/utils/version.py
+++ b/skills/aida/scripts/utils/version.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Python version checking utilities for AIDA.
 
 This module provides functions to verify that the Python version meets

--- a/skills/aida/templates/questionnaires/configure.yml
+++ b/skills/aida/templates/questionnaires/configure.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 ---
 # AIDA Project Configuration Questionnaire
 #

--- a/skills/aida/templates/questionnaires/install.yml
+++ b/skills/aida/templates/questionnaires/install.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 ---
 # AIDA Installation Questionnaire
 #

--- a/skills/aida/templates/questionnaires/project-context/SKILL.md
+++ b/skills/aida/templates/questionnaires/project-context/SKILL.md
@@ -11,6 +11,9 @@ tags:
   - metadata
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Project Context Skill
 
 This skill provides comprehensive context about the current project, including its state, architecture, recent decisions,

--- a/skills/aida/templates/questionnaires/project-documentation/SKILL.md
+++ b/skills/aida/templates/questionnaires/project-documentation/SKILL.md
@@ -11,6 +11,9 @@ tags:
   - reference
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Project Documentation Skill
 
 This skill provides an organized index of project documentation, making it easy to find relevant docs without

--- a/skills/claude-md-manager/SKILL.md
+++ b/skills/claude-md-manager/SKILL.md
@@ -13,6 +13,9 @@ tags:
   - claude-md
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # CLAUDE.md Manager
 
 Manages CLAUDE.md configuration files that provide

--- a/skills/claude-md-manager/references/best-practices.md
+++ b/skills/claude-md-manager/references/best-practices.md
@@ -7,6 +7,9 @@ description: >-
 version: 0.1.0
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # CLAUDE.md Best Practices
 
 This guide provides best practices for creating effective

--- a/skills/claude-md-manager/references/claude-md-workflow.md
+++ b/skills/claude-md-manager/references/claude-md-workflow.md
@@ -8,6 +8,9 @@ description: >-
 version: 0.1.0
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Claude MD Workflow
 
 This document describes the workflow for managing

--- a/skills/claude-md-manager/scripts/_paths.py
+++ b/skills/claude-md-manager/scripts/_paths.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Path utilities for claude-md-manager scripts.
 
 Sets up paths so that operations can import from scripts/shared/.

--- a/skills/claude-md-manager/scripts/manage.py
+++ b/skills/claude-md-manager/scripts/manage.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """CLAUDE.md Manager - Two-Phase API Entry Point.
 
 Manages CLAUDE.md configuration files across project, user, and

--- a/skills/claude-md-manager/scripts/operations/__init__.py
+++ b/skills/claude-md-manager/scripts/operations/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """CLAUDE.md management operations package."""

--- a/skills/claude-md-manager/scripts/operations/claude_md.py
+++ b/skills/claude-md-manager/scripts/operations/claude_md.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """CLAUDE.md management operations.
 
 Handles create, optimize, validate, and list operations

--- a/skills/claude-md-manager/scripts/operations/utils.py
+++ b/skills/claude-md-manager/scripts/operations/utils.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Shared utilities for CLAUDE.md management operations.
 
 Re-exports from scripts/shared/utils.py so that operation modules

--- a/skills/expert-registry/SKILL.md
+++ b/skills/expert-registry/SKILL.md
@@ -16,6 +16,9 @@ tags:
   - panels
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Expert Registry
 
 Manages expert agent activation and named panel composition.

--- a/skills/expert-registry/references/schemas.md
+++ b/skills/expert-registry/references/schemas.md
@@ -6,6 +6,9 @@ description: >-
   composition in global and project config files.
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Expert Registry Schemas
 
 Reference for the data shapes used by the expert registry:

--- a/skills/expert-registry/scripts/_paths.py
+++ b/skills/expert-registry/scripts/_paths.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Path setup for expert-registry scripts."""
 
 import sys

--- a/skills/expert-registry/scripts/expert_ops/__init__.py
+++ b/skills/expert-registry/scripts/expert_ops/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Expert registry operations package."""

--- a/skills/expert-registry/scripts/expert_ops/panels.py
+++ b/skills/expert-registry/scripts/expert_ops/panels.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Panel resolution for the expert registry."""
 from __future__ import annotations
 

--- a/skills/expert-registry/scripts/expert_ops/registry.py
+++ b/skills/expert-registry/scripts/expert_ops/registry.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Expert registry config I/O operations."""
 
 from __future__ import annotations

--- a/skills/expert-registry/scripts/manage.py
+++ b/skills/expert-registry/scripts/manage.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Expert Registry Script - Two-Phase API
 
 Entry point for managing expert activation and panel configuration.

--- a/skills/expert-registry/templates/questionnaires/configure.yml
+++ b/skills/expert-registry/templates/questionnaires/configure.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 ---
 # configure.yml
 # Question template for the expert-registry configure flow.

--- a/skills/hook-manager/SKILL.md
+++ b/skills/hook-manager/SKILL.md
@@ -13,6 +13,9 @@ tags:
   - configuration
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Hook Manager
 
 Manages Claude Code lifecycle hook configurations.

--- a/skills/hook-manager/references/hooks-reference.md
+++ b/skills/hook-manager/references/hooks-reference.md
@@ -9,6 +9,9 @@ description: >-
 version: 0.1.0
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Hooks Reference
 
 Claude Code hooks are shell commands that execute at

--- a/skills/hook-manager/scripts/_paths.py
+++ b/skills/hook-manager/scripts/_paths.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Path utilities for hook-manager scripts.
 
 Sets up sys.path so that shared utilities can be imported

--- a/skills/hook-manager/scripts/manage.py
+++ b/skills/hook-manager/scripts/manage.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Hook Manager - Two-Phase API entry point.
 
 Manages Claude Code hook configurations in settings.json

--- a/skills/hook-manager/scripts/operations/__init__.py
+++ b/skills/hook-manager/scripts/operations/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Hook manager operations package."""

--- a/skills/hook-manager/scripts/operations/hooks.py
+++ b/skills/hook-manager/scripts/operations/hooks.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Hook operations for Claude Code hook management.
 
 Handles lifecycle hooks configured in settings.json files:

--- a/skills/memento/SKILL.md
+++ b/skills/memento/SKILL.md
@@ -9,6 +9,9 @@ tags:
   - context
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Memento
 
 Mementos are persistent context snapshots that help Claude resume work after

--- a/skills/memento/references/memento-workflow.md
+++ b/skills/memento/references/memento-workflow.md
@@ -4,6 +4,9 @@ title: Memento Workflow
 description: Step-by-step process for creating and managing mementos
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Memento Workflow
 
 This document describes the workflow for creating, updating, and managing

--- a/skills/memento/scripts/_paths.py
+++ b/skills/memento/scripts/_paths.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Path configuration for memento scripts.
 
 Sets up sys.path so that shared utilities can be imported

--- a/skills/memento/scripts/memento.py
+++ b/skills/memento/scripts/memento.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Memento Management Script - Two-Phase API
 
 This script provides a two-phase API for managing mementos - persistent context

--- a/skills/permissions/SKILL.md
+++ b/skills/permissions/SKILL.md
@@ -12,6 +12,9 @@ tags:
   - configuration
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Permissions Skill
 
 Manages Claude Code permissions interactively by scanning installed

--- a/skills/permissions/references/permissions-workflow.md
+++ b/skills/permissions/references/permissions-workflow.md
@@ -4,6 +4,9 @@ title: Permissions Workflow
 description: Step-by-step guide for interactive permission management
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Permissions Workflow
 
 End-to-end workflow for managing Claude Code permissions through

--- a/skills/permissions/references/presets.md
+++ b/skills/permissions/references/presets.md
@@ -4,6 +4,9 @@ title: Permission Presets
 description: Pre-configured permission profiles for common use cases
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Permission Presets
 
 Presets provide quick permission configuration for common

--- a/skills/permissions/references/rule-syntax.md
+++ b/skills/permissions/references/rule-syntax.md
@@ -4,6 +4,9 @@ title: Rule Syntax
 description: Permission rule format and wildcard documentation
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Permission Rule Syntax
 
 Claude Code permissions use a `Tool(command:args)` format to

--- a/skills/permissions/scripts/_paths.py
+++ b/skills/permissions/scripts/_paths.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Path configuration for permissions scripts.
 
 Sets up sys.path so that shared utilities can be imported

--- a/skills/permissions/scripts/aggregator.py
+++ b/skills/permissions/scripts/aggregator.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Permission aggregator.
 
 Deduplicates, categorizes, and detects conflicts across plugin

--- a/skills/permissions/scripts/permissions.py
+++ b/skills/permissions/scripts/permissions.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Permissions management.
 
 Two-phase API for interactive permission setup. Scans installed

--- a/skills/permissions/scripts/rule_validation.py
+++ b/skills/permissions/scripts/rule_validation.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Shared permission rule validation.
 
 Centralizes rule syntax validation used by both scanner.py

--- a/skills/permissions/scripts/scanner.py
+++ b/skills/permissions/scripts/scanner.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Plugin permission scanner.
 
 Discovers recommended permissions from installed plugins by

--- a/skills/permissions/scripts/settings_manager.py
+++ b/skills/permissions/scripts/settings_manager.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Settings.json manager.
 
 Reads and writes Claude Code permission settings across user,

--- a/skills/plugin-manager/SKILL.md
+++ b/skills/plugin-manager/SKILL.md
@@ -14,6 +14,9 @@ tags:
   - scaffolding
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Plugin Manager
 
 Unified plugin management skill that combines two capabilities:

--- a/skills/plugin-manager/references/scaffolding-workflow.md
+++ b/skills/plugin-manager/references/scaffolding-workflow.md
@@ -3,6 +3,9 @@ type: reference
 title: Plugin Scaffolding Workflow
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Plugin Scaffolding Workflow
 
 Detailed reference for the plugin-manager scaffolding process.

--- a/skills/plugin-manager/references/schemas.md
+++ b/skills/plugin-manager/references/schemas.md
@@ -6,6 +6,9 @@ description: >-
   metadata files
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Plugin Schemas
 
 This document provides a complete reference for the JSON

--- a/skills/plugin-manager/references/update-workflow.md
+++ b/skills/plugin-manager/references/update-workflow.md
@@ -7,6 +7,9 @@ description: >-
   tracking, and backup recovery
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Plugin Update Workflow
 
 Detailed reference for the plugin-manager update process.

--- a/skills/plugin-manager/references/validate-workflow.md
+++ b/skills/plugin-manager/references/validate-workflow.md
@@ -6,6 +6,9 @@ description: >-
   JSON schema rules
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Plugin Validation Workflow
 
 This document describes the workflow for validating

--- a/skills/plugin-manager/scripts/_paths.py
+++ b/skills/plugin-manager/scripts/_paths.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Path setup for plugin-manager scripts.
 
 Configures sys.path so that operations/ and scripts/shared/

--- a/skills/plugin-manager/scripts/manage.py
+++ b/skills/plugin-manager/scripts/manage.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Plugin Manager Script - Unified Two-Phase API
 
 Entry point for all plugin operations:

--- a/skills/plugin-manager/scripts/operations/__init__.py
+++ b/skills/plugin-manager/scripts/operations/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 # Operations package for plugin-manager skill

--- a/skills/plugin-manager/scripts/operations/constants.py
+++ b/skills/plugin-manager/scripts/operations/constants.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Shared constants for plugin-manager operations."""
 
 GENERATOR_VERSION = "0.9.0"

--- a/skills/plugin-manager/scripts/operations/extensions.py
+++ b/skills/plugin-manager/scripts/operations/extensions.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Plugin extension management operations.
 
 Handles create, validate, version, and list operations for

--- a/skills/plugin-manager/scripts/operations/scaffold.py
+++ b/skills/plugin-manager/scripts/operations/scaffold.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Plugin Scaffolding Operations - Two-Phase API
 
 Scaffolds a complete Claude Code plugin project as a new local git

--- a/skills/plugin-manager/scripts/operations/scaffold_ops/__init__.py
+++ b/skills/plugin-manager/scripts/operations/scaffold_ops/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 # Operations package for plugin-manager scaffolding

--- a/skills/plugin-manager/scripts/operations/scaffold_ops/context.py
+++ b/skills/plugin-manager/scripts/operations/scaffold_ops/context.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Context gathering operations for plugin scaffolding.
 
 Functions for inferring git configuration, validating target

--- a/skills/plugin-manager/scripts/operations/scaffold_ops/generators.py
+++ b/skills/plugin-manager/scripts/operations/scaffold_ops/generators.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Generator operations for plugin scaffolding.
 
 Functions for creating directory structures, rendering templates,

--- a/skills/plugin-manager/scripts/operations/scaffold_ops/licenses.py
+++ b/skills/plugin-manager/scripts/operations/scaffold_ops/licenses.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """License text templates for plugin scaffolding.
 
 Stores full license bodies keyed by SPDX identifier with

--- a/skills/plugin-manager/scripts/operations/shared.py
+++ b/skills/plugin-manager/scripts/operations/shared.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Shared helpers for plugin-manager operations.
 
 Provides template variable construction used by both scaffold

--- a/skills/plugin-manager/scripts/operations/update.py
+++ b/skills/plugin-manager/scripts/operations/update.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Plugin Update Operations - Two-Phase API
 
 Scans existing plugin projects against current scaffold

--- a/skills/plugin-manager/scripts/operations/update_ops/__init__.py
+++ b/skills/plugin-manager/scripts/operations/update_ops/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Update operations subpackage for plugin-manager.
 
 Provides scanning, diffing, patching, and strategy modules

--- a/skills/plugin-manager/scripts/operations/update_ops/models.py
+++ b/skills/plugin-manager/scripts/operations/update_ops/models.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Data models for the plugin update operation.
 
 Defines enums for file categories, merge strategies, and

--- a/skills/plugin-manager/scripts/operations/update_ops/parsers.py
+++ b/skills/plugin-manager/scripts/operations/update_ops/parsers.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Shared parsing utilities for the update operation.
 
 Extracted from scanner.py and patcher.py to eliminate

--- a/skills/plugin-manager/scripts/operations/update_ops/patcher.py
+++ b/skills/plugin-manager/scripts/operations/update_ops/patcher.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Plugin patcher for the update operation.
 
 Applies approved patches to a plugin directory with backup

--- a/skills/plugin-manager/scripts/operations/update_ops/scanner.py
+++ b/skills/plugin-manager/scripts/operations/update_ops/scanner.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Plugin scanner for the update operation.
 
 Scans an existing plugin directory, compares each file against

--- a/skills/plugin-manager/scripts/operations/update_ops/strategies.py
+++ b/skills/plugin-manager/scripts/operations/update_ops/strategies.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """File classification and strategy registry for plugin update.
 
 Maps each scaffolded file to its category, template source,

--- a/skills/plugin-manager/scripts/operations/utils.py
+++ b/skills/plugin-manager/scripts/operations/utils.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Shared utilities for plugin-manager operations.
 
 Re-exports from scripts/shared/utils.py for convenient access

--- a/skills/skill-manager/SKILL.md
+++ b/skills/skill-manager/SKILL.md
@@ -10,6 +10,9 @@ tags:
   - skills
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Skill Manager
 
 Focused management interface for Claude Code skill definitions.

--- a/skills/skill-manager/references/create-workflow.md
+++ b/skills/skill-manager/references/create-workflow.md
@@ -4,6 +4,9 @@ title: Skill Create Workflow
 description: Step-by-step process for creating Claude Code skill definitions
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Skill Create Workflow
 
 This document describes the workflow for creating new Claude Code

--- a/skills/skill-manager/references/schemas.md
+++ b/skills/skill-manager/references/schemas.md
@@ -4,6 +4,9 @@ title: Skill Frontmatter Schema
 description: Reference for YAML frontmatter fields in Claude Code skill definitions
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Skill Frontmatter Schema
 
 This document provides a complete reference for YAML frontmatter

--- a/skills/skill-manager/references/validate-workflow.md
+++ b/skills/skill-manager/references/validate-workflow.md
@@ -4,6 +4,9 @@ title: Skill Validate Workflow
 description: Process for validating Claude Code skill definitions against schema rules
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # Skill Validate Workflow
 
 This document describes the workflow for validating existing

--- a/skills/skill-manager/scripts/_paths.py
+++ b/skills/skill-manager/scripts/_paths.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Path configuration for skill-manager scripts.
 
 Sets up sys.path so that shared utilities can be imported

--- a/skills/skill-manager/scripts/manage.py
+++ b/skills/skill-manager/scripts/manage.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Skill Manager Script - Two-Phase API
 
 Entry point for managing Claude Code skill definitions.

--- a/skills/skill-manager/scripts/operations/__init__.py
+++ b/skills/skill-manager/scripts/operations/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Skill manager operations package."""

--- a/skills/skill-manager/scripts/operations/extensions.py
+++ b/skills/skill-manager/scripts/operations/extensions.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Skill management operations for Claude Code.
 
 Handles create, validate, version, and list operations for skills.

--- a/skills/skill-manager/scripts/operations/utils.py
+++ b/skills/skill-manager/scripts/operations/utils.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Shared utilities for skill manager operations.
 
 Re-exports from scripts/shared/utils.py for local imports.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Shared test fixtures for pytest.
 
 Handles sys.modules restoration to prevent cross-skill module

--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 .PHONY: help build build-base build-all clean clean-all shell-% up down test-% test-all
 
 # Test result directory

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -10,6 +10,9 @@ tags:
   - environments
 ---
 
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
 # AIDA Test Environments
 
 Docker-based test environments for validating AIDA functionality across different project types.

--- a/tests/integration/aida/Dockerfile
+++ b/tests/integration/aida/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 FROM aida-test-base:latest
 
 WORKDIR /home/tester/projects/aida-test-project

--- a/tests/integration/base/Dockerfile
+++ b/tests/integration/base/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 FROM ubuntu:24.04
 
 # Avoid interactive prompts during package installation

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 services:
   # Base image (built first, used by all others)
   base:

--- a/tests/integration/monorepo/Dockerfile
+++ b/tests/integration/monorepo/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 FROM aida-test-base:latest
 
 USER root

--- a/tests/integration/nodejs/Dockerfile
+++ b/tests/integration/nodejs/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 FROM aida-test-base:latest
 
 WORKDIR /home/tester/projects/nodejs-test-project

--- a/tests/integration/php/Dockerfile
+++ b/tests/integration/php/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 FROM aida-test-base:latest
 
 USER root

--- a/tests/integration/python/Dockerfile
+++ b/tests/integration/python/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 FROM aida-test-base:latest
 
 USER root

--- a/tests/integration/scripts/install-aida.sh
+++ b/tests/integration/scripts/install-aida.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 set -e
 
 # AIDA Installation Script for Test Environments

--- a/tests/integration/scripts/run-tests.sh
+++ b/tests/integration/scripts/run-tests.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 set -e
 
 # AIDA Test Runner Script

--- a/tests/integration/test_bootstrap_install.py
+++ b/tests/integration/test_bootstrap_install.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Integration test for AIDA managed virtual environment bootstrap.
 
 Tests the real venv creation and dependency installation flow using

--- a/tests/integration/test_expert_discovery_integration.py
+++ b/tests/integration/test_expert_discovery_integration.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Integration test: discover_agents -> filter_experts_by_role -> resolve_active_experts.
 
 Exercises the full pipeline with real agent .md files on disk to verify

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Tests for hook operations."""
 
 from pathlib import Path

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for agent discovery and CLAUDE.md routing generation.
 
 This test suite covers agent discovery from project, user, and

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for scripts/shared/bootstrap.py.
 
 Tests the AIDA managed virtual environment bootstrap including

--- a/tests/unit/test_claude_md.py
+++ b/tests/unit/test_claude_md.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for claude-md-manager CLAUDE.md operations.
 
 This test suite covers the operations/claude_md.py module functionality including

--- a/tests/unit/test_error_recovery.py
+++ b/tests/unit/test_error_recovery.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for error recovery and resilience.
 
 This test suite covers handling of corrupted files, permission errors,

--- a/tests/unit/test_expert_panels.py
+++ b/tests/unit/test_expert_panels.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Tests for skills/expert-registry/scripts/operations/panels.py"""
 import sys
 from pathlib import Path

--- a/tests/unit/test_expert_registry.py
+++ b/tests/unit/test_expert_registry.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Tests for expert-registry registry module (config I/O)."""
 
 import sys

--- a/tests/unit/test_feedback.py
+++ b/tests/unit/test_feedback.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for AIDA feedback system.
 
 This test suite covers all functionality in the feedback.py script including

--- a/tests/unit/test_manage.py
+++ b/tests/unit/test_manage.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for agent-manager manage.py script.
 
 This test suite covers the manage.py script functionality including

--- a/tests/unit/test_memento.py
+++ b/tests/unit/test_memento.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for memento skill memento.py script.
 
 This test suite covers the memento.py script functionality including

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for permissions skill modules.
 
 This test suite covers plugin permission scanning, aggregation,

--- a/tests/unit/test_plugin_discovery.py
+++ b/tests/unit/test_plugin_discovery.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for plugin discovery and configuration utilities.
 
 This test suite covers functionality for discovering installed plugins,

--- a/tests/unit/test_plugin_extensions.py
+++ b/tests/unit/test_plugin_extensions.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for plugin-manager extension CRUD operations.
 
 This test suite covers the plugin-manager extensions.py module,

--- a/tests/unit/test_project_context_split.py
+++ b/tests/unit/test_project_context_split.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for the project-context split/merge helpers (issue #65)."""
 
 import sys

--- a/tests/unit/test_project_context_template.py
+++ b/tests/unit/test_project_context_template.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for the project-context SKILL.md.jinja2 template.
 
 Verifies that the rendered template produces clean markdown output

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for plugin-manager scaffold.py main entry point."""
 
 import sys

--- a/tests/unit/test_scaffold_context.py
+++ b/tests/unit/test_scaffold_context.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for plugin-manager context operations."""
 
 import os

--- a/tests/unit/test_scaffold_generators.py
+++ b/tests/unit/test_scaffold_generators.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for plugin-manager generator operations."""
 
 import sys

--- a/tests/unit/test_scaffold_licenses.py
+++ b/tests/unit/test_scaffold_licenses.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for plugin-manager license operations."""
 
 import sys

--- a/tests/unit/test_security_edge_cases.py
+++ b/tests/unit/test_security_edge_cases.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for security edge cases.
 
 This test suite covers path traversal attempts, unicode edge cases,

--- a/tests/unit/test_shared_utils.py
+++ b/tests/unit/test_shared_utils.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for scripts/shared/utils.py.
 
 Verifies that shared utils are importable and that the extraction

--- a/tests/unit/test_skill_extensions.py
+++ b/tests/unit/test_skill_extensions.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for skill-manager extension CRUD operations.
 
 Tests the skill-manager's operations/extensions.py module which

--- a/tests/unit/test_update_integration.py
+++ b/tests/unit/test_update_integration.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Integration tests for plugin update end-to-end flow."""
 
 from __future__ import annotations

--- a/tests/unit/test_update_patcher.py
+++ b/tests/unit/test_update_patcher.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for plugin-manager update patcher."""
 
 from __future__ import annotations

--- a/tests/unit/test_update_scanner.py
+++ b/tests/unit/test_update_scanner.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for plugin-manager update scanner."""
 
 from __future__ import annotations

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
 """Unit tests for AIDA utils module.
 
 This test suite covers all functionality in the utils package including


### PR DESCRIPTION
## Summary

- Bulk-adds SPDX `SPDX-FileCopyrightText` / `SPDX-License-Identifier: MPL-2.0` headers to every hand-authored source file (markdown, Python, YAML, shell, Makefile, Dockerfile, requirements.txt). 240 files updated; large diff is mostly mechanical — review the new tooling and config first.
- Adds `scripts/add_spdx_headers.py` — idempotent, dry-run-by-default header inserter. Reads `git ls-files`, applies the right comment style per file type, respects shebangs and YAML/markdown frontmatter, and honors the org skip list (JSON, lockfiles, fixtures, scaffolding templates, `LICENSE` itself).
- Adds `REUSE.toml` to license the skip categories that can't carry inline headers. Copyright attribution is `2026 The AIDA Core Authors` everywhere; the actual roster lives in `AUTHORS` (added in #75).
- Adds `LICENSES/MPL-2.0.txt` (REUSE-required canonical text). Existing `LICENSE` at the root is unchanged — GitHub still displays it.
- Wires `reuse lint` into `make lint`, so the existing CI lint job becomes the **blocking** gate for REUSE compliance. Project is REUSE 3.3 compliant.
- Depends on #75 (AUTHORS file). Recommend merging that first; this PR will likely need a 1-line CHANGELOG/version rebase against `main` afterward.

**Out of scope (next PR for #73):** updating the scaffolding tools (`plugin-manager`, `agent-manager`, `skill-manager`, `claude-md-manager`, `hook-manager`) to inject SPDX headers into generated artifacts. Templates themselves are intentionally header-free here — `REUSE.toml` covers them — so the renderer can set the year and copyright per artifact.

Refs #72, #73.

## How the diff is structured

- New code / config: `scripts/add_spdx_headers.py`, `REUSE.toml`, `LICENSES/MPL-2.0.txt`, Makefile additions, requirements bump, CHANGELOG entry, plugin.json version bump.
- Mechanical: the rest is just two lines of header per file.

To re-verify locally:
```
make install
make lint              # includes lint-reuse
~/.aida/venv/bin/reuse lint
python3 scripts/add_spdx_headers.py    # dry run; should report 0 files to update
```

## Notes for reviewers

- `scripts/add_spdx_headers.py` is kept in-repo (not deleted post-merge) because it's idempotent and useful when manually backfilling files that bypass the scaffolding. Ping me if you'd rather it be a one-shot.
- I considered `.reuse/dep5` (per the issue) but `reuse 6.x` raises a `PendingDeprecationWarning` for that format and ships a `convert-dep5` migrator. Used `REUSE.toml` instead.
- Test fixtures under `tests/integration/*/sample-project/` are licensed via `REUSE.toml` rather than headered inline, since they simulate downstream user projects and a sample `package.json` shouldn't carry our header.

## Test plan

- [x] `make lint` clean locally (ruff, yamllint, markdownlint, frontmatter, reuse)
- [x] `make test TEST_ARGS="tests/unit/"` — 836 passed
- [x] `~/.aida/venv/bin/reuse lint` — REUSE 3.3 compliant
- [ ] CI green (lint + unit-test matrix + integration-test + version-check + check-attribution)