### PR TITLE
feat: emit SPDX headers from skill / claude-md / hook scaffolding (1.5.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   End-to-end smoke test: `reuse lint` is green on a Python
   scaffold with both agent and skill stubs (18/18 files)
 
+### Fixed
+
+- Test helper `_create_skill` in `test_extension_spdx.py` now
+  saves and restores `sys.path` plus the cached `operations.*` /
+  `_paths` modules around the skill-manager import dance. Without
+  this, the helper silently propagated the swapped sys.path[0] to
+  every later test in the same session — passing today only because
+  no later test cared
+- (Folded in from the prior 1.5.0 entry, made explicit here)
+  `## [1.4.8]` heading was missing from the CHANGELOG when 1.5.0
+  was added, conflating the two versions and tripping markdownlint
+  MD024. The split is now in place
+
 ### Notes
 
 - `hook-manager` doesn't render hand-authored files (it edits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,34 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-04-30
+
+### Added
+
+- `skill-manager`'s `SKILL.md` template now emits an SPDX header
+  after the YAML frontmatter, using the same `{{ spdx_md }}`
+  variable as `agent-manager`. New skills are reuse-compliant
+  by default
+- `claude-md-manager`'s project / user / plugin CLAUDE.md
+  templates now emit an SPDX header. `execute_create` plumbs
+  SPDX context through `spdx_template_variables` so callers can
+  override `copyright_holder` / `license_id` / `year`
+- `plugin-manager`'s `render_stub_skill` accepts an
+  `spdx_context` argument and seeds the skill stub variables
+  with it — so `aida plugin scaffold --include-skill-stub` now
+  produces a fully reuse-compliant plugin (skill stub included).
+  End-to-end smoke test: `reuse lint` is green on a Python
+  scaffold with both agent and skill stubs (18/18 files)
+
+### Notes
+
+- `hook-manager` doesn't render hand-authored files (it edits
+  `settings.json`), so it has no template to update — closes the
+  scaffolding portion of #73
+- Refs #73
+
+---
+
 ## [1.5.0] - 2026-04-30
 
 ### Added
@@ -61,6 +89,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   flows are unchanged in this PR — that's the next PR on #73.
   Plugins scaffolded with `include_skill_stub=True` will not yet
   have an SPDX-headered `SKILL.md`
+
+---
+
+## [1.4.8] - 2026-04-30
 
 ### Added
 

