### PR TITLE
fix: configure.py mechanical bugs — dead plugin ref + option-count cap (1.5.4)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,42 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.4] - 2026-05-22
+
+### Fixed
+
+- `configure.py` `render_aida_project_marker` previously hardcoded
+  `plugins = ["aida-workflow-commands"]`, planting a dead reference
+  in every generated `.claude/aida.yml` — `aida-workflow-commands`
+  isn't a real plugin. The default is now an empty list; projects
+  add entries via `/aida config` or by editing the file. Fixes #83
+- `configure.py` `get_questions` defined two choice questions with
+  more options than `AskUserQuestion` accepts (cap is 4 plus the
+  always-supplied "Other"): `branching_model` had 6 options,
+  `issue_tracking` had 5. Both are trimmed to 4 mutually-exclusive
+  named choices; the reserved "Custom workflow" / "No specific
+  model" / unsupported-tracker cases fall through to the built-in
+  "Other". Help text updated to point users at "Other" for those
+  edge cases. Fixes #85
+
+### Added
+
+- `tests/unit/test_utils.py::TestConfigureQuestionOptions` — scans
+  `configure.py` and asserts every choice question has ≤ 4 options.
+  Guards against the #85 family regressing when new questions are
+  added (since AskUserQuestion's option-cap isn't enforced at
+  question-definition time)
+- `test_render_aida_project_marker_omits_dead_plugin_reference` —
+  regression guard for #83
+
+### Notes
+
+- The reporter on #85 only mentioned `branching_model`; the same
+  latent bug was present on `issue_tracking` and is included
+- Milestone: `1.6.0 — Bug fixes`
+
+---
+
 ## [1.5.3] - 2026-05-22
 
 ### Fixed

--- a/skills/aida/scripts/configure.py
+++ b/skills/aida/scripts/configure.py
@@ -44,7 +44,7 @@ import logging
 import traceback
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Dict, List
 
 import _paths  # noqa: F401
 
