### PR TITLE
test: regression guard for scaffolded ci.yml YAML parse (#74, 1.5.5)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.5] - 2026-05-22
+
+### Added
+
+- `tests/unit/test_scaffold.py::TestScaffoldedCiYamlParses` —
+  regression test that scaffolds a full Python plugin and a full
+  TypeScript plugin, then asserts the generated
+  `.github/workflows/ci.yml` parses as YAML and that the
+  `Set up Python` / `Set up Node` step doesn't mash `name:` and
+  `uses:` onto a single line. Closes #74 (the underlying parse error
+  was fixed in 1.5.0 by switching the templates from
+  `{% raw %}…{% endraw %}` to Jinja-literal `${{ '{{' }}…{{ '}}' }}`,
+  but no test pinned the fix — so any future template change in the
+  same shape could silently reintroduce it).
+
+### Notes
+
+- No behavior change in this release; the underlying bug has been
+  fixed since 1.5.0
+- Milestone: `1.6.0 — Bug fixes`
+
+---
+
 ## [1.5.4] - 2026-05-22
 
 ### Fixed

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -186,6 +186,117 @@ class TestExecuteTypeScriptProject(unittest.TestCase):
             self.assertTrue((target_path / "vitest.config.ts").exists())
 
 
+class TestScaffoldedCiYamlParses(unittest.TestCase):
+    """Regression guard for #74: scaffolded ci.yml must be valid YAML.
+
+    The original bug used `{% raw %}…{% endraw %}` blocks to escape
+    GitHub Actions `${{ … }}` expressions. With Jinja2's
+    `trim_blocks=True`, `{% endraw %}` ate the trailing newline so
+    `name:` and `uses:` ended up concatenated on a single line,
+    producing a YAML parse error on the very first CI run of every
+    scaffolded plugin. Fix landed in 1.5.0 by switching to
+    `${{ '{{' }}…{{ '}}' }}` Jinja literals. This test pins the fix
+    so any future template change that reintroduces the same shape
+    fails loudly here instead of silently in user repos.
+    """
+
+    @patch.object(_scaffold_mod, "initialize_git", return_value=True)
+    @patch.object(_scaffold_mod, "create_initial_commit", return_value=True)
+    def test_python_scaffold_ci_yml_parses(self, mock_commit, mock_git):
+        import yaml
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target = str(Path(tmp) / "py-plugin")
+            context = {
+                "plugin_name": "py-plugin",
+                "description": "A Python plugin for #74 regression testing",
+                "license": "MIT",
+                "language": "python",
+                "target_directory": target,
+                "author_name": "Test Author",
+                "author_email": "test@example.com",
+                "keywords": "",
+                "version": "0.1.0",
+            }
+            result = execute(context)
+            self.assertTrue(result["success"], result.get("message"))
+
+            ci_yml = (
+                Path(result["path"]) / ".github" / "workflows" / "ci.yml"
+            )
+            self.assertTrue(
+                ci_yml.exists(), f"ci.yml not generated at {ci_yml}"
+            )
+
+            # Must parse without raising — the original bug raised
+            # yaml.YAMLError on the mashed-together name/uses line.
+            content = ci_yml.read_text(encoding="utf-8")
+            parsed = yaml.safe_load(content)
+            self.assertIsInstance(parsed, dict)
+            self.assertEqual(parsed.get("name"), "CI")
+
+            # And specifically: the `name: Set up Python` step must
+            # have its own line, with `uses:` on the next line.
+            lines = content.splitlines()
+            for i, line in enumerate(lines):
+                if "Set up Python" in line and "name:" in line:
+                    self.assertNotIn(
+                        "uses:",
+                        line,
+                        f"`name:` and `uses:` mashed on line {i + 1}: {line!r}",
+                    )
+                    break
+            else:
+                self.fail(
+                    "Expected a 'Set up Python' step in scaffolded ci.yml"
+                )
+
+    @patch.object(_scaffold_mod, "initialize_git", return_value=True)
+    @patch.object(_scaffold_mod, "create_initial_commit", return_value=True)
+    def test_typescript_scaffold_ci_yml_parses(self, mock_commit, mock_git):
+        import yaml
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target = str(Path(tmp) / "ts-plugin")
+            context = {
+                "plugin_name": "ts-plugin",
+                "description": "A TypeScript plugin for #74 regression testing",
+                "license": "MIT",
+                "language": "typescript",
+                "target_directory": target,
+                "author_name": "Test Author",
+                "author_email": "test@example.com",
+                "keywords": "",
+                "version": "0.1.0",
+            }
+            result = execute(context)
+            self.assertTrue(result["success"], result.get("message"))
+
+            ci_yml = (
+                Path(result["path"]) / ".github" / "workflows" / "ci.yml"
+            )
+            self.assertTrue(ci_yml.exists())
+
+            content = ci_yml.read_text(encoding="utf-8")
+            parsed = yaml.safe_load(content)
+            self.assertIsInstance(parsed, dict)
+            self.assertEqual(parsed.get("name"), "CI")
+
+            lines = content.splitlines()
+            for i, line in enumerate(lines):
+                if "Set up Node" in line and "name:" in line:
+                    self.assertNotIn(
+                        "uses:",
+                        line,
+                        f"`name:` and `uses:` mashed on line {i + 1}: {line!r}",
+                    )
+                    break
+            else:
+                self.fail(
+                    "Expected a 'Set up Node' step in scaffolded ci.yml"
+                )
+
+
 class TestExecuteWithAgentStub(unittest.TestCase):
     """Test execute with agent stub."""
 


### PR DESCRIPTION
## Summary

The underlying YAML parse error in scaffolded \`ci.yml\` was fixed in **1.5.0** (PR #79) by switching the python/ and typescript/ \`ci.yml.jinja2\` templates from \`{% raw %}…{% endraw %}\` to Jinja-literal \`\${{ '{{' }}…{{ '}}' }}\`. But no test pinned the fix, so a future template tweak in the same shape would silently reintroduce the bug — and downstream plugin authors would only discover it on the very first failed CI run.

This PR adds two tests in \`TestScaffoldedCiYamlParses\` that:

- Scaffold a full Python plugin and a full TypeScript plugin into a temp dir
- Assert \`.github/workflows/ci.yml\` exists
- Assert it parses as YAML via \`yaml.safe_load\`
- Assert the \"Set up Python\" / \"Set up Node\" step keeps \`name:\` and \`uses:\` on **separate** lines (the original bug's specific shape)

## Test plan

- [x] \`pytest\` — 923 pass (was 921, +2 regression tests)
- [x] \`ruff check\` clean
- [x] Version bump 1.5.4 → 1.5.5 + CHANGELOG entry

## Notes

- **No behavioral change** in this release — the underlying bug has been fixed since 1.5.0; this PR just makes the fix permanent
- Part of milestone **1.6.0 — Bug fixes**
- The reporter on #74 also flagged a separate Node 24 / setup-node@v4 sunset concern (GitHub forces JS-based actions to Node 24 on 2026-06-02; Node 20 removed 2026-09-16). That's a real follow-up but distinct from the parse-error fix — happy to file as a new issue if you want.

Closes #74