### PR TITLE
fix: scaffold license prompt cap + 'Other' SPDX id support (#111, 1.5.11)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,70 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.11] - 2026-05-22
+
+### Fixed
+
+- **Scaffold license prompt no longer exceeds the AskUserQuestion
+  4-option cap.** The scaffold previously offered all 6 entries in
+  `SUPPORTED_LICENSES` (MIT, Apache-2.0, ISC, GPL-3.0, AGPL-3.0,
+  UNLICENSED). AskUserQuestion caps `options` at 4 plus the
+  always-supplied "Other", so the scaffold prompt was
+  undeliverable. New curated `PROMPT_LICENSE_OPTIONS` lists the 4
+  most-common values; ISC and AGPL-3.0 remain accepted for
+  non-interactive callers. Fixes #111
+
+### Added
+
+- **"Other" SPDX id support in the scaffold.** Picking "Other" in
+  the license prompt and typing any well-formed SPDX id
+  (`MPL-2.0`, `BSD-3-Clause`, `LGPL-3.0-or-later`, `0BSD`,
+  `Unlicense`, …) now works end-to-end. The scaffold writes:
+  - A placeholder `LICENSE` at the repo root that names the SPDX id
+    and points the author at
+    `https://spdx.org/licenses/<id>.html` to paste the canonical
+    text
+  - `LICENSES/<id>.txt` (REUSE-required) with the same placeholder
+  - SPDX-License-Identifier headers in every generated file
+    referencing the chosen id
+  End-to-end verified on a `MPL-2.0` scaffold: 16/16 files clean
+  under `reuse lint`
+- `is_valid_license_id(license_id)` validator in
+  `skills/plugin-manager/scripts/operations/scaffold_ops/licenses.py`.
+  Accepts known LICENSES dict ids, NON_SPDX_PLACEHOLDERS, and any
+  string matching the loose SPDX shape `^[A-Za-z0-9.+\-]+$`.
+  Rejects empty / whitespace / shell-metacharacter ids
+- Regression tests:
+  - `tests/unit/test_scaffold_licenses.py::TestIsValidLicenseId`
+    (5 cases, including shell-metacharacter defense-in-depth)
+  - `tests/unit/test_scaffold_licenses.py::TestGetLicenseTextOther`
+    (3 cases pinning the placeholder LICENSE behavior)
+  - `tests/unit/test_scaffold.py::TestExecuteCustomLicense`
+    (end-to-end `MPL-2.0` scaffold + malformed-id rejection)
+  - `tests/unit/test_scaffold_licenses.py::test_prompt_option_cap`
+    (asserts `PROMPT_LICENSE_OPTIONS` <= 4)
+
+### Changed
+
+- `tests/unit/test_utils.py::TestConfigureQuestionOptions` now
+  scans both `configure.py` and `scaffold.py` for choice questions
+  with literal `options: [...]` lists exceeding 4 entries.
+  Single source of truth for the #85-family guard
+
+### Notes
+
+- `get_license_text` now raises `ValueError` only for *invalid*
+  ids (empty, whitespace, shell metacharacters). Previously it
+  raised for any id not in the `LICENSES` dict, which was the bug
+  this PR fixes
+- The placeholder LICENSE explicitly tells the author where to
+  fetch canonical text — better than silently writing nothing
+  (the path UNLICENSED takes is different: it gets the
+  proprietary all-rights-reserved attribution block)
+- Milestone: `Scaffold v2 — usable out of the box`
+
+---
+
 ## [1.5.10] - 2026-05-22
 
 ### Added

--- a/skills/plugin-manager/scripts/operations/scaffold.py
+++ b/skills/plugin-manager/scripts/operations/scaffold.py
@@ -36,7 +36,8 @@ from .scaffold_ops.context import (
 )
 from .scaffold_ops.licenses import (
     get_license_text,
-    SUPPORTED_LICENSES,
+    PROMPT_LICENSE_OPTIONS,
+    is_valid_license_id,
 )
 from .scaffold_ops.generators import (
     create_directory_structure,
@@ -136,16 +137,22 @@ def get_questions(
             }
         )
 
-    # License
+    # License. Capped at 4 mutually-exclusive named options to fit
+    # AskUserQuestion's option cap. AskUserQuestion supplies its own
+    # "Other" automatically — picking it lets the user type any SPDX
+    # id (MPL-2.0, BSD-3-Clause, LGPL-3.0-or-later, …) and the
+    # scaffold writes a placeholder LICENSE for unknown ids (#85,
+    # #111).
     if not context.get("license"):
         questions.append(
             {
                 "id": "license",
                 "question": (
-                    "Which license should the plugin use?"
+                    "Which license should the plugin use? "
+                    "Pick 'Other' to type a custom SPDX id."
                 ),
                 "type": "choice",
-                "options": SUPPORTED_LICENSES,
+                "options": PROMPT_LICENSE_OPTIONS,
                 "default": "UNLICENSED",
             }
         )
@@ -335,10 +342,14 @@ def execute(context: dict[str, Any]) -> dict[str, Any]:
         }
 
     license_id = context.get("license", "UNLICENSED")
