### PR TITLE
fix: AIDA-generated YAML is yamllint-default clean (1.5.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,43 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3] - 2026-05-22
+
+### Fixed
+
+- `write_yaml` (`skills/aida/scripts/utils/files.py`) now emits a
+  `---` document-start marker and indents sequence items inside their
+  parent key (the expected yamllint-default shape). Affects
+  `.claude/aida-project-context.yml` and `.claude/aida-project-context.local.yml`,
+  which previously failed yamllint with `missing document start "---"`
+  and `wrong indentation: expected 4 but found 2` on nested sequences
+  like `tools.detected`. Implementation: new `_IndentedDumper`
+  (subclass of `yaml.SafeDumper`) overrides `increase_indent` to never
+  go indentless; `yaml.dump` is invoked with `explicit_start=True` and
+  this custom dumper. Fixes #81
+- The two string-concat YAML renderers — `render_aida_marker`
+  (`skills/aida/scripts/install.py`, writes `~/.claude/aida.yml`) and
+  `render_aida_project_marker` (`skills/aida/scripts/configure.py`,
+  writes `.claude/aida.yml`) — now prepend `---` to their output. The
+  comment header still sits at the top of the file, just after the
+  document marker. Fixes #97
+
+### Notes
+
+- All three generated files (`~/.claude/aida.yml`,
+  `.claude/aida.yml`, `.claude/aida-project-context.yml`) are now
+  clean against both the repo's own `.yamllint.yml` and the strict
+  yamllint defaults that scaffolded plugins enforce
+- New tests in `tests/unit/test_utils.py`:
+  `TestFiles.test_write_yaml_emits_document_start`,
+  `test_write_yaml_indents_nested_sequences`,
+  `test_write_yaml_roundtrip`,
+  `test_write_yaml_top_level_sequence`; plus four
+  `TestAidaYmlRenderers` cases for the install / configure renderers
+- Milestone: `1.6.0 — Bug fixes`
+
+---
+
 ## [1.5.2] - 2026-05-22
 
 ### Fixed

--- a/skills/aida/scripts/configure.py
+++ b/skills/aida/scripts/configure.py
@@ -183,8 +183,11 @@ def render_aida_project_marker(preferences: Dict[str, Any], project_name: str) -
     if "documentation_level" in preferences:
         config["documentation_level"] = preferences["documentation_level"]
 
-    # Build YAML content
-    content = f"""# AIDA Project Configuration Marker
+    # Build YAML content. Leading `---` is required for yamllint's
+    # default `document-start` rule (which the scaffolder enforces in
+    # every plugin we generate).
+    content = f"""---
+# AIDA Project Configuration Marker
 # This file indicates AIDA is configured for this project
 version: "{AIDA_VERSION}"
 configured: "{timestamp}"

--- a/skills/aida/scripts/install.py
+++ b/skills/aida/scripts/install.py
@@ -304,8 +304,11 @@ def render_aida_marker(detected_data: Dict[str, Any]) -> str:
     # Extract relevant metadata
     plugins = ["aida-core"]
 
-    # Build YAML content (metadata only - NO preferences)
-    content = f"""# AIDA Installation Marker
+    # Build YAML content (metadata only - NO preferences).
+    # Leading `---` is required for yamllint's default `document-start`
+    # rule, which the scaffolder enforces in every plugin we generate.
+    content = f"""---
+# AIDA Installation Marker
 # This file indicates AIDA is installed and tracks metadata
 # User preferences are stored in ~/.claude/skills/user-context/SKILL.md
 version: "{AIDA_VERSION}"

--- a/skills/aida/scripts/utils/files.py
+++ b/skills/aida/scripts/utils/files.py
@@ -16,6 +16,32 @@ from typing import Any, Dict, Optional
 import yaml
 HAS_YAML = True
 
+
+class _IndentedDumper(yaml.SafeDumper):
+    """SafeDumper that indents sequence items inside their parent.
+
+    PyYAML's default emits sequences flush with the parent key:
+
+        tools:
+          detected:
+          - Git
+          - GitHub Actions
+
+    yamllint's `indentation` rule (with `indent-sequences: true`, the
+    default) expects sequence items indented one level deeper:
+
+        tools:
+          detected:
+            - Git
+            - GitHub Actions
+
+    Overriding `increase_indent` to never go indentless restores the
+    expected indentation.
+    """
+
+    def increase_indent(self, flow=False, indentless=False):
+        return super().increase_indent(flow, False)
+
 # Try to import fcntl for Unix file locking
 try:
     import fcntl
