### PR TITLE
test: regression guard for narrow .claude/ gitignore (#95, 1.5.6)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,27 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.6] - 2026-05-22
+
+### Added
+
+- `tests/unit/test_scaffold_generators.py::TestAssembleGitignore::test_gitignore_does_not_blanket_ignore_claude_dir`
+  — regression guard for #95. Asserts that the scaffolded
+  `.gitignore` contains the narrow exclusion
+  `.claude/settings.local.json` and does **not** contain a bare
+  `.claude/` line that would shadow `/aida config` outputs (which
+  are committable team-shared state). The bug was fixed in PR #62
+  (commit `48a882c`) by switching the template from `.claude/` to
+  `.claude/settings.local.json`; this test pins the fix.
+
+### Notes
+
+- No behavior change in this release; the underlying bug has been
+  fixed since PR #62
+- Milestone: `1.6.0 — Bug fixes`
+
+---
+
 ## [1.5.5] - 2026-05-22
 
 ### Added

--- a/tests/unit/test_scaffold_generators.py
+++ b/tests/unit/test_scaffold_generators.py
@@ -261,6 +261,52 @@ class TestAssembleGitignore(unittest.TestCase):
 
             self.assertNotEqual(py_content, ts_content)
 
+    def test_gitignore_does_not_blanket_ignore_claude_dir(self):
+        """Regression: gitignore must not blanket-ignore .claude/.
+
+        #95: a bare `.claude/` entry shadows the shared project config
+        that `/aida config` writes (aida.yml, aida-project-context.yml,
+        rendered project-context skill) — those are *committable*
+        team-shared state, not user-local. The convention is to ignore
+        only `.claude/settings.local.json` (Claude Code's own
+        local-overrides file).
+
+        Fixed in PR #62 (commit 48a882c). This test pins the fix so a
+        future template edit can't silently reintroduce the broad
+        pattern.
+        """
+        for lang in ("python", "typescript"):
+            with tempfile.TemporaryDirectory() as tmp:
+                target = Path(tmp)
+                assemble_gitignore(target, lang, TEMPLATES_DIR)
+                content = (target / ".gitignore").read_text()
+
+                # The narrow, correct exclusion must be present.
+                self.assertIn(
+                    ".claude/settings.local.json",
+                    content,
+                    f"{lang}: gitignore must exclude "
+                    f"settings.local.json",
+                )
+
+                # The broad pattern must NOT appear as a standalone
+                # ignore line. Check line-by-line (substring would
+                # false-positive on `.claude/settings.local.json`).
+                for line in content.splitlines():
+                    stripped = line.strip()
+                    self.assertNotEqual(
+                        stripped,
+                        ".claude/",
+                        f"{lang}: gitignore has blanket '.claude/' "
+                        f"that would shadow shared project config",
+                    )
+                    self.assertNotEqual(
+                        stripped,
+                        ".claude",
+                        f"{lang}: gitignore has blanket '.claude' "
+                        f"that would shadow shared project config",
+                    )
+
 
 class TestAssembleMakefile(unittest.TestCase):
     """Test Makefile assembly."""


### PR DESCRIPTION
## Summary

The underlying bug behind #95 was already fixed in **PR #62** (commit \`48a882c\`) by switching \`gitignore-shared.jinja2\` from blanket-ignoring \`.claude/\` to ignoring only \`.claude/settings.local.json\`. But no test pinned the fix, so a future template edit could silently reintroduce the broad pattern and shadow the team-shared project config that \`/aida config\` writes (\`.claude/aida.yml\`, \`.claude/aida-project-context.yml\`, the rendered project-context skill).

This PR adds \`test_gitignore_does_not_blanket_ignore_claude_dir\` to \`TestAssembleGitignore\`. It runs against both Python and TypeScript scaffolds and asserts:

- The narrow exclusion \`.claude/settings.local.json\` is present
- No standalone \`.claude/\` or \`.claude\` line appears (line-by-line check — substring would false-positive on the narrow pattern)

## Test plan

- [x] \`pytest tests/unit/test_scaffold_generators.py::TestAssembleGitignore\` — 4 pass (1 new)
- [x] \`pytest\` full suite — 924 pass (was 923, +1)
- [x] \`ruff check\` clean
- [x] Version bump 1.5.5 → 1.5.6 + CHANGELOG entry

## Notes

- **No behavior change**; the underlying bug has been fixed since PR #62
- Part of milestone **1.6.0 — Bug fixes**
- #91 (flavor-aware .gitignore) is a separate feature — not in scope for 1.6.0

Closes #95