--- a/skills/claude-md-manager/scripts/operations/claude_md.py
+++ b/skills/claude-md-manager/scripts/operations/claude_md.py
@@ -14,6 +14,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from shared.spdx import spdx_template_variables
+
 from .utils import (
     get_project_root,
     parse_frontmatter,
@@ -840,6 +842,9 @@ def execute_create(
         "conventions": context.get("conventions", ""),
         "constraints": context.get("constraints", ""),
     }
+    # Seed SPDX template vars (year, copyright_holder, license_id,
+    # plus pre-formatted spdx_md / spdx_hash / spdx_slash blocks).
+    template_vars.update(spdx_template_variables(context))
 
     # Select template
     template_name = TEMPLATES.get(

--- a/skills/claude-md-manager/templates/claude-md/plugin.md.jinja2
+++ b/skills/claude-md-manager/templates/claude-md/plugin.md.jinja2
@@ -4,6 +4,7 @@ title: {{ name }} Plugin - CLAUDE.md
 description: Plugin-specific Claude Code configuration
 ---
 
+{{ spdx_md }}
 # {{ name }} Plugin CLAUDE.md
 
 {{ description | default('Plugin description here.') }}

--- a/skills/claude-md-manager/templates/claude-md/project.md.jinja2
+++ b/skills/claude-md-manager/templates/claude-md/project.md.jinja2
@@ -4,6 +4,7 @@ title: {{ name }} - CLAUDE.md
 description: Claude Code configuration for this repository
 ---
 
+{{ spdx_md }}
 # CLAUDE.md
 
 {{ description | default('Project description here.') }}

--- a/skills/claude-md-manager/templates/claude-md/user.md.jinja2
+++ b/skills/claude-md-manager/templates/claude-md/user.md.jinja2
@@ -4,6 +4,7 @@ title: User CLAUDE.md
 description: Global Claude Code preferences and defaults
 ---
 
+{{ spdx_md }}
 # User CLAUDE.md
 
 Personal preferences and defaults that apply across all projects.

--- a/skills/plugin-manager/scripts/operations/scaffold.py
+++ b/skills/plugin-manager/scripts/operations/scaffold.py
@@ -471,6 +471,7 @@ def execute(context: dict[str, Any]) -> dict[str, Any]:
                 language,
                 SKILL_TEMPLATES_DIR,
                 timestamp=variables["timestamp"],
+                spdx_context=spdx_for_stubs,
             )
             all_files.extend(stub_files)
 

--- a/skills/plugin-manager/scripts/operations/scaffold_ops/generators.py
+++ b/skills/plugin-manager/scripts/operations/scaffold_ops/generators.py
@@ -287,6 +287,7 @@ def render_stub_skill(
     language: str,
     extension_templates_dir: Path,
     timestamp: str = "",
+    spdx_context: dict[str, str] | None = None,
 ) -> list[str]:
     """Render a skill stub using extension templates.
 
@@ -298,6 +299,9 @@ def render_stub_skill(
         extension_templates_dir: Path to skill extension
             templates directory
         timestamp: ISO 8601 timestamp
+        spdx_context: ``{year, copyright_holder, license_id}``
+            used to render SPDX headers in generated files. If
+            absent, defaults are computed via ``resolve_spdx_context``.
 
     Returns:
         List of created file paths (relative to target)
@@ -311,6 +315,9 @@ def render_stub_skill(
         ".py" if language == "python" else ".ts"
     )
 
+    spdx = resolve_spdx_context(spdx_context or {})
+    spdx_blocks = render_spdx_blocks(spdx)
+
     variables = {
         "name": name,
         "description": description,
@@ -318,6 +325,8 @@ def render_stub_skill(
         "tags": ["custom"],
         "timestamp": timestamp,
         "script_extension": script_extension,
+        **spdx,
+        **spdx_blocks,
     }
 
     content = render_template(

--- a/skills/skill-manager/templates/skill/SKILL.md.jinja2
+++ b/skills/skill-manager/templates/skill/SKILL.md.jinja2
@@ -9,6 +9,7 @@ tags:
 {% endfor %}
 ---
 
+{{ spdx_md }}
 # {{ name | replace("-", " ") | title }}
 
 {{ description }}

--- a/tests/unit/test_extension_spdx.py
+++ b/tests/unit/test_extension_spdx.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: 2026 The AIDA Core Authors
 # SPDX-License-Identifier: MPL-2.0
 
-"""Tests that the agent-manager scaffolding emits SPDX headers.
+"""Tests that extension-manager scaffolding emits SPDX headers.
 
 Verifies the leverage point of issue #73: a downstream plugin author
-running the agent-manager scaffolding ends up with a reuse-compliant
-agent file without having to think about SPDX headers themselves.
+running agent-manager / skill-manager scaffolding ends up with a
+reuse-compliant artifact without having to think about SPDX headers
+themselves.
 """
 
 # REUSE-IgnoreStart — assertions reference literal SPDX strings.
@@ -14,9 +15,9 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
-# Reset cached operations modules so this file's agent-manager
-# imports don't conflict with other test files using a different
-# manager. shared.* is intentionally left intact.
+# Reset cached operations modules so this file's manager imports
+# don't conflict with other test files using a different manager.
+# shared.* is intentionally left intact.
 for _mod_name in list(sys.modules):
     if (
         _mod_name == "operations"
@@ -33,11 +34,12 @@ sys.path.insert(
 
 from operations.extensions import execute_create  # noqa: E402
 
-_TEMPLATES = _project_root / "skills" / "agent-manager" / "templates"
+_AGENT_TEMPLATES = _project_root / "skills" / "agent-manager" / "templates"
+_SKILL_TEMPLATES = _project_root / "skills" / "skill-manager" / "templates"
 
 
 def _create_agent(tmp_path, **overrides):
-    """Run execute_create against a tempdir and return the file content."""
+    """Run agent execute_create against a tempdir and return content."""
     base = tmp_path / ".claude"
     with patch(
         "shared.extension_utils.get_location_path",
@@ -51,7 +53,57 @@ def _create_agent(tmp_path, **overrides):
             version=overrides.get("version", "0.1.0"),
             tags=overrides.get("tags", ["core"]),
             location="project",
-            templates_dir=_TEMPLATES,
+            templates_dir=_AGENT_TEMPLATES,
+        )
+    assert result["success"], result.get("message")
+    return Path(result["path"]).read_text()
+
+
+def _create_skill(tmp_path, **overrides):
+    """Run skill execute_create against a tempdir and return content.
+
+    Imports skill-manager separately because it shares the
+    ``operations`` package name with agent-manager / plugin-manager
+    / etc. We have to (a) drop their cached ``operations.*`` and
+    ``_paths`` modules, (b) put skill-manager's scripts dir at
+    sys.path[0], and (c) invalidate importlib's finder cache so
+    Python doesn't reuse the previously-resolved plugin-manager
+    location on import.
+    """
+    import importlib
+
+    for mod_name in list(sys.modules):
+        if (
+            mod_name == "operations"
+            or mod_name.startswith("operations.")
+            or mod_name == "_paths"
+        ):
+            del sys.modules[mod_name]
+
+    skill_scripts = str(
+        _project_root / "skills" / "skill-manager" / "scripts"
+    )
+    if skill_scripts in sys.path:
+        sys.path.remove(skill_scripts)
+    sys.path.insert(0, skill_scripts)
+    importlib.invalidate_caches()
+
+    from operations.extensions import execute_create as skill_create
+
+    base = tmp_path / ".claude"
+    with patch(
+        "shared.extension_utils.get_location_path",
+        return_value=base,
+    ):
+        result = skill_create(
+            name=overrides.get("name", "test-skill"),
+            description=overrides.get(
+                "description", "A skill used to test SPDX emission"
+            ),
+            version=overrides.get("version", "0.1.0"),
+            tags=overrides.get("tags", ["core"]),
+            location="project",
+            templates_dir=_SKILL_TEMPLATES,
         )
     assert result["success"], result.get("message")
     return Path(result["path"]).read_text()
@@ -81,5 +133,19 @@ class TestAgentCreateEmitsSpdx:
         # render as a Markdown heading, which we never want.
         assert "<!-- SPDX-FileCopyrightText:" in content
         assert "<!-- SPDX-License-Identifier:" in content
+
+
+class TestSkillCreateEmitsSpdx:
+    def test_emits_copyright_after_frontmatter(self, tmp_path):
+        content = _create_skill(tmp_path)
+        assert content.lstrip().startswith("---")
+        frontmatter_end = content.find("\n---\n", 1)
+        assert frontmatter_end > 0
+        body = content[frontmatter_end:]
+        assert "<!-- SPDX-FileCopyrightText:" in body
+
+    def test_emits_default_license_id(self, tmp_path):
+        content = _create_skill(tmp_path)
+        assert "SPDX-License-Identifier: MPL-2.0" in content
 
 # REUSE-IgnoreEnd

--- a/tests/unit/test_extension_spdx.py
+++ b/tests/unit/test_extension_spdx.py
@@ -69,44 +69,63 @@ def _create_skill(tmp_path, **overrides):
     sys.path[0], and (c) invalidate importlib's finder cache so
     Python doesn't reuse the previously-resolved plugin-manager
     location on import.
+
+    Restores both ``sys.path`` and the cached ``operations.*``
+    modules afterward so this helper is self-contained — later
+    tests in the same session see the state they expect.
     """
     import importlib
 
-    for mod_name in list(sys.modules):
-        if (
-            mod_name == "operations"
-            or mod_name.startswith("operations.")
-            or mod_name == "_paths"
-        ):
+    saved_path = list(sys.path)
+    saved_modules = {
+        k: v for k, v in sys.modules.items()
+        if k == "operations"
+        or k.startswith("operations.")
+        or k == "_paths"
+    }
+
+    try:
+        for mod_name in list(saved_modules):
             del sys.modules[mod_name]
 
-    skill_scripts = str(
-        _project_root / "skills" / "skill-manager" / "scripts"
-    )
-    if skill_scripts in sys.path:
-        sys.path.remove(skill_scripts)
-    sys.path.insert(0, skill_scripts)
-    importlib.invalidate_caches()
-
-    from operations.extensions import execute_create as skill_create
-
-    base = tmp_path / ".claude"
-    with patch(
-        "shared.extension_utils.get_location_path",
-        return_value=base,
-    ):
-        result = skill_create(
-            name=overrides.get("name", "test-skill"),
-            description=overrides.get(
-                "description", "A skill used to test SPDX emission"
-            ),
-            version=overrides.get("version", "0.1.0"),
-            tags=overrides.get("tags", ["core"]),
-            location="project",
-            templates_dir=_SKILL_TEMPLATES,
+        skill_scripts = str(
+            _project_root / "skills" / "skill-manager" / "scripts"
         )
-    assert result["success"], result.get("message")
-    return Path(result["path"]).read_text()
+        if skill_scripts in sys.path:
+            sys.path.remove(skill_scripts)
+        sys.path.insert(0, skill_scripts)
+        importlib.invalidate_caches()
+
+        from operations.extensions import execute_create as skill_create
+
+        base = tmp_path / ".claude"
+        with patch(
+            "shared.extension_utils.get_location_path",
+            return_value=base,
+        ):
+            result = skill_create(
+                name=overrides.get("name", "test-skill"),
+                description=overrides.get(
+                    "description", "A skill used to test SPDX emission"
+                ),
+                version=overrides.get("version", "0.1.0"),
+                tags=overrides.get("tags", ["core"]),
+                location="project",
+                templates_dir=_SKILL_TEMPLATES,
+            )
+        assert result["success"], result.get("message")
+        return Path(result["path"]).read_text()
+    finally:
+        sys.path[:] = saved_path
+        for mod_name in [
+            k for k in sys.modules
+            if k == "operations"
+            or k.startswith("operations.")
+            or k == "_paths"
+        ]:
+            del sys.modules[mod_name]
+        sys.modules.update(saved_modules)
+        importlib.invalidate_caches()
 
 
 class TestAgentCreateEmitsSpdx:


### PR DESCRIPTION
## Summary

Closes the scaffolding portion of #73 by extending SPDX emission to the remaining extension managers:

- **`skill-manager`** — `SKILL.md.jinja2` emits an SPDX header after the frontmatter, mirroring `agent-manager`. The shared `execute_extension_create` infrastructure (PR #77) already seeds the template vars, so this is a one-line template change.
- **`claude-md-manager`** — `project.md.jinja2` / `user.md.jinja2` / `plugin.md.jinja2` all emit SPDX headers. `execute_create` calls `spdx_template_variables` explicitly so the caller can override `copyright_holder` / `license_id` / `year` per file.
- **`plugin-manager`** — `render_stub_skill` now takes an `spdx_context` kwarg symmetric with `render_stub_agent`. End-to-end smoke is now clean: scaffolding a Python plugin with both `--include-agent-stub` and `--include-skill-stub` passes `reuse lint` 18/18 (was 17/18 in PR #77).
- **`hook-manager`** — no templates to update; it modifies `settings.json` rather than emitting hand-authored files. Closes the "if it generates files" caveat from #73.

**Stacked on #77** (which is stacked on #76 / #75). Base is `feat/73-scaffolding-spdx-emit`. Once #77 merges, retarget to `main`.

Refs #73 (closes the scaffolding portion).

## Reuse-compliance verification

| Scaffold | Pre-PR (PR #77 only) | This PR |
|---|---|---|
| Python + agent + skill stubs | 17/18 (SKILL.md missing header) | 18/18 ✔ |
| TypeScript + agent + skill stubs | 21/22 (SKILL.md missing header) | 22/22 ✔ |

## Test plan

- [x] `make test TEST_ARGS="tests/unit/"` — 857 passed
- [x] `make lint` — ruff / yamllint / frontmatter / reuse all clean
- [x] `markdownlint` clean
- [x] Manual smoke: scaffold Python plugin with both stubs → `reuse lint` 18/18
- [ ] CI green

## Notes for reviewers

`tests/unit/test_extension_spdx.py` had a sequencing bug when run in the full pytest suite (importlib's finder cache held the previously-resolved `operations` package location across test files). Fixed by calling `importlib.invalidate_caches()` after re-inserting skill-manager's scripts dir at sys.path[0]. Tests now pass standalone, in pairs, and in the full suite.