### PR TITLE
chore: pin slim gitignore policy with tests + docs (#91, 1.5.7)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,43 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.7] - 2026-05-22
+
+### Added
+
+- **Gitignore policy documentation** — new "Gitignore Policy" section
+  in `skills/plugin-manager/references/scaffolding-workflow.md`
+  describing the slim-fragment composition (shared + per-language),
+  the forbidden patterns list, the 50-line size budget, and the
+  background that motivates it (#91)
+- **Slimness regression tests** in
+  `tests/unit/test_scaffold_generators.py::TestAssembleGitignore`:
+  - `test_gitignore_avoids_broad_file_name_blanket_patterns` —
+    asserts the assembled `.gitignore` does not contain `lib/`,
+    `*secrets*`, `*credentials*`, `*.key`, `*.pem`, or `*.env*` (the
+    specific patterns that caused the reporter's 11-file data loss
+    in the original #91 incident)
+  - `test_gitignore_stays_slim` — caps any language's assembled
+    `.gitignore` at 50 lines. If a language needs more, add a new
+    fragment rather than expanding an existing one
+
+### Notes
+
+- Audit finding: the AIDA plugin scaffold already met #91's literal
+  criteria — `assemble_gitignore` composes slim shared +
+  per-language fragments, and the fragments don't contain the broad
+  name-based wildcards the issue called out. The reporter's
+  incident came from a separate monorepo's universal `.gitignore`,
+  not AIDA scaffold output. This release pins the slim design with
+  tests and docs so future contributions can't drift toward the
+  kitchen-sink shape that caused the original failure
+- Adding new flavors beyond `python` / `typescript` (e.g., `cdk`,
+  `dbt`, `metabase`, `docs-only`) is out of scope for AIDA's plugin
+  scaffold and would belong in a broader scaffolding tool
+- Closes the **1.6.0 — Bug fixes** milestone (9/9 issues resolved)
+
+---
+
 ## [1.5.6] - 2026-05-22
 
 ### Added

--- a/skills/plugin-manager/references/scaffolding-workflow.md
+++ b/skills/plugin-manager/references/scaffolding-workflow.md
@@ -68,6 +68,54 @@ All templates receive these variables:
 - Makefile targets: `lint-ts`, `test` (vitest), `build` (tsc), `format` (prettier)
 - `.gitignore` includes `node_modules/`, `dist/`, `coverage/`
 
+## Gitignore Policy
+
+The scaffolded `.gitignore` is composed from **slim, flavor-specific
+fragments**, not a universal kitchen-sink template. The intent is to
+ignore noise without silently swallowing legitimate files.
+
+### Fragment composition
+
+`assemble_gitignore(target, language, …)` concatenates two fragments:
+
+| Fragment | Path | Scope |
+| --- | --- | --- |
+| Shared | `shared/gitignore-shared.jinja2` | OS files, IDE/editor scratch, `.claude/settings.local.json` |
+| Language | `<lang>/gitignore-<lang>.jinja2` | Patterns specific to the toolchain (Python venv, Node `dist/`, etc.) |
+
+Each fragment is intentionally small — typically 10–16 patterns. New
+patterns should be **bounded** (directory suffix `/`, file extension
+`.<ext>`, anchored path), not name-based wildcards.
+
+### Forbidden patterns
+
+The following are banned by `test_gitignore_avoids_broad_file_name_blanket_patterns`:
+
+| Pattern | Why it's banned |
+| --- | --- |
+| `lib/` | Swallows AWS CDK / Node `lib/` directories that contain real code |
+| `*secrets*` | Matches legitimate filenames like `SecretsStack.ts` (manages secrets, doesn't contain them) |
+| `*credentials*` | Matches legitimate filenames like `CredentialsStack.ts` |
+| `*.key` | Would swallow JWT / crypto sample fixtures in tests |
+| `*.pem` | Would swallow PEM fixtures in tests |
+| `*.env*` | Would swallow `.env.example` / `.env.sample` which are committable |
+
+### Size budget
+
+The assembled `.gitignore` for any single language must stay under 50
+lines (enforced by `test_gitignore_stays_slim`). If a language needs
+more patterns than the budget allows, **add a new flavor fragment**
+rather than appending to an existing one — that's the slim-fragment
+design.
+
+### Background
+
+This policy exists because a kitchen-sink universal `.gitignore`
+silently dropped 11 files from a CDK repo migration (see #91). The
+fragments are small, predictable, and auditable: anything that lands
+in `.gitignore` should be traceable to a specific fragment and
+rationale.
+
 ## Error Handling
 
 | Error | Cause | Resolution |

--- a/tests/unit/test_scaffold_generators.py
+++ b/tests/unit/test_scaffold_generators.py
@@ -307,6 +307,94 @@ class TestAssembleGitignore(unittest.TestCase):
                         f"that would shadow shared project config",
                     )
 
+    def test_gitignore_avoids_broad_file_name_blanket_patterns(self):
+        """Regression: gitignore must not contain broad blanket
+        patterns that match by file *name* rather than location.
+
+        #91 background: the reporter scaffolded 9 repos using a
+        kitchen-sink monorepo `.gitignore` and silently lost 11 files
+        because patterns like `*secrets*`, `*credentials*`, and `lib/`
+        matched legitimate code:
+
+            - `lib/` swallowed an AWS CDK stack directory
+            - `*secrets*` swallowed `SecretsStack.ts` (which *manages*
+              secrets — it doesn't *contain* any)
+            - `*credentials*` swallowed similar `*CredentialsStack.ts`
+
+        AIDA's plugin scaffold already meets the slim-fragment design
+        the issue asks for (shared + per-language fragments, ~10-16
+        patterns each, no name-based blanket blocks). This test pins
+        that policy so future contributions can't drift toward the
+        kitchen-sink shape.
+        """
+        forbidden = {
+            "lib/": "matches CDK / Node lib directories",
+            "*secrets*": (
+                "matches legitimate filenames like SecretsStack.ts"
+            ),
+            "*credentials*": (
+                "matches legitimate filenames like CredentialsStack.ts"
+            ),
+            "*.key": "would swallow JWT / crypto sample fixtures",
+            "*.pem": "would swallow PEM fixtures in tests",
+            # `*.env*` would also match `.env.example` / `.env.sample`
+            # which teams typically want to commit.
+            "*.env*": "would swallow .env.example / .env.sample",
+        }
+
+        for lang in ("python", "typescript"):
+            with tempfile.TemporaryDirectory() as tmp:
+                target = Path(tmp)
+                assemble_gitignore(target, lang, TEMPLATES_DIR)
+                lines = [
+                    line.strip()
+                    for line in (target / ".gitignore")
+                    .read_text()
+                    .splitlines()
+                ]
+                for pattern, reason in forbidden.items():
+                    self.assertNotIn(
+                        pattern,
+                        lines,
+                        f"{lang} gitignore contains forbidden broad "
+                        f"pattern {pattern!r} — {reason}",
+                    )
+
+    def test_gitignore_stays_slim(self):
+        """Regression: the assembled gitignore must stay slim.
+
+        #91 motivation was a kitchen-sink universal gitignore that
+        silently swallowed legitimate files. AIDA's design is small,
+        flavor-specific fragments; that property is observable as a
+        line-count budget. The current python and typescript outputs
+        are ~30 lines each (including section comments and blank
+        lines). The budget below leaves slack for one or two more
+        narrow patterns per language without re-opening the door to
+        the kitchen-sink failure mode.
+
+        If you find yourself raising this budget, prefer adding a new
+        per-flavor fragment (see scaffolding-workflow.md > Gitignore
+        Policy) over appending more patterns to an existing one.
+        """
+        MAX_LINES = 50
+
+        for lang in ("python", "typescript"):
+            with tempfile.TemporaryDirectory() as tmp:
+                target = Path(tmp)
+                assemble_gitignore(target, lang, TEMPLATES_DIR)
+                line_count = len(
+                    (target / ".gitignore")
+                    .read_text()
+                    .splitlines()
+                )
+                self.assertLessEqual(
+                    line_count,
+                    MAX_LINES,
+                    f"{lang} gitignore is {line_count} lines, exceeds "
+                    f"slim budget of {MAX_LINES}. Either trim, or "
+                    f"split into a new per-flavor fragment.",
+                )
+
 
 class TestAssembleMakefile(unittest.TestCase):
     """Test Makefile assembly."""


### PR DESCRIPTION
## Summary

Audit finding: the AIDA plugin scaffold **already** meets #91's literal criteria. \`assemble_gitignore\` composes slim shared + per-language fragments (10–16 patterns each), and none of the broad name-based wildcards the issue called out are present in either fragment.

The reporter's 11-file data loss incident came from a **separate** monorepo's universal \`.gitignore\`, not from AIDA scaffold output.

This PR pins the slim-fragment design so future contributions can't drift back to the kitchen-sink shape:

- **\`test_gitignore_avoids_broad_file_name_blanket_patterns\`** — bans the exact patterns that caused the original incident: \`lib/\`, \`*secrets*\`, \`*credentials*\`, \`*.key\`, \`*.pem\`, \`*.env*\`
- **\`test_gitignore_stays_slim\`** — caps any language's assembled \`.gitignore\` at 50 lines. If a language needs more, add a new fragment rather than expanding an existing one
- **New \"Gitignore Policy\" section** in \`skills/plugin-manager/references/scaffolding-workflow.md\` documents the fragment composition, the forbidden patterns table, the size budget, and the background

## Out of scope

Adding new flavors beyond \`python\` / \`typescript\` (e.g., \`cdk\`, \`dbt\`, \`metabase\`, \`docs-only\`) is out of scope for AIDA's *plugin* scaffold. Those belong in a broader scaffolding tool, not the plugin manager.

## Test plan

- [x] \`pytest tests/unit/test_scaffold_generators.py::TestAssembleGitignore\` — 6 pass (2 new)
- [x] \`pytest\` full suite — 926 pass (was 924, +2)
- [x] \`ruff check\` clean
- [x] \`yamllint -c .yamllint.yml skills/\` clean
- [x] Version bump 1.5.6 → 1.5.7 + CHANGELOG entry

## Notes

- **Closes the 1.6.0 — Bug fixes milestone** (9/9 issues resolved)
- No behavioral change; purely policy + regression guards

Closes #91