@@ -245,7 +271,19 @@ def write_yaml(path: Path, data: Dict[str, Any], create_parents: bool = True) ->
         >>> write_yaml(Path("config.yml"), {"setting": "value"})
     """
     try:
-        content = yaml.dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True)
+        # explicit_start emits a `---` document marker; the custom
+        # Dumper indents sequences inside their parent. Together these
+        # produce yamllint-default-clean output so consumers (including
+        # every scaffolded plugin that enforces yamllint) don't have
+        # to special-case AIDA-generated files.
+        content = yaml.dump(
+            data,
+            Dumper=_IndentedDumper,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+            explicit_start=True,
+        )
         write_file(path, content, create_parents=create_parents)
 
     except yaml.YAMLError as e:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -36,6 +36,7 @@ from utils import (
     write_file,
     read_json,
     write_json,
+    write_yaml,
     update_json,
     copy_template,
     file_exists,
@@ -352,6 +353,160 @@ class TestFiles(unittest.TestCase):
             self.assertTrue(directory_exists(test_dir))
             self.assertFalse(directory_exists(Path(tmpdir) / "missing"))
             self.assertFalse(directory_exists(Path(tmpdir) / "file.txt"))
+
+    def test_write_yaml_emits_document_start(self):
+        """write_yaml output must start with `---`.
+
+        Regression for #97: yamllint's default `document-start` rule
+        requires a `---` marker, and the scaffolder enforces this rule
+        in every plugin it generates. AIDA-generated YAML must clear
+        the same bar.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "config.yml"
+            write_yaml(test_file, {"key": "value"})
+
+            content = test_file.read_text(encoding="utf-8")
+            self.assertTrue(
+                content.startswith("---\n"),
+                f"output must start with '---'; got: {content!r}",
+            )
+
+    def test_write_yaml_indents_nested_sequences(self):
+        """Sequence items must be indented inside their parent key.
+
+        Regression for #81 and #97: PyYAML's default emits
+        `tools:\\n  detected:\\n  - Git` (items flush with parent at
+        column 2). yamllint's `indentation` rule with
+        `indent-sequences: true` (the default) expects items at column
+        4. The custom Dumper restores the expected indentation.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "context.yml"
+            write_yaml(
+                test_file,
+                {"tools": {"detected": ["Git", "GitHub Actions"]}},
+            )
+
+            content = test_file.read_text(encoding="utf-8")
+            # Sequence items must be at column 4 (4 leading spaces),
+            # not column 2 — the bug being fixed.
+            self.assertIn("    - Git\n", content)
+            self.assertIn("    - GitHub Actions\n", content)
+            # Stronger guard: assert the bug pattern literally isn't
+            # present by checking line-by-line rather than substring.
+            for line in content.splitlines():
+                if "- Git" in line:
+                    self.assertTrue(
+                        line.startswith("    - "),
+                        f"Sequence item under-indented: {line!r}",
+                    )
+
+    def test_write_yaml_roundtrip(self):
+        """Round-trip through write_yaml + yaml.safe_load preserves data.
+
+        Guards against the new Dumper accidentally mangling content.
+        """
+        import yaml
+
+        data = {
+            "version": "1.5.2",
+            "project": {"name": "demo"},
+            "tools": {"detected": ["Git", "GitHub Actions"]},
+            "plugins": ["aida-core"],
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "roundtrip.yml"
+            write_yaml(test_file, data)
+            loaded = yaml.safe_load(
+                test_file.read_text(encoding="utf-8")
+            )
+
+            self.assertEqual(loaded, data)
+
+    def test_write_yaml_top_level_sequence(self):
+        """A top-level sequence still renders correctly.
+
+        Indentless-sequence is only inappropriate inside a mapping; a
+        bare top-level list should still emit `- item` at column 0.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = Path(tmpdir) / "list.yml"
+            write_yaml(test_file, ["alpha", "beta"])
+
+            content = test_file.read_text(encoding="utf-8")
+            self.assertTrue(content.startswith("---\n"))
+            self.assertIn("- alpha\n", content)
+            self.assertIn("- beta\n", content)
+
+
+class TestAidaYmlRenderers(unittest.TestCase):
+    """Test the YAML marker renderers in install.py and configure.py.
+
+    Both render via string concatenation (not write_yaml), so the
+    `document-start` fix is local to each. These guards keep the
+    yamllint-clean shape from drifting back.
+    """
+
+    def test_render_aida_marker_starts_with_doc_start(self):
+        """Global ~/.claude/aida.yml must start with `---`. (#97)"""
+        from install import render_aida_marker
+
+        content = render_aida_marker({})
+
+        self.assertTrue(
+            content.startswith("---\n"),
+            f"render_aida_marker output must start with '---'; "
+            f"got first line: {content.splitlines()[0]!r}",
+        )
+
+    def test_render_aida_marker_is_yamllint_compatible(self):
+        """Generated content must parse as valid YAML.
+
+        Cheap structural check — doesn't pull in yamllint as a runtime
+        dep, but catches gross syntax regressions from the renderer.
+        """
+        import yaml
+        from install import render_aida_marker
+
+        content = render_aida_marker({})
+        loaded = yaml.safe_load(content)
+
+        self.assertIsInstance(loaded, dict)
+        self.assertIn("version", loaded)
+        self.assertIn("plugins", loaded)
+
+    def test_render_aida_project_marker_starts_with_doc_start(self):
+        """Project .claude/aida.yml must start with `---`. (#97)"""
+        from configure import render_aida_project_marker
+
+        content = render_aida_project_marker(
+            preferences={"project_type": "Plugin"},
+            project_name="demo",
+        )
+
+        self.assertTrue(
+            content.startswith("---\n"),
+            f"render_aida_project_marker output must start with '---'; "
+            f"got first line: {content.splitlines()[0]!r}",
+        )
+
+    def test_render_aida_project_marker_is_yamllint_compatible(self):
+        """Generated project marker content must parse as valid YAML."""
+        import yaml
+        from configure import render_aida_project_marker
+
+        content = render_aida_project_marker(
+            preferences={
+                "project_type": "Plugin",
+                "team_collaboration": "Open source",
+            },
+            project_name="demo",
+        )
+        loaded = yaml.safe_load(content)
+
+        self.assertIsInstance(loaded, dict)
+        self.assertEqual(loaded["project"]["name"], "demo")
 
 
 class TestQuestionnaire(unittest.TestCase):


