### PR TITLE
feat: language=none (skills-only) scaffold flavor (#96, 1.5.10)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,63 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.10] - 2026-05-22
+
+### Added
+
+- **`language=none` (skills-only / markdown-only) scaffold flavor.**
+  Previously the scaffold defaulted to Python without asking, so
+  authors of markdown-only plugins (pure agents + skills + CLAUDE.md)
+  got a full Python toolchain that had to be manually ripped out.
+  Now an explicit choice — Python / TypeScript / **None** — surfaces
+  in the wizard, and picking `none` skips every Python and
+  TypeScript toolchain artifact:
+  - No `pyproject.toml`, no `.python-version`, no `tests/conftest.py`
+  - No `package.json`, no `tsconfig.json`, no `eslint.config.mjs`,
+    no `.prettierrc.json`, no `.nvmrc`, no `vitest.config.ts`
+  - No language-specific directories (`scripts/`, `tests/`, `src/`)
+  - A minimal `Makefile` whose `lint:` aggregate covers only the
+    shared markdown / YAML / frontmatter / REUSE targets
+  - A minimal `.github/workflows/ci.yml` that installs Python +
+    Node just enough to run `reuse lint` and `markdownlint-cli`,
+    then runs `make lint`
+  - Slim `.gitignore` (shared fragment only — OS / IDE /
+    `.claude/settings.local.json`); no language patterns
+- New template directory `skills/plugin-manager/templates/scaffold/none/`
+  holding `ci.yml.jinja2` and `makefile-none.jinja2`
+- `render_none_files` generator in
+  `skills/plugin-manager/scripts/operations/scaffold_ops/generators.py`
+- Language question prompt reworded so the choice is explicit:
+  `"Which language toolchain? ('none' = skills-only, no Python or TypeScript)"`
+- `_build_next_steps` skips the `pip install` / `npm install` step
+  and the `make test` step for `none` scaffolds
+
+### Changed
+
+- `assemble_gitignore` and `assemble_makefile` switched from
+  `if/else` to `if/elif/else` so `language="none"` doesn't fall
+  through to the TypeScript fragment
+
+### Notes
+
+- End-to-end verified: scaffolded a fresh `language=none` MIT
+  plugin → 16 files created, REUSE 3.3 compliant (13/13 files);
+  none of `pyproject.toml`, `package.json`, `tsconfig.json`, or
+  the language-specific test directories are present
+- Pairs naturally with `/aida plugin update`'s skills-only path —
+  once update flows respect the recorded `language=none`
+  (tracked separately in #110's design note), the silent-Python
+  default is closed end-to-end
+- License-prompt option cap exceeded by `SUPPORTED_LICENSES`
+  (6 options vs AskUserQuestion's cap of 4) is the same #85
+  family bug in a new file — tracked in **#111**
+- Fixes #96 (language portion). The license-prompt half is split
+  out into #111 because the fix involves a separate design
+  decision (how to handle "Other" SPDX ids)
+- Milestone: `Scaffold v2 — usable out of the box`
+
+---
+
 ## [1.5.9] - 2026-05-22
 
 ### Added

--- a/skills/plugin-manager/scripts/operations/constants.py
+++ b/skills/plugin-manager/scripts/operations/constants.py
@@ -4,4 +4,8 @@
 """Shared constants for plugin-manager operations."""
 
 GENERATOR_VERSION = "0.9.0"
-SUPPORTED_LANGUAGES = ("python", "typescript")
+# "none" is a skills-only / markdown-only flavor — no Python or
+# TypeScript toolchain (no pyproject.toml, no package.json, no
+# language-specific tests directory). Used for plugins that ship
+# pure agents / skills / CLAUDE.md content (#96).
+SUPPORTED_LANGUAGES = ("python", "typescript", "none")

--- a/skills/plugin-manager/scripts/operations/scaffold.py
+++ b/skills/plugin-manager/scripts/operations/scaffold.py
@@ -41,6 +41,7 @@ from .scaffold_ops.licenses import (
 from .scaffold_ops.generators import (
     create_directory_structure,
     render_shared_files,
+    render_none_files,
     render_python_files,
     render_typescript_files,
     render_stub_agent,
@@ -149,12 +150,20 @@ def get_questions(
             }
         )
 
-    # Language
+    # Language. "none" is a skills-only / markdown-only flavor — no
+    # Python or TypeScript toolchain files. Explicit confirmation
+    # here so the scaffold doesn't silently default to Python for
+    # plugins that ship pure agents / skills / CLAUDE.md content
+    # (#96 — a markdown-only plugin previously got the full Python
+    # toolchain by default and had to manually rip it out).
     if not context.get("language"):
         questions.append(
             {
                 "id": "language",
-                "question": "Which language toolchain?",
+                "question": (
+                    "Which language toolchain? "
+                    "('none' = skills-only, no Python or TypeScript)"
+                ),
                 "type": "choice",
                 "options": list(SUPPORTED_LANGUAGES),
                 "default": "python",
@@ -409,9 +418,17 @@ def execute(context: dict[str, Any]) -> dict[str, Any]:
                     SCAFFOLD_TEMPLATES_DIR,
                 )
             )
-        else:
+        elif language == "typescript":
             all_files.extend(
                 render_typescript_files(
+                    target,
+                    variables,
+                    SCAFFOLD_TEMPLATES_DIR,
+                )
+            )
+        else:  # "none" — skills-only plugin
+            all_files.extend(
+                render_none_files(
                     target,
                     variables,
                     SCAFFOLD_TEMPLATES_DIR,
@@ -526,11 +543,19 @@ def _build_next_steps(
 
     if language == "python":
         steps.append('pip install -e ".[dev]"')
-    else:
+    elif language == "typescript":
         steps.append("npm install")
+    else:  # "none" — skills-only plugin
+        # No language deps to install; the lint tools (`reuse`,
+        # `markdownlint-cli`) come from the CI workflow's install
+        # step. For local dev, see CONTRIBUTING.md.
+        steps.append(
+            "# (skills-only: no language deps to install)"
+        )
 
     steps.append("make lint  # verify project structure")
-    steps.append("make test  # run initial tests")
+    if language != "none":
+        steps.append("make test  # run initial tests")
 
     if create_repo:
         steps.append(

--- a/skills/plugin-manager/scripts/operations/scaffold_ops/generators.py
+++ b/skills/plugin-manager/scripts/operations/scaffold_ops/generators.py
@@ -209,6 +209,45 @@ def render_typescript_files(
     return created
 
 
+def render_none_files(
+    target: Path,
+    variables: dict[str, Any],
+    templates_dir: Path,
+) -> list[str]:
+    """Render files for a skills-only (no toolchain) plugin.
+
+    Skills-only plugins skip every Python and TypeScript toolchain
+    artifact (no pyproject.toml, no package.json, no tests/conftest,
+    no .python-version / .nvmrc). The only language-flavored file
+    rendered here is the CI workflow, which still installs Python
+    and Node so `make lint` can run end-to-end against the
+    Markdown/YAML/REUSE checks.
+
+    Args:
+        target: Target directory path
+        variables: Template variables
+        templates_dir: Path to scaffold templates directory
+
+    Returns:
+        List of created file paths (relative to target)
+    """
+    none_templates = {
+        "none/ci.yml.jinja2": ".github/workflows/ci.yml",
+    }
+
+    created = []
+    for template_name, output_path in none_templates.items():
+        content = render_template(
+            templates_dir, template_name, variables
+        )
+        file_path = target / output_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(content)
+        created.append(output_path)
+
+    return created
+
+
 def render_stub_agent(
     target: Path,
     name: str,
@@ -363,7 +402,9 @@ def assemble_gitignore(
 
     Args:
         target: Target directory path
-        language: "python" or "typescript"
+        language: "python", "typescript", or "none" (skills-only —
+            no language-specific fragment added; only the shared
+            patterns apply)
         templates_dir: Path to scaffold templates directory
 
     Returns:
@@ -384,13 +425,17 @@ def assemble_gitignore(
             "python/gitignore-python.jinja2",
             {},
         )
-    else:
+        parts.append(lang_content)
+    elif language == "typescript":
         lang_content = render_template(
             templates_dir,
             "typescript/gitignore-node.jinja2",
             {},
         )
-    parts.append(lang_content)
+        parts.append(lang_content)
+    # language == "none": no language-specific fragment — the
+    # shared block (OS, IDE, .claude/settings.local.json) is all a
+    # skills-only plugin needs.
 
     gitignore_path = target / ".gitignore"
     gitignore_path.write_text("\n".join(parts))
@@ -408,7 +453,9 @@ def assemble_makefile(
 
     Args:
         target: Target directory path
-        language: "python" or "typescript"
+        language: "python", "typescript", or "none" (skills-only —
+            uses a stub fragment with `lint:` aggregate but no
+            install/test targets for a language toolchain)
         variables: Template variables
         templates_dir: Path to scaffold templates directory
 
@@ -430,10 +477,16 @@ def assemble_makefile(
             "python/makefile-python.jinja2",
             variables,
         )
-    else:
+    elif language == "typescript":
         lang_targets = render_template(
             templates_dir,
             "typescript/makefile-typescript.jinja2",
+            variables,
+        )
+    else:  # "none" — skills-only plugin
+        lang_targets = render_template(
+            templates_dir,
+            "none/makefile-none.jinja2",
             variables,
         )
     parts.append(lang_targets)

--- a/skills/plugin-manager/templates/scaffold/none/ci.yml.jinja2
+++ b/skills/plugin-manager/templates/scaffold/none/ci.yml.jinja2
@@ -1,0 +1,36 @@
+{{ spdx_hash }}
+---
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Skills-only plugins still need Python (for `reuse`) and Node
+      # (for `npx markdownlint-cli`) so `make lint` can run end-to-end.
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '{{ python_version }}'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '{{ node_version }}'
+
+      - name: Install lint tools
+        run: |
+          pip install 'reuse>=4.0'
+          npm install -g markdownlint-cli@0.43.0
+
+      - name: Lint
+        run: make lint

--- a/skills/plugin-manager/templates/scaffold/none/makefile-none.jinja2
+++ b/skills/plugin-manager/templates/scaffold/none/makefile-none.jinja2
@@ -1,0 +1,14 @@
+
+# Skills-only plugin (no Python or TypeScript toolchain)
+.PHONY: lint test install clean
+
+lint: lint-md lint-yaml lint-frontmatter lint-reuse ## Run all linters
+
+test: ## No automated tests configured (skills-only plugin)
+	@echo "No automated tests configured. Add a test target if your skills include scripts."
+
+install: ## No language deps to install (skills-only plugin)
+	@echo "No language dependencies. Markdown / YAML / skill content only."
+
+clean: ## Remove ephemeral cache files
+	find . -name ".DS_Store" -delete 2>/dev/null || true

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -576,6 +576,143 @@ class TestScaffoldedLintBaseline(unittest.TestCase):
             )
 
 
+class TestExecuteSkillsOnlyProject(unittest.TestCase):
+    """Test execute with language='none' (skills-only / markdown-only).
+
+    Regression for #96: scaffold previously had no skills-only flavor,
+    so plugins with no scripting (pure agents / skills / CLAUDE.md)
+    silently got a full Python toolchain that had to be manually
+    removed. language='none' is now an explicit choice; toolchain
+    files for both Python and TypeScript are skipped, leaving only
+    the shared scaffold (Makefile, CI for lint, .gitignore, REUSE
+    files, etc.).
+    """
+
+    @patch.object(_scaffold_mod, "initialize_git", return_value=True)
+    @patch.object(_scaffold_mod, "create_initial_commit", return_value=True)
+    def test_creates_minimal_project(self, mock_commit, mock_git):
+        """Skills-only scaffold should create only shared + skills/
+        agents/ docs directories; no Python / TypeScript toolchain.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            target = str(Path(tmp) / "skills-plugin")
+            context = {
+                "plugin_name": "skills-plugin",
+                "description": (
+                    "A skills-only plugin for #96 regression"
+                ),
+                "license": "MIT",
+                "language": "none",
+                "target_directory": target,
+                "author_name": "Test Author",
+                "author_email": "test@example.com",
+                "keywords": "skills",
+                "version": "0.1.0",
+            }
+            result = execute(context)
+            self.assertTrue(result["success"], result.get("message"))
+            self.assertEqual(result["language"], "none")
+
+            target_path = Path(result["path"])
+            # Shared files must still be present
+            for f in (
+                ".claude-plugin/plugin.json",
+                "CLAUDE.md",
+                "README.md",
+                "LICENSE",
+                "Makefile",
+                ".gitignore",
+                "CONTRIBUTING.md",
+                ".github/workflows/ci.yml",
+            ):
+                self.assertTrue(
+                    (target_path / f).exists(),
+                    f"none scaffold missing shared file: {f}",
+                )
+
+            # Python toolchain files must NOT exist
+            for forbidden in (
+                "pyproject.toml",
+                ".python-version",
+                "tests/conftest.py",
+            ):
+                self.assertFalse(
+                    (target_path / forbidden).exists(),
+                    f"none scaffold should not create {forbidden}",
+                )
+
+            # TypeScript toolchain files must NOT exist
+            for forbidden in (
+                "package.json",
+                "tsconfig.json",
+                "eslint.config.mjs",
+                ".prettierrc.json",
+                ".nvmrc",
+                "vitest.config.ts",
+            ):
+                self.assertFalse(
+                    (target_path / forbidden).exists(),
+                    f"none scaffold should not create {forbidden}",
+                )
+
+            # Per-language dirs are skipped too.
+            self.assertFalse((target_path / "tests").exists())
+            self.assertFalse((target_path / "scripts").exists())
+            self.assertFalse((target_path / "src").exists())
+
+    @patch.object(_scaffold_mod, "initialize_git", return_value=True)
+    @patch.object(_scaffold_mod, "create_initial_commit", return_value=True)
+    def test_lint_aggregate_has_no_language_targets(
+        self, mock_commit, mock_git
+    ):
+        """Skills-only Makefile's `lint:` aggregate must not reference
+        lint-py or lint-ts — those targets don't exist in this flavor.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            target = str(Path(tmp) / "skills-plugin")
+            context = {
+                "plugin_name": "skills-plugin",
+                "description": (
+                    "A skills-only plugin for #96 lint-aggregate test"
+                ),
+                "license": "MIT",
+                "language": "none",
+                "target_directory": target,
+                "author_name": "Test Author",
+                "author_email": "test@example.com",
+                "keywords": "",
+                "version": "0.1.0",
+            }
+            result = execute(context)
+            self.assertTrue(result["success"], result.get("message"))
+
+            makefile = (
+                Path(result["path"]) / "Makefile"
+            ).read_text()
+
+            for line in makefile.splitlines():
+                stripped = line.strip()
+                if stripped.startswith("lint:") and "##" in stripped:
+                    self.assertNotIn(
+                        "lint-py",
+                        stripped,
+                        "none-flavor lint: should not depend on "
+                        f"lint-py — got {stripped!r}",
+                    )
+                    self.assertNotIn(
+                        "lint-ts",
+                        stripped,
+                        "none-flavor lint: should not depend on "
+                        f"lint-ts — got {stripped!r}",
+                    )
+                    break
+            else:
+                self.fail(
+                    "Did not find a `lint:` target in skills-only "
+                    "scaffolded Makefile"
+                )
+
+
 class TestExecuteWithSkillStub(unittest.TestCase):
     """Test execute with skill stub."""
 


### PR DESCRIPTION
## Summary

Previously the scaffold defaulted to Python without asking, so authors of markdown-only plugins (pure agents + skills + CLAUDE.md) got a full Python toolchain that had to be manually ripped out. The #96 reporter hit this on \`/aida plugin update\` for a private skills-only plugin.

Now an explicit choice — **Python / TypeScript / None** — surfaces in the wizard. Picking \`none\` skips every Python and TypeScript toolchain artifact:

- No \`pyproject.toml\`, \`.python-version\`, \`tests/conftest.py\`
- No \`package.json\`, \`tsconfig.json\`, \`eslint.config.mjs\`, \`.prettierrc.json\`, \`.nvmrc\`, \`vitest.config.ts\`
- No language-specific directories (\`scripts/\`, \`tests/\`, \`src/\`)
- A minimal \`Makefile\` whose \`lint:\` aggregate covers only the shared markdown / YAML / frontmatter / REUSE targets
- A minimal \`.github/workflows/ci.yml\` that installs Python + Node just enough to run \`reuse lint\` and \`markdownlint-cli\`, then runs \`make lint\`
- Slim \`.gitignore\` (shared fragment only — OS / IDE / \`.claude/settings.local.json\`)

## What's new

- Template directory \`skills/plugin-manager/templates/scaffold/none/\` with \`ci.yml.jinja2\` and \`makefile-none.jinja2\`
- \`render_none_files\` generator function
- \`assemble_gitignore\` / \`assemble_makefile\` switched from \`if/else\` to \`if/elif/else\` so \`none\` doesn't fall through to TypeScript
- \`_build_next_steps\` skips \`pip install\` / \`npm install\` and \`make test\` for \`none\` scaffolds
- Language prompt reworded: \`\"Which language toolchain? ('none' = skills-only, no Python or TypeScript)\"\`

## Test plan

- [x] \`pytest tests/unit/test_scaffold.py::TestExecuteSkillsOnlyProject\` — 2 pass (new)
- [x] \`pytest\` full suite — 937 pass (was 935, +2)
- [x] \`ruff check\` clean
- [x] \`reuse lint\` on aida-core itself — 321/321 files clean
- [x] **End-to-end**: scaffolded a fresh \`language=none\` MIT plugin → 16 files, REUSE 3.3 compliant (13/13). Asserted python-only and ts-only artifacts are absent.
- [x] Version bump 1.5.9 → 1.5.10 + CHANGELOG entry

## Not in this PR

- **License-prompt option cap (6 options vs AskUserQuestion's cap of 4)** — same #85 family bug in a new file. Split into **#111** because the fix involves a separate design decision around how to handle \"Other\" SPDX ids
- \`/aida plugin update\` respecting \`language=none\` — depends on metadata that doesn't exist yet (see design note in **#110**)

## Notes

- Part of milestone **Scaffold v2 — usable out of the box** (4/7 closed after merge — issue count grew to 7 because we filed #110 and #111 while doing this work)

Closes #96 (language portion)