-    if license_id not in SUPPORTED_LICENSES:
+    if not is_valid_license_id(license_id):
         return {
             "success": False,
-            "message": f"Unsupported license: {license_id}",
+            "message": (
+                f"Invalid license: {license_id!r}. Expected an "
+                f"SPDX id (e.g., 'MIT', 'MPL-2.0', 'Apache-2.0') "
+                f"or 'UNLICENSED' for proprietary projects."
+            ),
         }
 
     author_name = context.get("author_name", "")

--- a/skills/plugin-manager/scripts/operations/scaffold_ops/licenses.py
+++ b/skills/plugin-manager/scripts/operations/scaffold_ops/licenses.py
@@ -7,6 +7,10 @@ Stores full license bodies keyed by SPDX identifier with
 year/author placeholders for substitution at render time.
 """
 
+import re
+
+from shared.spdx import NON_SPDX_PLACEHOLDERS
+
 
 LICENSES = {
     "MIT": (
@@ -172,11 +176,61 @@ LICENSES = {
 
 SUPPORTED_LICENSES = list(LICENSES.keys())
 
+# Curated short list shown in the interactive scaffold prompt.
+# Capped at 4 to fit AskUserQuestion's option cap (#85 family). Other
+# ids in LICENSES (ISC, AGPL-3.0) remain accepted by validation for
+# non-interactive callers; arbitrary SPDX ids reach a placeholder
+# LICENSE via the "Other" branch in get_license_text.
+PROMPT_LICENSE_OPTIONS = [
+    "MIT",
+    "Apache-2.0",
+    "GPL-3.0",
+    "UNLICENSED",
+]
+
+# Loose SPDX identifier shape — letters / digits / dot / plus / dash.
+# Accepts obscure-but-real ids like ``GPL-3.0-only``, ``LGPL-3.0-or-later``,
+# ``0BSD``, ``MPL-2.0``. The deny-list lives in ``shared.spdx`` (UNLICENSED,
+# Proprietary, None, TBD, ...) and runs separately — those are valid
+# *values* here but get attribution-only treatment downstream.
+_SPDX_LICENSE_ID_RE = re.compile(r"^[A-Za-z0-9.+\-]+$")
+
+
+def is_valid_license_id(license_id: str) -> bool:
+    """Return True if ``license_id`` is acceptable for scaffolding.
+
+    Accepts:
+      - Any id known in ``LICENSES`` (full text available)
+      - Any placeholder in ``NON_SPDX_PLACEHOLDERS`` (UNLICENSED-style)
+      - Any string matching the loose SPDX shape — for those we write
+        a placeholder LICENSE and rely on ``reuse lint`` downstream
+        to catch typos
+
+    Rejects empty strings and strings with whitespace / shell
+    metacharacters / control chars.
+    """
+    if not license_id or not license_id.strip():
+        return False
+    if license_id in LICENSES or license_id in NON_SPDX_PLACEHOLDERS:
+        return True
+    return bool(_SPDX_LICENSE_ID_RE.match(license_id))
+
 
 def get_license_text(
     license_id: str, year: str, author_name: str
 ) -> str:
     """Get rendered license text for a given SPDX identifier.
+
+    Behavior:
+      - If ``license_id`` is in ``LICENSES``: returns the full known
+        text with ``{year}`` and ``{author_name}`` substituted
+      - If ``license_id`` is in ``NON_SPDX_PLACEHOLDERS`` (UNLICENSED,
+        Proprietary, ...): returns the UNLICENSED-style attribution
+        block (proprietary, all-rights-reserved)
+      - Otherwise (any other valid-looking SPDX id): returns a
+        placeholder LICENSE that names the id and asks the author to
+        paste in the canonical text. ``reuse lint`` will surface
+        typos in the id itself.
 
     Args:
         license_id: SPDX license identifier