### PR DESCRIPTION
## Summary

Three generators were emitting YAML that failed yamllint default rules. The scaffolder enforces those same rules in every plugin it generates, so downstream projects hit hard errors on AIDA-written files inside \`.claude/\`.

- **\`write_yaml\`** (\`skills/aida/scripts/utils/files.py\`) — new \`_IndentedDumper\` subclasses \`yaml.SafeDumper\` and overrides \`increase_indent\` so nested sequences indent inside their parent key. \`yaml.dump\` now called with \`explicit_start=True\`. Fixes the \`tools.detected\` indentation and document-start failures on \`.claude/aida-project-context.yml\` (and \`.local.yml\`).
- **\`render_aida_marker\`** (install.py) and **\`render_aida_project_marker\`** (configure.py) use string concat — each now prepends \`---\\n\`. Fixes document-start on \`~/.claude/aida.yml\` and \`.claude/aida.yml\`.

## Test plan

- [x] \`pytest tests/unit/test_utils.py\` — 82 pass (8 new)
- [x] \`pytest\` full suite — 919 pass (was 911)
- [x] \`ruff check\` clean on changed files
- [x] Generated all three files in a scratch dir and ran yamllint against:
  - the repo's own \`.yamllint.yml\` (exit 0)
  - strict yamllint defaults (exit 0)
- [x] Version bump 1.5.2 → 1.5.3 + CHANGELOG entry

## New tests

\`TestFiles\` (write_yaml):
- \`test_write_yaml_emits_document_start\` — output starts with \`---\`
- \`test_write_yaml_indents_nested_sequences\` — sequence items at column 4 under depth-2 key
- \`test_write_yaml_roundtrip\` — yaml.safe_load preserves data through write
- \`test_write_yaml_top_level_sequence\` — top-level lists still render correctly

\`TestAidaYmlRenderers\` (install + configure renderers):
- \`test_render_aida_marker_starts_with_doc_start\`
- \`test_render_aida_marker_is_yamllint_compatible\`
- \`test_render_aida_project_marker_starts_with_doc_start\`
- \`test_render_aida_project_marker_is_yamllint_compatible\`

## Notes

- Two-for-one: closes #81 and #97. Different code paths, shared root theme (yamllint-default compliance for generated files).
- Part of milestone **1.6.0 — Bug fixes**.
- No behavioural change for callers — produces strictly cleaner output, same data shape.

Closes #81
Closes #97