### PR TITLE
fix: scope-aware template_vars + validation in claude-md-manager (1.5.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,49 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.2] - 2026-05-22
+
+### Fixed
+
+- `claude-md-manager` `create --scope user`: the `--responses` payload
+  was silently dropped because `execute_create` built `template_vars`
+  from project-scope keys only. The user template at
+  `templates/claude-md/user.md.jinja2` references `default_behaviors`,
+  `patterns`, `tool_config`, `preferred_languages`, and
+  `preferred_tools` — none were threaded in, so the file rendered with
+  the template's `default()` placeholder text while the operation
+  still returned `success:true`. `execute_create` now selects the
+  variable set that matches `scope`. Plugin-scope had the same latent
+  bug (`plugin_type`, `provides`, `usage`, `config_options`,
+  `extension_points` were all unwired) and is fixed in the same
+  change. Fixes #98
+- `claude-md-manager validate`: project-scope required sections
+  (`overview`, `commands`) were applied to every file regardless of
+  scope, so a well-formed user-scope or plugin-scope file would fail
+  validation with `Missing required sections: overview, commands`.
+  Required sections are now keyed by scope — project keeps
+  `["overview", "commands"]`, user and plugin have no required
+  sections (free-form). `validate_claude_md`, `calculate_audit_score`,
+  and `generate_audit_findings` now accept an optional `scope`
+  parameter (defaulting to `project` for callers that don't know it).
+  `execute_validate`, `execute_optimize`, and `execute_list` thread
+  the per-file scope through from `file_info["scope"]`. Fixes #99
+
+### Notes
+
+- Both bugs were originally reported against 1.1.5 but reproduced on
+  1.5.1 — the relevant code paths were unchanged between those
+  versions
+- New tests in `tests/unit/test_claude_md.py` cover all three scopes:
+  user-scope create persists `default_behaviors` / `patterns` /
+  `tool_config`; plugin-scope create persists `plugin_type` /
+  `provides` / `usage` / etc.; user-scope and plugin-scope validate
+  succeed without project-style required sections; project-scope
+  validate still requires `overview` + `commands`
+- Milestone: `1.6.0 — Bug fixes`
+
+---
+
 ## [1.5.1] - 2026-04-30
 
 ### Added

--- a/skills/claude-md-manager/scripts/operations/claude_md.py
+++ b/skills/claude-md-manager/scripts/operations/claude_md.py
@@ -22,9 +22,25 @@ from .utils import (
     render_template,
 )
 
-# Required sections for validation
-REQUIRED_SECTIONS = ["overview", "commands"]
+# Required sections per scope. project-scope files document a codebase
+# and need overview + commands. user-scope files capture free-form
+# personal preferences; plugin-scope files document a plugin's own surface.
+# Neither benefits from project-style required sections.
+REQUIRED_SECTIONS: Dict[str, List[str]] = {
+    "project": ["overview", "commands"],
+    "user": [],
+    "plugin": [],
+}
 RECOMMENDED_SECTIONS = ["architecture", "conventions", "constraints"]
+
+
+def required_sections_for(scope: str) -> List[str]:
+    """Return the required-section list for a given scope.
+
+    Unknown scopes fall back to the project list so callers that
+    don't know the scope keep their previous behavior.
+    """
+    return REQUIRED_SECTIONS.get(scope, REQUIRED_SECTIONS["project"])
 
 # Template options
 TEMPLATES = {
@@ -404,11 +420,16 @@ def detect_project_context(
     return context
 
 
-def validate_claude_md(path: Path) -> Dict[str, Any]:
+def validate_claude_md(
+    path: Path, scope: str = "project"
+) -> Dict[str, Any]:
     """Validate a CLAUDE.md file.
 
     Args:
         path: Path to CLAUDE.md file
+        scope: 'project', 'user', or 'plugin'. Controls which sections
+            are treated as required. Defaults to 'project' for callers
+            that don't know the scope.
 
     Returns:
         Validation results dictionary
@@ -455,9 +476,9 @@ def validate_claude_md(path: Path) -> Dict[str, Any]:
             "Has frontmatter"
         )
 
-    # Check required sections
+    # Check required sections (scope-aware)
     missing_sections = []
-    for req in REQUIRED_SECTIONS:
+    for req in required_sections_for(scope):
         if req not in sections:
             missing_sections.append(req)
 
@@ -507,13 +528,17 @@ def validate_claude_md(path: Path) -> Dict[str, Any]:
 
 
 def calculate_audit_score(
-    results: Dict[str, Any], sections: List[str]
+    results: Dict[str, Any],
+    sections: List[str],
+    scope: str = "project",
 ) -> int:
     """Calculate audit score (0-100).
 
     Args:
         results: Validation results
         sections: Detected sections
+        scope: 'project', 'user', or 'plugin'. Controls which sections
+            count toward the required-section bonus.
 
     Returns:
         Score from 0 to 100
@@ -525,8 +550,8 @@ def calculate_audit_score(
         if check["pass"]:
             score += 10
 
-    # Add points for sections
-    for section in REQUIRED_SECTIONS:
+    # Add points for required sections present (scope-aware)
+    for section in required_sections_for(scope):
         if section in sections:
             score += 5
 
@@ -546,6 +571,7 @@ def generate_audit_findings(
     content: str,
     validation: Dict[str, Any],
     detected_context: Dict[str, Any],
+    scope: str = "project",
 ) -> List[Dict[str, Any]]:
     """Generate audit findings with fix suggestions.
 
@@ -554,6 +580,8 @@ def generate_audit_findings(
         content: File content
         validation: Validation results
         detected_context: Detected project context
+        scope: 'project', 'user', or 'plugin'. Controls which required
+            sections are checked for fix suggestions.
 
     Returns:
         List of findings with fixes
@@ -561,8 +589,8 @@ def generate_audit_findings(
     findings: List[Dict[str, Any]] = []
     sections = detect_sections(content)
 
-    # Check for missing required sections
-    for req in REQUIRED_SECTIONS:
+    # Check for missing required sections (scope-aware)
+    for req in required_sections_for(scope):
         if req not in sections:
             fix_content = ""
             if req == "commands" and detected_context.get(
@@ -728,12 +756,13 @@ def get_questions(
         file_info = files[0]
         path = Path(file_info["path"])
         content = path.read_text(encoding="utf-8")
+        file_scope = file_info.get("scope", "project")
 
         # Run validation
-        validation = validate_claude_md(path)
+        validation = validate_claude_md(path, file_scope)
         sections = detect_sections(content)
         score = calculate_audit_score(
-            validation, sections
+            validation, sections, file_scope
         )
 
         # Detect project context for comparison
@@ -741,7 +770,7 @@ def get_questions(
 
         # Generate findings
         findings = generate_audit_findings(
-            path, content, validation, detected
+            path, content, validation, detected, file_scope
         )
 
         result["audit"] = {
@@ -830,18 +859,51 @@ def execute_create(
             ),
         }
 
-    # Prepare template variables
-    template_vars = {
+    # Prepare template variables. The three scopes ship templates that
+    # reference disjoint variable sets — wire each scope's expected keys
+    # explicitly so --responses content from Phase 2 actually renders.
+    template_vars: Dict[str, Any] = {
         "name": context.get("name", project_root.name),
         "description": context.get("description", ""),
-        "languages": context.get("languages", []),
-        "tools": context.get("tools", []),
-        "commands": context.get("commands", []),
-        "project_type": context.get("project_type", ""),
-        "architecture": context.get("architecture", ""),
-        "conventions": context.get("conventions", ""),
-        "constraints": context.get("constraints", ""),
     }
+
+    if scope == "user":
+        template_vars.update({
+            "preferred_languages": context.get(
+                "preferred_languages", []
+            ),
+            "preferred_tools": context.get(
+                "preferred_tools", []
+            ),
+            "default_behaviors": context.get(
+                "default_behaviors", ""
+            ),
+            "patterns": context.get("patterns", ""),
+            "tool_config": context.get("tool_config", ""),
+        })
+    elif scope == "plugin":
+        template_vars.update({
+            "plugin_type": context.get("plugin_type", ""),
+            "provides": context.get("provides", []),
+            "usage": context.get("usage", ""),
+            "config_options": context.get(
+                "config_options", ""
+            ),
+            "extension_points": context.get(
+                "extension_points", ""
+            ),
+        })
+    else:  # project (default)
+        template_vars.update({
+            "languages": context.get("languages", []),
+            "tools": context.get("tools", []),
+            "commands": context.get("commands", []),
+            "project_type": context.get("project_type", ""),
+            "architecture": context.get("architecture", ""),
+            "conventions": context.get("conventions", ""),
+            "constraints": context.get("constraints", ""),
+        })
+
     # Seed SPDX template vars (year, copyright_holder, license_id,
     # plus pre-formatted spdx_md / spdx_hash / spdx_slash blocks).
     template_vars.update(spdx_template_variables(context))
@@ -913,15 +975,17 @@ def execute_optimize(
             ),
         }
 
-    path = Path(files[0]["path"])
+    file_info = files[0]
+    path = Path(file_info["path"])
     content = path.read_text(encoding="utf-8")
+    file_scope = file_info.get("scope", "project")
 
     # Get findings
     project_root = get_project_root()
     detected = detect_project_context(project_root)
-    validation = validate_claude_md(path)
+    validation = validate_claude_md(path, file_scope)
     findings = generate_audit_findings(
-        path, content, validation, detected
+        path, content, validation, detected, file_scope
     )
 
     # Filter findings based on fix_mode
@@ -980,10 +1044,10 @@ def execute_optimize(
             }
 
     # Recalculate score
-    new_validation = validate_claude_md(path)
+    new_validation = validate_claude_md(path, file_scope)
     new_sections = detect_sections(content)
     new_score = calculate_audit_score(
-        new_validation, new_sections
+        new_validation, new_sections, file_scope
     )
 
     return {
@@ -1027,7 +1091,8 @@ def execute_validate(
 
     for file_info in files:
         path = Path(file_info["path"])
-        validation = validate_claude_md(path)
+        file_scope = file_info.get("scope", "project")
+        validation = validate_claude_md(path, file_scope)
 
         results.append({
             "name": file_info["scope"],
@@ -1071,7 +1136,8 @@ def execute_list(
     # Add validation status to each file
     for file_info in files:
         path = Path(file_info["path"])
-        validation = validate_claude_md(path)
+        file_scope = file_info.get("scope", "project")
+        validation = validate_claude_md(path, file_scope)
         file_info["valid"] = validation["valid"]
         file_info["errors"] = len(validation["errors"])
         file_info["warnings"] = len(

--- a/tests/unit/test_claude_md.py
+++ b/tests/unit/test_claude_md.py
@@ -13,6 +13,7 @@ import json
 import tempfile
 import shutil
 from pathlib import Path
+from unittest import mock
 
 # Add scripts directories to path for imports
 _project_root = Path(__file__).parent.parent.parent
@@ -513,6 +514,97 @@ Just some content without proper sections.
         self.assertFalse(results["valid"])
         self.assertTrue(len(results["errors"]) > 0)
 
+    def test_validate_user_scope_no_required_sections(self):
+        """User-scope files don't need overview/commands sections.
+
+        Regression for #99: previously the validator applied
+        project-scope required-sections to every file, so a perfectly
+        well-formed user-scope CLAUDE.md (Default Behaviors / Patterns
+        / Tool Config) was flagged invalid. User-scope is free-form
+        preferences and has no required sections.
+        """
+        content = """---
+type: documentation
+title: User CLAUDE.md
+---
+
+# CLAUDE.md
+
+## Default Behaviors
+
+Be terse.
+
+## Cross-Project Patterns
+
+Conventional commits.
+
+## Editor/Tool Configuration
+
+VS Code.
+"""
+        claude_md = self.temp_path / "CLAUDE.md"
+        claude_md.write_text(content)
+
+        results = validate_claude_md(claude_md, scope="user")
+
+        self.assertTrue(
+            results["valid"],
+            f"user-scope should be valid; got errors: {results['errors']}",
+        )
+        self.assertEqual(results["errors"], [])
+
+    def test_validate_plugin_scope_no_required_sections(self):
+        """Plugin-scope files don't need overview/commands either.
+
+        Same #99 family: plugin-scope templates don't ship an Overview
+        or Key Commands section, so requiring them produced false
+        negatives on the scaffold's own output.
+        """
+        content = """---
+type: documentation
+title: Demo Plugin
+---
+
+# Demo Plugin
+
+## Usage
+
+Run things.
+"""
+        claude_md = self.temp_path / "CLAUDE.md"
+        claude_md.write_text(content)
+
+        results = validate_claude_md(claude_md, scope="plugin")
+
+        self.assertTrue(
+            results["valid"],
+            f"plugin-scope should be valid; got errors: {results['errors']}",
+        )
+
+    def test_validate_project_scope_still_requires_sections(self):
+        """Project-scope keeps the existing overview/commands requirement.
+
+        Guard against the #99 fix accidentally relaxing project-scope
+        validation, which is the most common case.
+        """
+        content = """---
+type: documentation
+---
+
+# CLAUDE.md
+
+Just some content without proper sections.
+"""
+        claude_md = self.temp_path / "CLAUDE.md"
+        claude_md.write_text(content)
+
+        results = validate_claude_md(claude_md, scope="project")
+
+        self.assertFalse(results["valid"])
+        joined_errors = " ".join(results["errors"])
+        self.assertIn("overview", joined_errors)
+        self.assertIn("commands", joined_errors)
+
     def test_validate_nonexistent_file(self):
         """Test validation handles nonexistent file."""
         results = validate_claude_md(self.temp_path / "nonexistent.md")
@@ -767,6 +859,86 @@ class TestExecuteCreate(unittest.TestCase):
 
         self.assertFalse(result["success"])
         self.assertIn("already exists", result["message"])
+
+    def test_create_user_scope_persists_responses(self):
+        """User-scope create wires --responses payload into template_vars.
+
+        Regression for #98: previously execute_create only built
+        template_vars from project-scope keys, so user-scope responses
+        (default_behaviors / patterns / tool_config) were silently
+        dropped and the file rendered with placeholder text while the
+        operation still returned success:true.
+        """
+        import os
+        os.chdir(self.temp_path)
+
+        fake_home = self.temp_path / "fake_home"
+        (fake_home / ".claude").mkdir(parents=True)
+
+        responses = {
+            "default_behaviors": "Be terse. No emojis.",
+            "patterns": "Conventional commits everywhere.",
+            "tool_config": "VS Code; iTerm2; 1Password CLI.",
+        }
+        context = {"operation": "create", "scope": "user"}
+
+        with mock.patch.object(Path, "home", return_value=fake_home):
+            result = execute(context, responses, TEMPLATES_DIR)
+
+        self.assertTrue(result["success"], result.get("message"))
+
+        written = (fake_home / ".claude" / "CLAUDE.md").read_text()
+        self.assertIn("Be terse. No emojis.", written)
+        self.assertIn("Conventional commits everywhere.", written)
+        self.assertIn("VS Code; iTerm2; 1Password CLI.", written)
+        # And the placeholder text must NOT be there
+        self.assertNotIn(
+            "Add your preferred default behaviors here.", written
+        )
+
+    def test_create_plugin_scope_persists_responses(self):
+        """Plugin-scope create wires --responses into template_vars.
+
+        Same root cause as #98: plugin.md.jinja2 references plugin_type,
+        provides, usage, config_options, extension_points — none were
+        threaded through before. Covered here to prevent the same
+        regression in the plugin-scope path.
+        """
+        import os
+        os.chdir(self.temp_path)
+        (self.temp_path / ".claude-plugin").mkdir()
+
+        responses = {
+            "plugin_type": "Skill collection",
+            "provides": ["agent-manager", "skill-manager"],
+            "usage": "Invoke /aida agent create to scaffold an agent.",
+            "config_options": "No runtime config — operates on files.",
+            "extension_points": "Drop new templates in templates/.",
+        }
+        context = {
+            "operation": "create",
+            "scope": "plugin",
+            "name": "Demo Plugin",
+            "description": "Demo plugin for testing.",
+        }
+
+        result = execute(context, responses, TEMPLATES_DIR)
+        self.assertTrue(result["success"], result.get("message"))
+
+        written = (
+            self.temp_path / ".claude-plugin" / "CLAUDE.md"
+        ).read_text()
+        self.assertIn("Skill collection", written)
+        self.assertIn("agent-manager", written)
+        self.assertIn(
+            "Invoke /aida agent create to scaffold an agent.", written
+        )
+        self.assertIn(
+            "No runtime config — operates on files.", written
+        )
+        self.assertIn(
+            "Drop new templates in templates/.", written
+        )
 
 
 class TestSafeJsonLoad(unittest.TestCase):


### PR DESCRIPTION
## Summary

- **#98 (Major)**: \`claude-md-manager create --scope user\` silently dropped the \`--responses\` payload — files rendered with placeholder text while the operation returned \`success:true\`. \`execute_create\` now selects the variable set that matches scope. Plugin-scope had the same latent bug (\`plugin_type\`, \`provides\`, \`usage\`, \`config_options\`, \`extension_points\` all unwired) and is fixed in the same change.
- **#99 (Minor)**: \`claude-md-manager validate\` applied project-scope required sections (\`overview\`, \`commands\`) to every file, so well-formed user-scope or plugin-scope files were flagged invalid. \`REQUIRED_SECTIONS\` is now scope-keyed; \`validate_claude_md\` / \`calculate_audit_score\` / \`generate_audit_findings\` accept an optional \`scope\` (default \`project\`); callers thread per-file scope from \`file_info[\"scope\"]\`.

## Test plan

- [x] \`pytest tests/unit/test_claude_md.py\` — 60 pass (5 new)
- [x] \`pytest\` full suite — 911 pass (was 906)
- [x] \`ruff check\` clean on changed files
- [x] \`reuse lint\` — 318/318 files, REUSE 3.3 compliant
- [x] Version bump 1.5.1 → 1.5.2 + matching CHANGELOG entry (version-check workflow expectations met)

## New tests

- \`test_create_user_scope_persists_responses\` — confirms \`default_behaviors\` / \`patterns\` / \`tool_config\` reach the rendered file, mocks \`Path.home\` so it doesn't touch the real \`~/.claude/CLAUDE.md\`
- \`test_create_plugin_scope_persists_responses\` — same for plugin-scope keys
- \`test_validate_user_scope_no_required_sections\` — free-form user file with no overview/commands is valid
- \`test_validate_plugin_scope_no_required_sections\` — plugin file likewise
- \`test_validate_project_scope_still_requires_sections\` — guard against accidentally relaxing project-scope validation

## Notes

- Both bugs were reported on 1.1.5 but reproduced on 1.5.1
- Part of milestone **1.6.0 — Bug fixes**
- No behavioural API change for project-scope callers; new \`scope\` parameter defaults preserve old behavior

Closes #98
Closes #99