@@ -184,18 +238,44 @@ def get_license_text(
         author_name: Author/copyright holder name
 
     Returns:
-        Full license text with year and author substituted
+        Full LICENSE file contents
 
     Raises:
-        ValueError: If license_id is not supported
+        ValueError: If ``license_id`` is empty or fails the loose
+            SPDX format check (see ``is_valid_license_id``)
     """
-    if license_id not in LICENSES:
+    if not is_valid_license_id(license_id):
         raise ValueError(
-            f"Unsupported license: {license_id}. "
-            f"Supported: {', '.join(SUPPORTED_LICENSES)}"
+            f"Invalid license identifier: {license_id!r}. "
+            f"Expected an SPDX id (e.g., 'MIT', 'MPL-2.0', "
+            f"'Apache-2.0') or a recognized placeholder "
+            f"('UNLICENSED', 'Proprietary')."
         )
 
-    text = LICENSES[license_id]
+    if license_id in LICENSES:
+        text = LICENSES[license_id]
+    elif license_id in NON_SPDX_PLACEHOLDERS:
+        # Treat all proprietary / placeholder ids uniformly with the
+        # UNLICENSED template.
+        text = LICENSES["UNLICENSED"]
+    else:
+        # Custom / unknown SPDX id picked via "Other". Emit a
+        # minimal LICENSE shell so the project still has *something*
+        # at the root and consumers know what to look for.
+        text = (
+            "{license_id}\n"
+            "\n"
+            "Copyright (c) {year} {author_name}\n"
+            "\n"
+            "This project is licensed under the {license_id} "
+            "license. The full text of this license is not "
+            "bundled in the scaffold — paste the canonical text "
+            "from https://spdx.org/licenses/{license_id}.html "
+            "here, or use `curl` against the SPDX license list "
+            "to fetch it.\n"
+        )
+
+    text = text.replace("{license_id}", license_id)
     text = text.replace("{year}", year)
     text = text.replace("{author_name}", author_name)
     return text

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -745,6 +745,97 @@ class TestExecuteWithSkillStub(unittest.TestCase):
             )
 
 
+# REUSE-IgnoreStart — this class asserts on literal SPDX-License-Identifier
+# strings inside test source; REUSE shouldn't try to parse those as real
+# expressions.
+class TestExecuteCustomLicense(unittest.TestCase):
+    """Test execute with a custom (Other) SPDX license id.
+
+    Regression for #111: previously the scaffold rejected any
+    license_id not in `SUPPORTED_LICENSES`. Users who picked "Other"
+    in the question UI and typed a real SPDX id like `MPL-2.0` or
+    `BSD-3-Clause` got `Unsupported license` and the scaffold
+    aborted. Now those ids succeed; the scaffold writes a
+    placeholder `LICENSE` referencing the SPDX list, plus the
+    correct `SPDX-License-Identifier` headers in every generated
+    file.
+    """
+
+    @patch.object(_scaffold_mod, "initialize_git", return_value=True)
+    @patch.object(_scaffold_mod, "create_initial_commit", return_value=True)
+    def test_accepts_mpl_2_0(self, mock_commit, mock_git):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = str(Path(tmp) / "mpl-plugin")
+            context = {
+                "plugin_name": "mpl-plugin",
+                "description": (
+                    "A plugin licensed under MPL-2.0 for #111"
+                ),
+                "license": "MPL-2.0",
+                "language": "python",
+                "target_directory": target,
+                "author_name": "Test Author",
+                "author_email": "test@example.com",
+                "keywords": "",
+                "version": "0.1.0",
+            }
+            result = execute(context)
+            self.assertTrue(result["success"], result.get("message"))
+
+            target_path = Path(result["path"])
+
+            # LICENSE present, mentions MPL-2.0
+            license_text = (target_path / "LICENSE").read_text()
+            self.assertIn("MPL-2.0", license_text)
+            self.assertIn("Test Author", license_text)
+            # Placeholder must point at the SPDX list so authors
+            # know how to fill in the canonical text.
+            self.assertIn("spdx.org/licenses/", license_text)
+
+            # The LICENSES/<id>.txt copy must also be written and
+            # carry the SPDX id so `reuse lint` is happy.
+            licenses_copy = (
+                target_path / "LICENSES" / "MPL-2.0.txt"
+            ).read_text()
+            self.assertIn("MPL-2.0", licenses_copy)
+
+            # SPDX headers in generated markdown must reference MPL-2.0.
+            claude_md = (target_path / "CLAUDE.md").read_text()
+            self.assertIn(
+                "SPDX-License-Identifier: MPL-2.0",
+                claude_md,
+                "CLAUDE.md should carry SPDX-License-Identifier: "
+                "MPL-2.0 header",
+            )
+
+    @patch.object(_scaffold_mod, "initialize_git", return_value=True)
+    @patch.object(_scaffold_mod, "create_initial_commit", return_value=True)
+    def test_rejects_malformed_license(
+        self, mock_commit, mock_git
+    ):
+        """Defense-in-depth: shell-metachar / whitespace ids are
+        still rejected even though we accept arbitrary SPDX ids."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = str(Path(tmp) / "evil-plugin")
+            context = {
+                "plugin_name": "evil-plugin",
+                "description": (
+                    "A plugin with a malformed license id for #111"
+                ),
+                "license": "MIT; rm -rf /",
+                "language": "python",
+                "target_directory": target,
+                "author_name": "Test Author",
+                "author_email": "test@example.com",
+                "keywords": "",
+                "version": "0.1.0",
+            }
+            result = execute(context)
+            self.assertFalse(result["success"])
+            self.assertIn("Invalid license", result["message"])
+# REUSE-IgnoreEnd
+
+
 class TestExecuteValidation(unittest.TestCase):
     """Test execute input validation."""
 

--- a/tests/unit/test_scaffold_licenses.py
+++ b/tests/unit/test_scaffold_licenses.py
@@ -21,7 +21,9 @@ sys.modules.pop("_paths", None)
 
 from operations.scaffold_ops.licenses import (  # noqa: E402
     get_license_text,
+    is_valid_license_id,
     LICENSES,
+    PROMPT_LICENSE_OPTIONS,
     SUPPORTED_LICENSES,
 )
 
@@ -86,26 +88,114 @@ class TestGetLicenseText(unittest.TestCase):
         self.assertNotIn("{year}", text)
         self.assertNotIn("{author_name}", text)
 
-    def test_unknown_license_raises_value_error(self):
-        """Unknown license IDs should raise ValueError."""
-        with self.assertRaises(ValueError) as cm:
-            get_license_text("UNKNOWN-LICENSE", "2026", "Author")
-        self.assertIn("Unsupported license", str(cm.exception))
-        self.assertIn("UNKNOWN-LICENSE", str(cm.exception))
-
     def test_supported_licenses_list(self):
         """SUPPORTED_LICENSES should match LICENSES dict keys."""
         self.assertEqual(set(SUPPORTED_LICENSES), set(LICENSES.keys()))
 
     def test_licenses_count(self):
-        """Should have exactly 6 supported licenses."""
+        """Should have exactly 6 fully-bundled licenses."""
         self.assertEqual(len(SUPPORTED_LICENSES), 6)
+
+    def test_prompt_option_cap(self):
+        """Interactive prompt options must fit AskUserQuestion's
+        4-option cap (#85, #111).
+        """
+        self.assertLessEqual(len(PROMPT_LICENSE_OPTIONS), 4)
+        # Sanity: every prompt option must be either a fully-bundled
+        # license or a recognized placeholder.
+        for opt in PROMPT_LICENSE_OPTIONS:
+            self.assertTrue(
+                is_valid_license_id(opt),
+                f"PROMPT_LICENSE_OPTIONS contains an invalid id: {opt}",
+            )
 
     def test_format_string_injection_safe(self):
         """Author names with format-like patterns should not cause errors."""
         # This should not raise KeyError or other format-related errors
         text = get_license_text("MIT", "2026", "Author {with} {curly} braces")
         self.assertIn("Author {with} {curly} braces", text)
+
+
+class TestIsValidLicenseId(unittest.TestCase):
+    """Test the loose SPDX-id validator that gates scaffold input."""
+
+    def test_known_license_is_valid(self):
+        for lic in ("MIT", "Apache-2.0", "GPL-3.0", "ISC", "AGPL-3.0"):
+            self.assertTrue(is_valid_license_id(lic))
+
+    def test_placeholder_is_valid(self):
+        # UNLICENSED + friends are valid scaffold input even though
+        # they're not real SPDX ids — downstream they suppress the
+        # License-Identifier header.
+        for lic in ("UNLICENSED", "Proprietary", "PROPRIETARY"):
+            self.assertTrue(is_valid_license_id(lic))
+
+    def test_other_spdx_id_is_valid(self):
+        # Real SPDX ids we don't bundle text for must still validate.
+        for lic in (
+            "MPL-2.0",
+            "BSD-3-Clause",
+            "LGPL-3.0-or-later",
+            "GPL-3.0-only",
+            "0BSD",
+            "Unlicense",
+        ):
+            self.assertTrue(
+                is_valid_license_id(lic),
+                f"Real SPDX id {lic!r} should validate",
+            )
+
+    def test_empty_or_whitespace_rejected(self):
+        for lic in ("", " ", "  ", "\t"):
+            self.assertFalse(is_valid_license_id(lic))
+
+    def test_shell_metacharacters_rejected(self):
+        # Defense in depth — license_id flows into file content but
+        # could end up in a shell context (e.g., next-steps printing).
+        for bad in (
+            "MIT; rm -rf /",
+            "MIT && evil",
+            "MIT $(whoami)",
+            "MIT`evil`",
+            "MIT|pipe",
+            "MIT\nnewline",
+        ):
+            self.assertFalse(
+                is_valid_license_id(bad),
+                f"Suspicious id should be rejected: {bad!r}",
+            )
+
+
+class TestGetLicenseTextOther(unittest.TestCase):
+    """Test the 'Other' SPDX id path — unknown ids get a placeholder
+    LICENSE instead of an error (#111).
+    """
+
+    def test_unknown_spdx_id_writes_placeholder(self):
+        # MPL-2.0 is a real SPDX id but we don't bundle the full text.
+        # The scaffold should still succeed and write a placeholder.
+        text = get_license_text("MPL-2.0", "2026", "Test Author")
+        self.assertIn("MPL-2.0", text)
+        self.assertIn("Test Author", text)
+        self.assertIn("2026", text)
+        # Placeholder should explicitly point at the SPDX license list
+        # so authors know how to fill it in.
+        self.assertIn("spdx.org/licenses/", text)
+
+    def test_invalid_identifier_still_raises(self):
+        # An id that fails is_valid_license_id (whitespace, shell
+        # metacharacters) must still raise — defense in depth.
+        with self.assertRaises(ValueError):
+            get_license_text("MIT; rm -rf /", "2026", "Author")
+
+    def test_unlicensed_placeholder_uses_attribution_text(self):
+        """All NON_SPDX_PLACEHOLDERS render as proprietary attribution.
+        """
+        for placeholder in ("UNLICENSED", "Proprietary", "PROPRIETARY"):
+            text = get_license_text(placeholder, "2026", "Author")
+            self.assertIn("All rights reserved", text)
+            self.assertIn("2026", text)
+            self.assertIn("Author", text)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -536,25 +536,24 @@ class TestConfigureQuestionOptions(unittest.TestCase):
 
     AskUserQuestion's JSON schema caps `options` at 4 items per
     question (the user always gets a free "Other" on top of that).
-    Any choice question in configure.py that ships with > 4 options
-    is undeliverable to the user. This test scans the source and
-    asserts every choice question is within cap, so future additions
-    don't reintroduce the bug.
+    Any choice question in our question-emitting Python files that
+    ships with > 4 options is undeliverable to the user. This test
+    scans the source files and asserts every choice question is within
+    cap, so future additions don't reintroduce the bug.
     """
 
     ASK_USER_QUESTION_OPTION_CAP = 4
 
+    # Files we scan for question definitions. Add new ones here as
+    # they ship — anything that builds `{"id": ..., "options": [...]}`
+    # dicts is in scope.
+    QUESTION_SOURCE_FILES = (
+        ("skills", "aida", "scripts", "configure.py"),
+        ("skills", "plugin-manager", "scripts", "operations", "scaffold.py"),
+    )
+
     def test_choice_questions_respect_option_cap(self):
         import re
-
-        configure_path = (
-            Path(__file__).parent.parent.parent
-            / "skills"
-            / "aida"
-            / "scripts"
-            / "configure.py"
-        )
-        source = configure_path.read_text(encoding="utf-8")
 
         # Match each question dict: capture id and the options list.
         # Non-greedy across whitespace/lines. Tolerant of trailing
@@ -565,20 +564,38 @@ class TestConfigureQuestionOptions(unittest.TestCase):
             r'"options":\s*\[(?P<opts>[\s\S]*?)\]',
         )
 
+        # `options` can also be supplied as a bare identifier (e.g.,
+        # `options: SUPPORTED_LANGUAGES`); the static-list cap test
+        # only catches literal `[...]` definitions. That's fine —
+        # named lists like SUPPORTED_LANGUAGES are sized by separate
+        # unit tests where the constants live.
+
+        repo_root = Path(__file__).parent.parent.parent
         offenders = []
-        for m in pattern.finditer(source):
-            qid = m.group("id")
-            opts = re.findall(r'"([^"]+)"', m.group("opts"))
-            if len(opts) > self.ASK_USER_QUESTION_OPTION_CAP:
-                offenders.append((qid, len(opts), opts))
+        for parts in self.QUESTION_SOURCE_FILES:
+            source_path = repo_root.joinpath(*parts)
+            self.assertTrue(
+                source_path.exists(),
+                f"Expected question-emitting source file at "
+                f"{source_path}",
+            )
+            source = source_path.read_text(encoding="utf-8")
+
+            for m in pattern.finditer(source):
+                qid = m.group("id")
+                opts = re.findall(r'"([^"]+)"', m.group("opts"))
+                if len(opts) > self.ASK_USER_QUESTION_OPTION_CAP:
+                    offenders.append(
+                        (str(source_path), qid, len(opts), opts)
+                    )
 
         self.assertEqual(
             offenders,
             [],
             "Choice questions exceed AskUserQuestion's 4-option cap:\n"
             + "\n".join(
-                f"  {qid}: {n} options ({opts})"
-                for qid, n, opts in offenders
+                f"  {path} :: {qid}: {n} options ({opts})"
+                for path, qid, n, opts in offenders
             ),
         )
 


### PR DESCRIPTION
## Summary

The scaffold license prompt offered all 6 entries in \`SUPPORTED_LICENSES\` — AskUserQuestion caps \`options\` at 4 (plus its always-supplied \"Other\"), so the prompt was undeliverable. Same shape as #85, just in a different file.

### Two fixes in one PR

**1. Cap the prompt at 4 options** — new curated \`PROMPT_LICENSE_OPTIONS\` list:

- MIT
- Apache-2.0
- GPL-3.0
- UNLICENSED

ISC and AGPL-3.0 remain in \`SUPPORTED_LICENSES\` for non-interactive callers (\`/aida plugin scaffold --license ISC ...\` still works); they're just not in the interactive prompt.

**2. \"Other\" SPDX id support.** Picking \"Other\" and typing any well-formed SPDX id (\`MPL-2.0\`, \`BSD-3-Clause\`, \`LGPL-3.0-or-later\`, \`0BSD\`, \`Unlicense\`, …) now works end-to-end:

- Placeholder \`LICENSE\` at repo root names the SPDX id and points the author at \`https://spdx.org/licenses/<id>.html\` for canonical text
- \`LICENSES/<id>.txt\` (REUSE-required) gets the same placeholder
- Every generated file carries the correct \`SPDX-License-Identifier: <id>\` header

## Test plan

- [x] \`pytest tests/unit/test_scaffold_licenses.py\` — 20 pass (10 new across two new test classes)
- [x] \`pytest tests/unit/test_scaffold.py::TestExecuteCustomLicense\` — 2 pass (end-to-end MPL-2.0 + malformed-id rejection)
- [x] \`pytest tests/unit/test_utils.py::TestConfigureQuestionOptions\` — 1 pass (now scans both configure.py + scaffold.py)
- [x] \`pytest\` full suite — 947 pass (was 937, +10)
- [x] \`ruff check\` clean
- [x] \`reuse lint\` on aida-core itself — 321/321 files clean (test source's literal SPDX strings wrapped in \`REUSE-IgnoreStart\`/\`End\`)
- [x] **End-to-end**: scaffolded a fresh \`MPL-2.0\` Python plugin → 16/16 files REUSE 3.3 compliant; LICENSE points at \`spdx.org/licenses/MPL-2.0.html\`
- [x] Version bump 1.5.10 → 1.5.11 + CHANGELOG entry

## New helpers

- \`is_valid_license_id(license_id)\` in \`licenses.py\` — loose SPDX shape \`^[A-Za-z0-9.+\\-]+$\`, plus the existing \`NON_SPDX_PLACEHOLDERS\` from \`shared.spdx\`. Rejects empty / whitespace / shell metacharacters
- \`PROMPT_LICENSE_OPTIONS\` — separate constant from \`SUPPORTED_LICENSES\`, sized for the interactive cap

## Notes

- Closes the license half of the #96 promise (the language half landed in #112 / 1.5.10)
- \`TestConfigureQuestionOptions\` is now a single-source-of-truth guard for the #85-family bug across both \`configure.py\` and \`scaffold.py\`. Future question additions in either file get checked
- Part of milestone **Scaffold v2 — usable out of the box** (5/7 closed after merge)

Closes #111