### PR TITLE
fix: scaffold lint baseline that works on fresh installs (#82 #92, 1.5.8)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,66 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.8] - 2026-05-22
+
+### Fixed
+
+- **Scaffolded `lint-md` works on fresh installs** — Makefile now
+  invokes `npx --yes markdownlint-cli --config .markdownlint.json`
+  instead of bare `markdownlint`. TypeScript scaffolds get
+  `markdownlint-cli` in `devDependencies` so `npm install` brings
+  it in; Python scaffolds' CI now sets up Node via
+  `actions/setup-node@v4` so `npx` can resolve the tool. Previously
+  a fresh `make lint` on either flavor failed with
+  `markdownlint: No such file or directory`. Fixes #82 (bug 1)
+- **`yamllint` no longer scans vendored / generated directories** —
+  the scaffolded `.yamllint.yml` now has a top-level `ignore:`
+  block excluding `node_modules/`, `dist/`, `coverage/`, `build/`,
+  `__pycache__/`, `.venv/`, `venv/`, `.pytest_cache/`,
+  `.ruff_cache/`. Previously `yamllint -c .yamllint.yml .` walked
+  `node_modules/` and emitted hundreds of failures from
+  third-party YAML. Fixes #82 (bug 2)
+- **Markdownlint default rules tuned for AIDA prose** — the
+  scaffolded `.markdownlint.json` now disables rules that conflict
+  with valid skill / agent content: `MD022` (blanks around
+  headings), `MD032` (blanks around lists), `MD033` (inline HTML —
+  skill stubs use `<PRD>` / `<ticket>` placeholders), `MD034`
+  (bare URLs), `MD036` (`**Last updated:** …` footer pattern), and
+  `MD040` (fenced code language tags on plain output dumps).
+  Previously every scaffolded plugin failed lint on the very first
+  push from these rules firing on real prose. Fixes #82 (bug 3)
+  and #92
+
+### Added
+
+- **"Lint Policy" section** in
+  `skills/plugin-manager/references/scaffolding-workflow.md`
+  documenting the markdownlint rule table (with the *why* for each
+  disable), the yamllint config choices (including why
+  `document-start` stays on — the #81/#97 work in 1.5.3 makes our
+  generators emit `---`), and the Python-CI Node setup rationale
+- Regression tests in
+  `tests/unit/test_scaffold_generators.py::TestRenderSharedFiles`
+  and `tests/unit/test_scaffold.py::TestScaffoldedLintBaseline`
+  pinning all four fixes at the rendered-output level:
+  - yamllint config carries the required `ignore:` paths
+  - markdownlint config disables the required rules (`MD022`,
+    `MD025`, `MD032`, `MD033`, `MD034`, `MD036`, `MD040`, `MD041`)
+  - TypeScript `package.json` includes `markdownlint-cli` devDep
+  - Makefile uses `npx --yes markdownlint-cli` + explicit
+    `--config`, never bare `markdownlint`
+  - Python `ci.yml` includes `actions/setup-node@v4`
+
+### Notes
+
+- Verified end-to-end: scaffolded a Python plugin, added bogus YAML
+  inside a simulated `node_modules/`, ran `yamllint -c
+  .yamllint.yml .` — exit 0 (the ignore block successfully prunes
+  the noise)
+- Milestone: `Scaffold v2 — usable out of the box`
+
+---
+
 ## [1.5.7] - 2026-05-22
 
 ### Added

--- a/skills/plugin-manager/references/scaffolding-workflow.md
+++ b/skills/plugin-manager/references/scaffolding-workflow.md
@@ -116,6 +116,74 @@ fragments are small, predictable, and auditable: anything that lands
 in `.gitignore` should be traceable to a specific fragment and
 rationale.
 
+## Lint Policy
+
+The scaffolded plugin ships with `markdownlint`, `yamllint`, and
+language-specific linters (`ruff` for Python, `eslint`/`prettier` for
+TypeScript). The defaults are pre-tuned so a fresh scaffold lands
+**green on first `make lint`** — see #82 and #92 for the failure
+modes that motivated each choice.
+
+### markdownlint defaults
+
+`.markdownlint.json` disables the rules that flag valid AIDA-skill
+prose (template placeholders, tight technical text, footer patterns).
+The full set:
+
+| Rule | Setting | Why |
+| --- | --- | --- |
+| `MD013` | line_length 120, off for headings/code/tables | Long, descriptive prose in skill/agent files |
+| `MD022` | false | Tight knowledge docs omit blanks around headings |
+| `MD024` | `siblings_only: true` | Same heading text under different parents is fine |
+| `MD025` | false | Conflicts with frontmatter `title:` plus `# Heading` |
+| `MD032` | false | Tight technical lists without surrounding blanks |
+| `MD033` | false | Skill stubs use `<PRD>`, `<ticket>`, `<figma-url>` placeholders |
+| `MD034` | false | Bare URLs in references are intentional |
+| `MD036` | false | `**Last updated:** …` footer is convention, not heading |
+| `MD040` | false | Plain output dumps without language tags |
+| `MD041` | false | First line is frontmatter, not H1 |
+| `MD046` | `style: fenced` | Consistent code-block style |
+
+If you add a rule back, add a comment in the JSON explaining what
+real content it caught — `default: true` plus a small disable list
+is intentional friction against re-enabling rules that flag
+non-problems.
+
+### yamllint defaults
+
+`.yamllint.yml` extends the default ruleset with:
+
+- `ignore:` block excluding `node_modules/`, `dist/`, `coverage/`,
+  `build/`, `__pycache__/`, `.venv/`, `venv/`, `.pytest_cache/`,
+  `.ruff_cache/`. Without this, `yamllint -c .yamllint.yml .` walks
+  third-party YAML in `node_modules/` and emits hundreds of failures
+  (#82 bug 2)
+- `line-length` raised to 120
+- `truthy` accepts the common explicit values; `check-keys: false`
+  so GitHub Actions `on:` (parses as truthy) doesn't trip the rule
+- `document-start: present: true` is **kept on** — AIDA's own
+  generators (#81/#97 fix in 1.5.3) always emit a `---` marker, so
+  consumers should expect one
+
+### markdownlint invocation
+
+The Makefile uses `npx --yes markdownlint-cli --config .markdownlint.json`:
+
+- `npx --yes` resolves to the version in `devDependencies` for
+  TypeScript scaffolds (no global install needed after
+  `npm install`); on Python scaffolds, `--yes` suppresses the
+  install prompt so CI doesn't hang on first run
+- `--config` is passed explicitly because markdownlint-cli's
+  auto-discovery can silently miss the config when invoked through
+  `npx` from a non-package-root working directory
+
+### Python scaffold CI
+
+Python plugin CI installs Node.js via `actions/setup-node@v4` even
+though there's no JavaScript in the project. This is so `make lint`
+(which calls `lint-md` → `npx markdownlint-cli`) works without a
+manual install step.
+
 ## Error Handling
 
 | Error | Cause | Resolution |

--- a/skills/plugin-manager/templates/scaffold/python/ci.yml.jinja2
+++ b/skills/plugin-manager/templates/scaffold/python/ci.yml.jinja2
@@ -23,6 +23,14 @@ jobs:
         with:
           python-version: ${{ '{{' }} matrix.python-version {{ '}}' }}
 
+      # markdownlint-cli is a Node tool; `make lint-md` shells out to
+      # `npx --yes markdownlint-cli`. Hosted Ubuntu runners ship Node
+      # by default, so we only need setup-node to pin the version.
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '{{ node_version }}'
+
       - name: Install dependencies
         run: pip install -e ".[dev]"
 

--- a/skills/plugin-manager/templates/scaffold/shared/makefile-header.jinja2
+++ b/skills/plugin-manager/templates/scaffold/shared/makefile-header.jinja2
@@ -13,12 +13,20 @@ help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 	@echo ""
 
-# Linting (shared)
+# Linting (shared).
+# `npx --yes markdownlint-cli`:
+#   TS scaffolds: resolves to the version in devDependencies (no
+#     network round-trip after `npm install`)
+#   Python / globally-installed: --yes suppresses the install prompt
+#     so CI doesn't hang on first run
+# `--config .markdownlint.json` is passed explicitly because
+# markdownlint-cli auto-discovery can silently miss the config when
+# invoked through `npx` from non-package-root cwd.
 lint-md: ## Run markdownlint on Markdown files
-	markdownlint '**/*.md' --ignore node_modules
+	npx --yes markdownlint-cli '**/*.md' --ignore node_modules --config .markdownlint.json
 
 lint-fix-md: ## Fix markdownlint issues
-	markdownlint '**/*.md' --ignore node_modules --fix
+	npx --yes markdownlint-cli '**/*.md' --ignore node_modules --config .markdownlint.json --fix
 
 lint-yaml: ## Run yamllint on YAML files
 	yamllint -c .yamllint.yml .

--- a/skills/plugin-manager/templates/scaffold/shared/markdownlint.json.jinja2
+++ b/skills/plugin-manager/templates/scaffold/shared/markdownlint.json.jinja2
@@ -6,13 +6,16 @@
     "tables": false,
     "headings": false
   },
+  "MD022": false,
   "MD024": {
     "siblings_only": true
   },
   "MD025": false,
-  "MD033": {
-    "allowed_elements": ["br", "details", "summary", "sup", "sub", "kbd", "img"]
-  },
+  "MD032": false,
+  "MD033": false,
+  "MD034": false,
+  "MD036": false,
+  "MD040": false,
   "MD041": false,
   "MD046": {
     "style": "fenced"

--- a/skills/plugin-manager/templates/scaffold/shared/yamllint.yml.jinja2
+++ b/skills/plugin-manager/templates/scaffold/shared/yamllint.yml.jinja2
@@ -5,6 +5,20 @@
 
 extends: default
 
+# Exclude vendored / generated directories. yamllint walks them
+# otherwise — node_modules/ alone can produce hundreds of failures
+# from third-party YAML that we don't own (#82).
+ignore: |
+  node_modules/
+  dist/
+  coverage/
+  build/
+  __pycache__/
+  .venv/
+  venv/
+  .pytest_cache/
+  .ruff_cache/
+
 rules:
   # Allow longer lines - plugin configs often have descriptive text
   line-length:

--- a/skills/plugin-manager/templates/scaffold/typescript/package.json.jinja2
+++ b/skills/plugin-manager/templates/scaffold/typescript/package.json.jinja2
@@ -31,6 +31,7 @@
     "@eslint/js": "^9.0.0",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.0.0",
+    "markdownlint-cli": "^0.43.0",
     "prettier": "^3.2.0",
     "typescript": "^5.4.0",
     "typescript-eslint": "^8.0.0",

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -297,7 +297,165 @@ class TestScaffoldedCiYamlParses(unittest.TestCase):
                 )
 
 
-class TestExecuteWithAgentStub(unittest.TestCase):
+class TestScaffoldedLintBaseline(unittest.TestCase):
+    """Regression guards for #82 + #92: lint config that actually works.
+
+    The scaffold previously emitted three broken lint defaults:
+
+    - #82.1: `lint-md` called `markdownlint` directly while the
+      TypeScript package.json had no `markdownlint-cli` dependency,
+      so fresh installs hit `markdownlint: No such file or directory`
+    - #82.2: `lint-yaml` scanned `node_modules/`, producing hundreds
+      of failures from third-party YAML
+    - #82.3 / #92: markdownlint defaults conflicted with real
+      AIDA-generated prose (template placeholders → MD033, tight
+      technical content → MD022 / MD032, etc.)
+
+    Plus Python scaffolds had no Node.js setup in their CI workflow,
+    so `npx markdownlint-cli` would fail there too.
+
+    These tests pin all four fixes together at the scaffold-output
+    level — the rendered files have to be self-sufficient when a new
+    plugin gets `npm install` / `pip install -e .[dev]` and runs
+    `make lint`.
+    """
+
+    @patch.object(_scaffold_mod, "initialize_git", return_value=True)
+    @patch.object(_scaffold_mod, "create_initial_commit", return_value=True)
+    def test_typescript_package_includes_markdownlint_cli(
+        self, mock_commit, mock_git
+    ):
+        """TS package.json must ship markdownlint-cli as a devDep."""
+        import json as _json
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target = str(Path(tmp) / "ts-plugin")
+            context = {
+                "plugin_name": "ts-plugin",
+                "description": (
+                    "A TypeScript plugin for #82 lint dep testing"
+                ),
+                "license": "MIT",
+                "language": "typescript",
+                "target_directory": target,
+                "author_name": "Test",
+                "author_email": "test@test.com",
+                "keywords": "",
+                "version": "0.1.0",
+            }
+            result = execute(context)
+            self.assertTrue(result["success"], result.get("message"))
+
+            pkg = _json.loads(
+                (Path(result["path"]) / "package.json").read_text()
+            )
+            dev_deps = pkg.get("devDependencies", {})
+            self.assertIn(
+                "markdownlint-cli",
+                dev_deps,
+                f"package.json missing markdownlint-cli devDep; "
+                f"got {sorted(dev_deps)}",
+            )
+
+    @patch.object(_scaffold_mod, "initialize_git", return_value=True)
+    @patch.object(_scaffold_mod, "create_initial_commit", return_value=True)
+    def test_makefile_uses_npx_for_markdownlint(
+        self, mock_commit, mock_git
+    ):
+        """Makefile lint-md must use `npx --yes markdownlint-cli`.
+
+        Direct `markdownlint` invocation only works when the binary
+        is globally installed — broken on fresh TS scaffolds and on
+        Python scaffolds without an explicit global install. `npx
+        --yes` resolves to the devDep on TS, and prompt-suppresses
+        on first run elsewhere.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            target = str(Path(tmp) / "py-plugin")
+            context = {
+                "plugin_name": "py-plugin",
+                "description": (
+                    "A Python plugin for #82 makefile testing"
+                ),
+                "license": "MIT",
+                "language": "python",
+                "target_directory": target,
+                "author_name": "Test",
+                "author_email": "test@test.com",
+                "keywords": "",
+                "version": "0.1.0",
+            }
+            result = execute(context)
+            self.assertTrue(result["success"], result.get("message"))
+
+            makefile = (
+                Path(result["path"]) / "Makefile"
+            ).read_text()
+
+            # lint-md and lint-fix-md must call npx markdownlint-cli
+            # with explicit --config so auto-discovery quirks don't
+            # silently drop our config.
+            for marker in (
+                "npx --yes markdownlint-cli",
+                "--config .markdownlint.json",
+            ):
+                self.assertIn(
+                    marker,
+                    makefile,
+                    f"Makefile missing required marker: {marker!r}",
+                )
+
+            # The old `markdownlint '**/*.md'` direct invocation
+            # without npx must not appear — it's the broken shape.
+            for line in makefile.splitlines():
+                stripped = line.lstrip()
+                self.assertFalse(
+                    stripped.startswith("markdownlint ")
+                    and "npx" not in stripped,
+                    f"Direct `markdownlint` call (no npx): {line!r}",
+                )
+
+    @patch.object(_scaffold_mod, "initialize_git", return_value=True)
+    @patch.object(_scaffold_mod, "create_initial_commit", return_value=True)
+    def test_python_ci_yml_sets_up_node(self, mock_commit, mock_git):
+        """Python scaffold ci.yml must install Node before make lint.
+
+        `make lint` calls `lint-md`, which shells out to npx /
+        markdownlint-cli (a Node tool). Hosted Ubuntu runners have
+        Node pre-installed, but the workflow still needs an explicit
+        `actions/setup-node@v4` step so the version is pinned and
+        npm cache is set up.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            target = str(Path(tmp) / "py-plugin")
+            context = {
+                "plugin_name": "py-plugin",
+                "description": (
+                    "A Python plugin for #82 ci-yml testing"
+                ),
+                "license": "MIT",
+                "language": "python",
+                "target_directory": target,
+                "author_name": "Test",
+                "author_email": "test@test.com",
+                "keywords": "",
+                "version": "0.1.0",
+            }
+            result = execute(context)
+            self.assertTrue(result["success"], result.get("message"))
+
+            ci = (
+                Path(result["path"])
+                / ".github"
+                / "workflows"
+                / "ci.yml"
+            ).read_text()
+            self.assertIn(
+                "actions/setup-node@v4",
+                ci,
+                "Python ci.yml missing setup-node step — `npx "
+                "markdownlint-cli` will fail without Node.",
+            )
     """Test execute with agent stub."""
 
     @patch.object(_scaffold_mod, "initialize_git", return_value=True)

--- a/tests/unit/test_scaffold_generators.py
+++ b/tests/unit/test_scaffold_generators.py
@@ -221,6 +221,92 @@ class TestRenderSharedFiles(unittest.TestCase):
             self.assertFalse((target / "REUSE.toml").exists())
     # REUSE-IgnoreEnd
 
+    def test_yamllint_config_ignores_node_modules(self):
+        """yamllint must skip node_modules / venv / generated dirs.
+
+        Regression for #82 bug 2: `yamllint -c .yamllint.yml .`
+        recursively scans `node_modules/` by default, producing
+        hundreds of failures from third-party YAML we don't own. The
+        config's top-level `ignore:` block prunes those.
+        """
+        import yaml
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            render_shared_files(
+                target, self._build_variables(), TEMPLATES_DIR
+            )
+            yamllint_cfg = yaml.safe_load(
+                (target / ".yamllint.yml").read_text()
+            )
+
+            ignore_field = yamllint_cfg.get("ignore", "")
+            # `ignore:` is a YAML literal block scalar; parse it as
+            # newline-separated paths.
+            ignored = {
+                line.strip()
+                for line in ignore_field.splitlines()
+                if line.strip()
+            }
+            for required in (
+                "node_modules/",
+                "dist/",
+                "coverage/",
+                "build/",
+                "__pycache__/",
+                ".venv/",
+                "venv/",
+            ):
+                self.assertIn(
+                    required,
+                    ignored,
+                    f"yamllint config must ignore {required}; "
+                    f"got: {ignored}",
+                )
+
+    def test_markdownlint_disables_real_prose_rules(self):
+        """Markdownlint must disable rules that conflict with skill /
+        agent prose.
+
+        Regression for #82 bug 3 + #92: AIDA skill stubs use
+        `<PRD>` / `<ticket>` placeholders (would trip MD033 inline
+        HTML), tight technical prose without blanks around lists or
+        headings (MD032 / MD022), bold-as-heading patterns like
+        `**Last updated:** ...` (MD036), code blocks without language
+        tags in docs (MD040), and bare URLs (MD034). Across 9 repos
+        and ~40 PRs in the reporter's environment, none of these
+        rules caught real problems — they all flagged stylistic
+        conventions in scaffolded output.
+
+        These rules must be explicitly set to `false`:
+        """
+        import json as _json
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            render_shared_files(
+                target, self._build_variables(), TEMPLATES_DIR
+            )
+            cfg = _json.loads(
+                (target / ".markdownlint.json").read_text()
+            )
+            for rule in (
+                "MD022",
+                "MD025",
+                "MD032",
+                "MD033",
+                "MD034",
+                "MD036",
+                "MD040",
+                "MD041",
+            ):
+                self.assertIs(
+                    cfg.get(rule),
+                    False,
+                    f"markdownlint rule {rule} must be disabled; "
+                    f"got {cfg.get(rule)!r}",
+                )
+
 
 class TestAssembleGitignore(unittest.TestCase):
     """Test .gitignore assembly."""


### PR DESCRIPTION
## Summary

Every freshly scaffolded plugin failed \`make lint\` on the very first push due to four interlocking bugs in the scaffold's lint configuration. This PR fixes all of them and pins each at the rendered-output level so they can't silently regress.

### #82 bug 1 — \`lint-md\` had no dependency

\`lint-md\` called bare \`markdownlint\`, but:

- TypeScript scaffolds didn't declare \`markdownlint-cli\` in \`devDependencies\`
- Python scaffolds had no Node setup in CI at all

Fixed by:

- Adding \`\"markdownlint-cli\": \"^0.43.0\"\` to TS \`package.json\`
- Switching the Makefile to \`npx --yes markdownlint-cli --config .markdownlint.json\` (resolves to the devDep on TS; \`--yes\` suppresses the install prompt elsewhere)
- Adding \`actions/setup-node@v4\` to Python \`ci.yml\`

### #82 bug 2 — yamllint scanned node_modules/

\`yamllint -c .yamllint.yml .\` walked \`node_modules/\` recursively, emitting hundreds of failures from third-party YAML. Fixed by adding a top-level \`ignore:\` block to the scaffolded \`.yamllint.yml\` covering \`node_modules/\`, \`dist/\`, \`coverage/\`, \`build/\`, \`__pycache__/\`, \`.venv/\`, \`venv/\`, \`.pytest_cache/\`, \`.ruff_cache/\`.

### #82 bug 3 + #92 — markdownlint defaults flagged real prose

The default config tripped on patterns common in scaffolded skill/agent files. Disabled the rules that flag stylistic choices rather than real problems:

- \`MD022\` (blanks around headings) — tight knowledge docs
- \`MD032\` (blanks around lists) — tight technical prose
- \`MD033\` (inline HTML) — skill stubs use \`<PRD>\` / \`<ticket>\` placeholders
- \`MD034\` (bare URLs) — intentional in references
- \`MD036\` (emphasis as heading) — \`**Last updated:** …\` footer convention
- \`MD040\` (fenced code language) — plain output dumps

The keepers (\`MD013\` relaxed, \`MD024\` siblings_only, \`MD025\` off, \`MD041\` off, \`MD046\` fenced) are unchanged.

### #92 ask — explicit \`--config\` flag

Every markdownlint invocation passes \`--config .markdownlint.json\` explicitly. markdownlint-cli's auto-discovery can silently miss the config when invoked through \`npx\` from a non-package-root cwd, which would re-enable all the disabled rules.

## Test plan

- [x] \`pytest tests/unit/test_scaffold.py::TestScaffoldedLintBaseline\` — 3 pass (new)
- [x] \`pytest tests/unit/test_scaffold_generators.py::TestRenderSharedFiles\` — 9 pass (2 new)
- [x] \`pytest\` full suite — 931 pass (was 926, +5)
- [x] \`ruff check\` clean
- [x] \`yamllint -c .yamllint.yml skills/\` clean
- [x] **End-to-end**: scaffolded a Python plugin into \`/tmp\`, dropped malformed YAML inside a simulated \`node_modules/\`, ran \`yamllint -c .yamllint.yml .\` — exit 0 (ignore block works)
- [x] Version bump 1.5.7 → 1.5.8 + CHANGELOG entry

## New tests

\`TestScaffoldedLintBaseline\` (5 tests across two files):

- \`test_typescript_package_includes_markdownlint_cli\` — devDep present
- \`test_makefile_uses_npx_for_markdownlint\` — \`npx --yes markdownlint-cli\` + \`--config\`, no bare \`markdownlint\`
- \`test_python_ci_yml_sets_up_node\` — \`actions/setup-node@v4\` present
- \`test_yamllint_config_ignores_node_modules\` — required ignore paths present
- \`test_markdownlint_disables_real_prose_rules\` — required rules at \`false\`

## Notes

- New **\"Lint Policy\"** section in \`skills/plugin-manager/references/scaffolding-workflow.md\` documents each markdownlint rule's *why*, the yamllint config choices (including why \`document-start\` stays on — our generators emit \`---\` per 1.5.3), and the Python-CI Node setup rationale
- yamllint's \`document-start: present: true\` is **kept on** — the #81/#97 fix in 1.5.3 makes our generators emit \`---\` consistently
- Part of milestone **Scaffold v2 — usable out of the box**

Closes #82
Closes #92