@@ -169,8 +169,12 @@ def render_aida_project_marker(preferences: Dict[str, Any], project_name: str) -
     """
     timestamp = datetime.now(timezone.utc).isoformat()
 
-    # Extract relevant preferences for the marker file
-    plugins = ["aida-workflow-commands"]
+    # Plugins enabled for this project. Starts empty — projects add
+    # entries via /aida config (plugins selection) or by editing the
+    # file directly. Previously hardcoded to "aida-workflow-commands",
+    # which doesn't exist as a plugin and produced a dead reference
+    # in every generated aida.yml (#83).
+    plugins: List[str] = []
 
     # Build configuration section from preferences
     config = {}
@@ -601,38 +605,50 @@ def get_questions(context: Dict[str, Any]) -> Dict[str, Any]:
     preferences = project_config.get("preferences", {})
     questions = []
 
-    # Branching model (ask if null and using git)
+    # Branching model (ask if null and using git).
+    # Capped at 4 mutually-exclusive named models — AskUserQuestion
+    # caps at 4 options and supplies its own "Other" automatically,
+    # which covers "Custom workflow" and "No specific model" (#85).
     if preferences.get("branching_model") is None and project_config["vcs"]["type"] == "git":
         questions.append({
             "id": "branching_model",
             "question": "What branching model does this project follow?",
             "type": "choice",
             "required": True,
-            "help": "AIDA will suggest branch names and merge strategies based on this model",
+            "help": (
+                "AIDA suggests branch names and merge strategies "
+                "based on this model. Pick 'Other' if your project "
+                "uses a custom workflow or no specific model."
+            ),
             "options": [
                 "GitHub Flow (feature branches → main)",
                 "Git Flow (main, develop, feature, release, hotfix)",
                 "GitLab Flow (feature branches → main → environments)",
                 "Trunk-based (commit directly to main, short-lived branches)",
-                "Custom workflow",
-                "No specific model"
             ]
         })
 
-    # Issue tracking (ask if null, but already defaulted to GitHub Issues if GitHub)
+    # Issue tracking (ask if null, but already defaulted to GitHub
+    # Issues if GitHub). Capped at 4 — AskUserQuestion adds its own
+    # "Other" so users on Linear, Asana, etc. can type it in. The
+    # explicit "Other (not supported …)" entry was redundant with
+    # that built-in (#85).
     if preferences.get("issue_tracking") is None:
         questions.append({
             "id": "issue_tracking",
             "question": "What issue tracking system does this project use?",
             "type": "choice",
             "required": True,
-            "help": "AIDA provides native MCP integration for GitHub and JIRA/Atlassian",
+            "help": (
+                "AIDA provides native MCP integration for GitHub and "
+                "JIRA/Atlassian. Pick 'Other' for anything else and "
+                "note the system in your project conventions."
+            ),
             "options": [
                 "GitHub Issues",
                 "GitHub Projects (project board)",
                 "JIRA/Atlassian",
                 "None - informal tracking only",
-                "Other (not supported - specify in conventions)"
             ]
         })
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -508,6 +508,80 @@ class TestAidaYmlRenderers(unittest.TestCase):
         self.assertIsInstance(loaded, dict)
         self.assertEqual(loaded["project"]["name"], "demo")
 
+    def test_render_aida_project_marker_omits_dead_plugin_reference(self):
+        """`aida-workflow-commands` is not a real plugin — must not appear.
+
+        Regression for #83: the renderer previously hardcoded
+        `plugins = ["aida-workflow-commands"]`, putting a dead
+        reference into every generated .claude/aida.yml.
+        """
+        import yaml
+        from configure import render_aida_project_marker
+
+        content = render_aida_project_marker(
+            preferences={}, project_name="demo"
+        )
+        self.assertNotIn("aida-workflow-commands", content)
+
+        loaded = yaml.safe_load(content)
+        # `plugins:` section may be empty (or absent) but must not
+        # contain the dead reference.
+        plugins = loaded.get("plugins") or []
+        self.assertNotIn("aida-workflow-commands", plugins)
+
+
+class TestConfigureQuestionOptions(unittest.TestCase):
+    """Guard against the #85 family: choice questions exceeding the
+    AskUserQuestion 4-option cap.
+
+    AskUserQuestion's JSON schema caps `options` at 4 items per
+    question (the user always gets a free "Other" on top of that).
+    Any choice question in configure.py that ships with > 4 options
+    is undeliverable to the user. This test scans the source and
+    asserts every choice question is within cap, so future additions
+    don't reintroduce the bug.
+    """
+
+    ASK_USER_QUESTION_OPTION_CAP = 4
+
+    def test_choice_questions_respect_option_cap(self):
+        import re
+
+        configure_path = (
+            Path(__file__).parent.parent.parent
+            / "skills"
+            / "aida"
+            / "scripts"
+            / "configure.py"
+        )
+        source = configure_path.read_text(encoding="utf-8")
+
+        # Match each question dict: capture id and the options list.
+        # Non-greedy across whitespace/lines. Tolerant of trailing
+        # comma after the closing bracket of options.
+        pattern = re.compile(
+            r'"id":\s*"(?P<id>[^"]+)"'
+            r"[\s\S]*?"
+            r'"options":\s*\[(?P<opts>[\s\S]*?)\]',
+        )
+
+        offenders = []
+        for m in pattern.finditer(source):
+            qid = m.group("id")
+            opts = re.findall(r'"([^"]+)"', m.group("opts"))
+            if len(opts) > self.ASK_USER_QUESTION_OPTION_CAP:
+                offenders.append((qid, len(opts), opts))
+
+        self.assertEqual(
+            offenders,
+            [],
+            "Choice questions exceed AskUserQuestion's 4-option cap:\n"
+            + "\n".join(
+                f"  {qid}: {n} options ({opts})"
+                for qid, n, opts in offenders
+            ),
+        )
+
 
 class TestQuestionnaire(unittest.TestCase):
     """Test questionnaire system."""
@@ -1253,6 +1327,8 @@ def run_tests():
     suite.addTests(loader.loadTestsFromTestCase(TestVersion))
     suite.addTests(loader.loadTestsFromTestCase(TestPaths))
     suite.addTests(loader.loadTestsFromTestCase(TestFiles))
+    suite.addTests(loader.loadTestsFromTestCase(TestAidaYmlRenderers))
+    suite.addTests(loader.loadTestsFromTestCase(TestConfigureQuestionOptions))
     suite.addTests(loader.loadTestsFromTestCase(TestQuestionnaire))
     suite.addTests(loader.loadTestsFromTestCase(TestTemplateRendering))
     suite.addTests(loader.loadTestsFromTestCase(TestIntegration))


### PR DESCRIPTION
## Summary

Two small unrelated bugs in \`skills/aida/scripts/configure.py\`:

- **#83**: \`render_aida_project_marker\` hardcoded \`plugins = [\"aida-workflow-commands\"]\` — \`aida-workflow-commands\` isn't a real plugin. Every generated \`.claude/aida.yml\` carried a dead reference. Default is now an empty list.
- **#85**: Two \`get_questions\` choice questions exceeded AskUserQuestion's 4-option cap. \`branching_model\` had 6 options; \`issue_tracking\` had 5 (the reporter only mentioned branching, but issue_tracking was the same latent bug). Both trimmed to 4 mutually-exclusive named choices; the built-in \"Other\" covers what was dropped, and help text now points users at it.

## Test plan

- [x] \`pytest\` — 921 pass (was 919, +2 new)
- [x] \`ruff check\` clean on changed files
- [x] Version bump 1.5.3 → 1.5.4 + CHANGELOG entry

## New tests

- \`TestAidaYmlRenderers.test_render_aida_project_marker_omits_dead_plugin_reference\` — direct regression guard for #83
- \`TestConfigureQuestionOptions.test_choice_questions_respect_option_cap\` — scans configure.py and asserts **every** choice question has ≤ 4 options. Future additions can't reintroduce the #85 family.

## Notes

- AskUserQuestion supplies its own \"Other\" so we don't lose user flexibility; the cap is structural
- Part of milestone **1.6.0 — Bug fixes**

Closes #83
Closes #85