### PR TITLE
feat: scaffold CONTRIBUTING.md documenting SPDX/REUSE convention (#100, 1.5.9)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,55 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.9] - 2026-05-22
+
+### Added
+
+- **Scaffolded `CONTRIBUTING.md`** — every newly-scaffolded plugin
+  now ships a `CONTRIBUTING.md` that documents the SPDX/REUSE
+  convention for downstream plugin authors. The template adapts to
+  the plugin's `license_id`:
+  - For real SPDX licenses (MIT / MPL-2.0 / Apache-2.0 / …): includes
+    a "REUSE compliance" section explaining `LICENSES/<id>.txt`,
+    `REUSE.toml`, and `make lint-reuse`
+  - For UNLICENSED: skips the REUSE section, explains why
+    `SPDX-License-Identifier` lines are suppressed, but still covers
+    the `SPDX-FileCopyrightText` convention so authorship stays
+    unambiguous
+- Header examples for the three styles a contributor needs
+  (Markdown, hash-style, slash-style) — wrapped in
+  `<!-- REUSE-IgnoreStart --> / <!-- REUSE-IgnoreEnd -->` so the
+  example blocks don't trip `reuse lint` in downstream CI
+- **`lint-reuse` Makefile target** in the shared makefile header,
+  running `reuse lint`. Python scaffold's `lint:` aggregate now
+  depends on `lint-reuse`; TypeScript scaffolds leave it as an
+  opt-in target (REUSE is a Python tool — the CONTRIBUTING doc
+  points TS authors at `fsfe/reuse-action` for CI)
+- **`reuse>=4.0`** in Python scaffold's `pyproject.toml` dev
+  dependencies — `pip install -e .[dev]` now brings in the CLI so
+  `make lint-reuse` works without a separate install
+- Regression tests in `tests/unit/test_scaffold_generators.py` and
+  `tests/unit/test_scaffold.py`:
+  - `test_contributing_md_documents_spdx_convention` — pins the
+    required content for non-UNLICENSED scaffolds
+  - `test_contributing_md_omits_reuse_for_unlicensed` — pins the
+    proprietary-friendly variant
+  - `test_python_pyproject_includes_reuse_dev_dep` — pins the dev
+    dep
+  - `test_python_makefile_runs_lint_reuse` — pins the aggregate
+    target dep
+
+### Notes
+
+- End-to-end verified: a freshly-scaffolded MIT plugin is REUSE 3.3
+  compliant out of the box (16/16 files, including the new
+  `CONTRIBUTING.md`)
+- Closes the last checkbox from #73's umbrella ("Plugin scaffolding
+  documents the convention for plugin authors") — fixes #100
+- Milestone: `Scaffold v2 — usable out of the box`
+
+---
+
 ## [1.5.8] - 2026-05-22
 
 ### Fixed

--- a/skills/plugin-manager/scripts/operations/scaffold_ops/generators.py
+++ b/skills/plugin-manager/scripts/operations/scaffold_ops/generators.py
@@ -83,6 +83,7 @@ def render_shared_files(
             ".claude-plugin/aida-config.json"
         ),
         "shared/claude-md.jinja2": "CLAUDE.md",
+        "shared/contributing.md.jinja2": "CONTRIBUTING.md",
         "shared/readme.md.jinja2": "README.md",
         "shared/markdownlint.json.jinja2": (
             ".markdownlint.json"

--- a/skills/plugin-manager/templates/scaffold/python/makefile-python.jinja2
+++ b/skills/plugin-manager/templates/scaffold/python/makefile-python.jinja2
@@ -5,7 +5,7 @@
 lint-py: ## Run ruff linter on Python files
 	ruff check .
 
-lint: lint-py lint-md lint-yaml lint-frontmatter ## Run all linters
+lint: lint-py lint-md lint-yaml lint-frontmatter lint-reuse ## Run all linters
 
 test: ## Run pytest
 	pytest tests/ -v

--- a/skills/plugin-manager/templates/scaffold/python/pyproject.toml.jinja2
+++ b/skills/plugin-manager/templates/scaffold/python/pyproject.toml.jinja2
@@ -19,6 +19,7 @@ keywords = {{ keywords | tojson }}
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
+    "reuse>=4.0",
     "ruff>=0.6.0",
     "jinja2>=3.1",
 ]

--- a/skills/plugin-manager/templates/scaffold/shared/contributing.md.jinja2
+++ b/skills/plugin-manager/templates/scaffold/shared/contributing.md.jinja2
@@ -1,0 +1,109 @@
+{{ spdx_md }}
+
+# Contributing to {{ plugin_display_name }}
+
+Thanks for your interest in contributing. This document covers the
+project conventions that affect every contribution.
+
+## Adding new files
+
+Every hand-authored source file in this repository carries an SPDX
+license header so that license-inventory tools (FOSSA, Snyk, GitHub
+dep graph, [REUSE](https://reuse.software/), etc.) can attribute it
+automatically. When you add a new file, please add the corresponding
+header near the top — after any shebang line, after any YAML
+frontmatter block, but before any other content.
+
+<!-- REUSE-IgnoreStart -->
+**Markdown / HTML files:**
+
+```markdown
+<!-- SPDX-FileCopyrightText: {{ year }} {{ copyright_holder }} -->
+{% if license_id != "UNLICENSED" -%}
+<!-- SPDX-License-Identifier: {{ license_id }} -->
+{%- endif %}
+```
+
+**Python / shell / YAML / TOML (hash-style comments):**
+
+```text
+# SPDX-FileCopyrightText: {{ year }} {{ copyright_holder }}
+{% if license_id != "UNLICENSED" -%}
+# SPDX-License-Identifier: {{ license_id }}
+{%- endif %}
+```
+
+**TypeScript / JavaScript / C-family (slash-style comments):**
+
+```text
+// SPDX-FileCopyrightText: {{ year }} {{ copyright_holder }}
+{% if license_id != "UNLICENSED" -%}
+// SPDX-License-Identifier: {{ license_id }}
+{%- endif %}
+```
+<!-- REUSE-IgnoreEnd -->
+
+**Skip:** JSON files (no comment syntax), lockfiles, vendored or
+generated files, fixtures, and the `LICENSE`{% if license_id != "UNLICENSED" %} / `LICENSES/{{ license_id }}.txt`{% endif %} file{% if license_id != "UNLICENSED" %}s{% endif %} themselves.
+
+{% if license_id != "UNLICENSED" -%}
+## REUSE compliance
+
+This project follows the [REUSE Specification](https://reuse.software/spec/),
+which standardises copyright and licensing metadata across source
+files. Two artifacts at the repository root keep that machine-readable:
+
+- `LICENSES/{{ license_id }}.txt` — the canonical text of the
+  project's license. Add new license files here if the project ever
+  adopts a second license (e.g., a docs-only `CC0-1.0` alongside
+  the code license).
+- `REUSE.toml` — the skip-list for files that can't carry inline
+  headers (JSON, lockfiles, fixtures). Each entry attributes
+  copyright + license without modifying the file itself.
+
+### Verifying locally
+
+If your scaffold includes Python tooling, the project's `Makefile`
+exposes a `lint-reuse` target:
+
+```bash
+make lint-reuse
+```
+
+This runs `reuse lint` against the working tree and fails if any
+file is missing copyright information, missing a license identifier,
+or references a license that isn't in `LICENSES/`. CI runs the same
+check on every PR, so fixing locally before pushing saves a round
+trip.
+
+If you don't have `reuse` installed (pure Node.js / Markdown
+plugins), you can install it ad-hoc with `pip install reuse` or use
+the [fsfe/reuse-action](https://github.com/fsfe/reuse-action)
+GitHub Action in your CI.
+
+{% else -%}
+## License attribution
+
+This is a proprietary / unlicensed project — `SPDX-License-Identifier`
+lines are suppressed (UNLICENSED is not a valid SPDX identifier).
+We still record `SPDX-FileCopyrightText` so authorship is unambiguous
+across forks, moves, and external audits.
+
+{% endif -%}
+## Why this matters
+
+Clear, machine-readable attribution protects everyone's work:
+
+- **You** keep verifiable authorship of what you wrote
+- **The project** can answer "who wrote this and under what license"
+  without git-blame archaeology
+- **Downstream users** can run inventory tools (FOSSA / Snyk /
+  GitHub dep graph) and get clean reports
+{% if license_id != "UNLICENSED" -%}
+- **License audits** stay simple — the file headers, `LICENSES/`,
+  and `REUSE.toml` together describe the legal posture without
+  ambiguity
+{% endif %}
+If you have questions about how to apply these conventions to a
+specific contribution, open a draft PR and tag a maintainer — much
+easier to advise on a concrete file than in the abstract.

--- a/skills/plugin-manager/templates/scaffold/shared/makefile-header.jinja2
+++ b/skills/plugin-manager/templates/scaffold/shared/makefile-header.jinja2
@@ -5,7 +5,7 @@
 PLUGIN_PATH := $(shell pwd)
 PLUGIN_NAME := {{ plugin_name }}
 
-.PHONY: help lint lint-md lint-fix-md lint-yaml lint-frontmatter clean
+.PHONY: help lint lint-md lint-fix-md lint-yaml lint-frontmatter lint-reuse clean
 
 help: ## Show this help message
 	@echo "{{ plugin_display_name }} - Available targets:"
@@ -33,3 +33,12 @@ lint-yaml: ## Run yamllint on YAML files
 
 lint-frontmatter: ## Validate frontmatter in Markdown files
 	@echo "Frontmatter validation not yet configured"
+
+# REUSE / SPDX compliance: every hand-authored file should carry an
+# SPDX copyright header (and a license identifier if the project is
+# not UNLICENSED). `reuse` is a Python tool — Python scaffolds get
+# it through `pip install -e ".[dev]"`. TypeScript scaffolds can
+# install it ad-hoc with `pip install reuse` or use the
+# fsfe/reuse-action GitHub Action.
+lint-reuse: ## Verify REUSE / SPDX compliance
+	reuse lint

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -417,6 +417,95 @@ class TestScaffoldedLintBaseline(unittest.TestCase):
 
     @patch.object(_scaffold_mod, "initialize_git", return_value=True)
     @patch.object(_scaffold_mod, "create_initial_commit", return_value=True)
+    def test_python_pyproject_includes_reuse_dev_dep(
+        self, mock_commit, mock_git
+    ):
+        """Python pyproject.toml must ship `reuse` as a dev dep.
+
+        #100 follow-on: the scaffolded `Makefile` exposes a
+        `lint-reuse` target so the CONTRIBUTING docs can reference
+        it. For Python scaffolds, `reuse` should come in via
+        `pip install -e .[dev]` rather than requiring a separate
+        install step.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            target = str(Path(tmp) / "py-plugin")
+            context = {
+                "plugin_name": "py-plugin",
+                "description": (
+                    "A Python plugin for #100 pyproject test"
+                ),
+                "license": "MIT",
+                "language": "python",
+                "target_directory": target,
+                "author_name": "Test",
+                "author_email": "test@test.com",
+                "keywords": "",
+                "version": "0.1.0",
+            }
+            result = execute(context)
+            self.assertTrue(result["success"], result.get("message"))
+
+            pyproject = (
+                Path(result["path"]) / "pyproject.toml"
+            ).read_text()
+            self.assertIn(
+                'reuse>=4.0',
+                pyproject,
+                "pyproject.toml missing reuse>=4.0 dev dep",
+            )
+
+    @patch.object(_scaffold_mod, "initialize_git", return_value=True)
+    @patch.object(_scaffold_mod, "create_initial_commit", return_value=True)
+    def test_python_makefile_runs_lint_reuse(
+        self, mock_commit, mock_git
+    ):
+        """Python `lint:` aggregate must include `lint-reuse`.
+
+        The scaffolded CONTRIBUTING.md (and `make lint-reuse`
+        target) only delivers value if the project actually runs
+        the check. Python scaffolds get `reuse` via pip, so the
+        aggregate target wires it in.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            target = str(Path(tmp) / "py-plugin")
+            context = {
+                "plugin_name": "py-plugin",
+                "description": "A Python plugin for #100 lint aggregate",
+                "license": "MIT",
+                "language": "python",
+                "target_directory": target,
+                "author_name": "Test",
+                "author_email": "test@test.com",
+                "keywords": "",
+                "version": "0.1.0",
+            }
+            result = execute(context)
+            self.assertTrue(result["success"], result.get("message"))
+
+            makefile = (
+                Path(result["path"]) / "Makefile"
+            ).read_text()
+            self.assertIn("lint-reuse:", makefile)
+            # The lint aggregate must depend on lint-reuse.
+            for line in makefile.splitlines():
+                stripped = line.strip()
+                if stripped.startswith("lint:") and "##" in stripped:
+                    self.assertIn(
+                        "lint-reuse",
+                        stripped,
+                        f"Python `lint:` aggregate missing "
+                        f"`lint-reuse` dep: {stripped!r}",
+                    )
+                    break
+            else:
+                self.fail(
+                    "Did not find a `lint:` target with `## ` doc "
+                    "comment in scaffolded Makefile"
+                )
+
+    @patch.object(_scaffold_mod, "initialize_git", return_value=True)
+    @patch.object(_scaffold_mod, "create_initial_commit", return_value=True)
     def test_python_ci_yml_sets_up_node(self, mock_commit, mock_git):
         """Python scaffold ci.yml must install Node before make lint.
 

--- a/tests/unit/test_scaffold_generators.py
+++ b/tests/unit/test_scaffold_generators.py
@@ -133,6 +133,7 @@ class TestRenderSharedFiles(unittest.TestCase):
                 ".claude-plugin/marketplace.json",
                 ".claude-plugin/aida-config.json",
                 "CLAUDE.md",
+                "CONTRIBUTING.md",
                 "README.md",
                 ".markdownlint.json",
                 ".yamllint.yml",
@@ -263,6 +264,61 @@ class TestRenderSharedFiles(unittest.TestCase):
                     f"yamllint config must ignore {required}; "
                     f"got: {ignored}",
                 )
+
+    def test_contributing_md_documents_spdx_convention(self):
+        """CONTRIBUTING.md must teach downstream authors the SPDX
+        convention.
+
+        Regression for #100: scaffolded plugins shipped with SPDX
+        headers in every generated file (1.5.0+) but had no
+        contributor-facing docs explaining the convention. New plugin
+        authors had no way to discover that the project uses REUSE or
+        how to keep new files compliant.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            render_shared_files(
+                target, self._build_variables(), TEMPLATES_DIR
+            )
+            content = (target / "CONTRIBUTING.md").read_text()
+
+            # Must cover the three header styles a contributor needs.
+            for marker in (
+                "SPDX-FileCopyrightText",
+                "SPDX-License-Identifier",
+                "REUSE",
+                "make lint-reuse",
+                "LICENSES/",
+            ):
+                self.assertIn(
+                    marker,
+                    content,
+                    f"CONTRIBUTING.md missing required marker: "
+                    f"{marker!r}",
+                )
+
+    def test_contributing_md_omits_reuse_for_unlicensed(self):
+        """For UNLICENSED scaffolds, CONTRIBUTING.md should skip the
+        REUSE section (REUSE.toml is also omitted for the same
+        reason) and instead explain why SPDX-License-Identifier is
+        suppressed.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            variables = self._build_variables(license_id="UNLICENSED")
+            render_shared_files(target, variables, TEMPLATES_DIR)
+            content = (target / "CONTRIBUTING.md").read_text()
+
+            # No REUSE / lint-reuse content for UNLICENSED scaffolds.
+            self.assertNotIn("REUSE compliance", content)
+            self.assertNotIn("make lint-reuse", content)
+            # But SPDX copyright + the "License attribution"
+            # explanation must still be present.
+            self.assertIn("SPDX-FileCopyrightText", content)
+            self.assertIn("License attribution", content)
+            self.assertIn(
+                "UNLICENSED is not a valid SPDX identifier", content
+            )
 
     def test_markdownlint_disables_real_prose_rules(self):
         """Markdownlint must disable rules that conflict with skill /


### PR DESCRIPTION
## Summary

Closes the last open checkbox from #73's umbrella: scaffolded plugins emitted SPDX headers in every generated file (since 1.5.0) but had **no** contributor-facing docs explaining the convention. New plugin authors had no way to discover the project used REUSE or how to keep new files compliant.

This PR ships:

- **\`CONTRIBUTING.md\` template** that adapts to the plugin's \`license_id\`:
  - **Real SPDX licenses** (MIT / MPL-2.0 / Apache-2.0 / …): includes a "REUSE compliance" section, header examples for Markdown / hash-style / slash-style, and a pointer to \`make lint-reuse\`
  - **UNLICENSED**: skips REUSE (consistent with how \`REUSE.toml\` is also skipped), explains why \`SPDX-License-Identifier\` lines are suppressed, still covers \`SPDX-FileCopyrightText\` so authorship stays unambiguous
- Header examples wrapped in \`<!-- REUSE-IgnoreStart/End -->\` so the example blocks don't trip \`reuse lint\` in downstream CI (or in the template's own lint)
- **\`lint-reuse\` Makefile target** in the shared header (mirrors AIDA's own \`make lint-reuse\` → \`reuse lint\` pattern)
- **Python \`lint:\` aggregate** now depends on \`lint-reuse\`; TS leaves it opt-in (REUSE is a Python tool — CONTRIBUTING points TS authors at \`fsfe/reuse-action\` for CI)
- **\`reuse>=4.0\`** in Python \`pyproject.toml\` dev dependencies so the Make target works after \`pip install -e .[dev]\` without a separate install

## Test plan

- [x] \`pytest\` — 935 pass (was 931, +4 new)
- [x] \`ruff check\` clean
- [x] \`reuse lint\` on aida-core itself — 319/319 files, REUSE 3.3 compliant (the template's example blocks are inside REUSE-Ignore comments)
- [x] **End-to-end**: scaffolded a fresh MIT plugin → \`reuse lint\` exits clean inside the new plugin (16/16 files including the new \`CONTRIBUTING.md\`)
- [x] **End-to-end UNLICENSED**: scaffolded → no "REUSE compliance" section, no \`make lint-reuse\` mention, "License attribution" section present
- [x] Version bump 1.5.8 → 1.5.9 + CHANGELOG entry

## New tests

\`TestRenderSharedFiles\`:
- \`test_contributing_md_documents_spdx_convention\` — required content for non-UNLICENSED
- \`test_contributing_md_omits_reuse_for_unlicensed\` — proprietary-friendly variant

\`TestScaffoldedLintBaseline\`:
- \`test_python_pyproject_includes_reuse_dev_dep\` — \`reuse>=4.0\` present
- \`test_python_makefile_runs_lint_reuse\` — Python \`lint:\` aggregate depends on \`lint-reuse\`

## Notes

- Part of milestone **Scaffold v2 — usable out of the box** (3/6 closed after merge)
- Pairs naturally with the lint-baseline work in #108 (1.5.8): scaffolded plugins now ship green-on-first-push AND know how to stay that way

Closes #100