### PR TITLE
feat: scaffold detects existing plugin + metadata + auto-route (#110, 1.5.13)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,76 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.13] - 2026-05-23
+
+### Added
+
+- **Scaffold detects existing AIDA plugins and offers to upgrade.**
+  Previously, pointing `/aida plugin scaffold` at a directory that
+  already contained `.claude-plugin/plugin.json` failed with
+  "Target directory is not empty" — a confusing dead-end (#110).
+  Now `get_questions` short-circuits to a single confirmation
+  prompt:
+  - **Yes, upgrade in place** → routes to the standards-migration
+    (`update`) flow, returning its result with
+    `upgrade_routed: True` and `operation: "scaffold"` so the
+    orchestrator surfaces the right context
+  - **No, cancel** → returns a clean "Upgrade declined" message;
+    no files touched
+  Behaviour for unrelated non-empty directories is unchanged —
+  they still surface "Target directory is not empty"
+- **`.claude-plugin/aida-scaffold.json` metadata.** Every
+  successful scaffold writes a small metadata file recording what
+  was scaffolded: `schema_version`, `plugin_name`,
+  `generator_version` (read from this plugin's `plugin.json`),
+  `language`, `license_id`, `include_agent_stub`,
+  `include_skill_stub`, `created_at`, `last_upgraded_at`. This
+  pairs with the upgrade-routing flow so re-runs can be precise
+- **`is_existing_aida_plugin(target)`** helper in
+  `scaffold_ops/context.py` — single source of truth for the
+  "this is an AIDA plugin" check (presence of
+  `.claude-plugin/plugin.json`)
+- **`read_scaffold_metadata(target)`** in `scaffold.py` — reads
+  the new metadata file, returns `None` on missing/malformed
+  input so callers can fall back to inference
+
+### Changed
+
+- **`/aida plugin update` honors the recorded language** via
+  `.claude-plugin/aida-scaffold.json`. Previously
+  `_detect_language` inferred from file presence (`pyproject.toml`
+  → python, `package.json` → typescript, default python) and
+  couldn't distinguish a `language="none"` (skills-only) plugin
+  from a Python one. Now metadata wins; filesystem inference is
+  the fallback for plugins scaffolded before this metadata
+  existed. Closes the #96 reporter's "/aida plugin update
+  auto-inferred Python on a markdown-only plugin" experience
+  end-to-end
+- `_detect_language` now returns `"none"` as a valid value (was
+  `"python"` or `"typescript"` only). Invalid metadata values
+  (e.g., `"rust"`) fall back to inference rather than propagating
+
+### Notes
+
+- The recorded `generator_version` is read at scaffold time from
+  this plugin's own `.claude-plugin/plugin.json` — so it always
+  reflects the actual aida-core version that produced the
+  scaffold, not a hardcoded constant that can drift
+- The metadata file uses `schema_version: 1` so future shape
+  changes can be detected
+- End-to-end verified four-step flow: scaffold a plugin →
+  metadata written → scaffold again at same path → confirmation
+  question surfaces → user picks "No" → clean cancel; user picks
+  "Yes" → routes to update
+- New tests (8) split across `test_scaffold.py` (existing-plugin
+  detection + routing + metadata write) and `test_update_scanner.py`
+  (metadata-driven `_detect_language` with fallback for invalid /
+  malformed metadata)
+- Milestone: `Scaffold v2 — usable out of the box` (7/7 closed
+  after merge)
+
+---
+
 ## [1.5.12] - 2026-05-22
 
 ### Added

--- a/skills/plugin-manager/scripts/operations/scaffold.py
+++ b/skills/plugin-manager/scripts/operations/scaffold.py
@@ -16,6 +16,7 @@ Usage (via manage.py):
     python manage.py --execute --context='{"operation": "scaffold", ...}'
 """
 
+import json
 import shlex
 import logging
 from datetime import datetime, timezone
@@ -30,6 +31,7 @@ from .utils import (
 )
 from .scaffold_ops.context import (
     infer_git_config,
+    is_existing_aida_plugin,
     validate_target_directory,
     check_gh_available,
     resolve_default_target,
@@ -89,6 +91,45 @@ def get_questions(
     Returns:
         Dictionary with 'questions' list and 'inferred' data
     """
+    # #110: short-circuit if the caller has explicitly pointed
+    # `target_directory` at an existing AIDA plugin. In that case
+    # the scaffold flow doesn't make sense — the directory already
+    # has a plugin. Surface a single confirmation question that
+    # offers to route into the standards-migration (update) flow
+    # instead of failing with "directory not empty".
+    target_str = context.get("target_directory")
+    if target_str:
+        target_path = Path(target_str).resolve()
+        if (
+            target_path.exists()
+            and target_path.is_dir()
+            and is_existing_aida_plugin(target_path)
+        ):
+            return {
+                "questions": [
+                    {
+                        "id": "upgrade_existing",
+                        "question": (
+                            f"Found an existing AIDA plugin at "
+                            f"{target_path}. Upgrade it to the "
+                            f"latest scaffold templates?"
+                        ),
+                        "type": "choice",
+                        "options": [
+                            "Yes, upgrade in place",
+                            "No, cancel",
+                        ],
+                        "default": "Yes, upgrade in place",
+                        "required": True,
+                    }
+                ],
+                "inferred": {
+                    "existing_plugin": True,
+                    "existing_plugin_path": str(target_path),
+                },
+                "phase": "get_questions",
+            }
+
     questions: list[dict[str, Any]] = []
     inferred: dict[str, Any] = {}
 
@@ -301,6 +342,51 @@ def execute(context: dict[str, Any]) -> dict[str, Any]:
     Returns:
         Result dictionary with success status and details
     """
+    # #110: if get_questions surfaced an existing-plugin confirmation
+    # and the user picked "upgrade", route to the standards-migration
+    # (update) flow instead of running scaffold. Importing update
+    # lazily keeps the module graph honest and avoids a circular
+    # import at module load time.
+    upgrade_answer = context.get("upgrade_existing")
+    if upgrade_answer:
+        target_str = context.get("target_directory") or context.get(
+            "existing_plugin_path"
+        )
+        if not target_str:
+            return {
+                "success": False,
+                "message": (
+                    "upgrade_existing was supplied but no "
+                    "target_directory / existing_plugin_path is "
+                    "available to route the update against"
+                ),
+            }
+        if str(upgrade_answer).startswith("No"):
+            return {
+                "success": True,
+                "message": (
+                    f"Upgrade declined; existing plugin at "
+                    f"{target_str} left untouched."
+                ),
+                "operation": "scaffold",
+                "upgrade_routed": False,
+            }
+
+        from . import update as _update_op
+
+        update_context = dict(context)
+        update_context["plugin_path"] = target_str
+        update_context["operation"] = "update"
+        result = _update_op.execute(update_context, context)
+        if isinstance(result, dict):
+            result.setdefault(
+                "message",
+                f"Upgraded existing plugin at {target_str}.",
+            )
+            result["operation"] = "scaffold"
+            result["upgrade_routed"] = True
+        return result
+
     # Validate required fields
     plugin_name = context.get("plugin_name", "")
     if not plugin_name:
@@ -503,6 +589,27 @@ def execute(context: dict[str, Any]) -> dict[str, Any]:
             )
             all_files.extend(stub_files)
 
+        # Write scaffold metadata so a future re-run (#110) or
+        # /aida plugin update can be precise about what was
+        # scaffolded — language, license, stubs, generator
+        # version. This sits next to plugin.json under
+        # .claude-plugin/ rather than mixing into plugin.json
+        # itself; the two files have orthogonal concerns.
+        _write_scaffold_metadata(
+            target,
+            plugin_name=plugin_name,
+            language=language,
+            license_id=license_id,
+            include_agent_stub=bool(
+                context.get("include_agent_stub")
+            ),
+            include_skill_stub=bool(
+                context.get("include_skill_stub")
+            ),
+            timestamp=variables["timestamp"],
+        )
+        all_files.append(".claude-plugin/aida-scaffold.json")
+
         # Initialize git
         git_initialized = initialize_git(target)
         git_committed = False
@@ -575,3 +682,83 @@ def _build_next_steps(
         )
 
     return steps
+
+
+SCAFFOLD_METADATA_RELATIVE = (
+    ".claude-plugin/aida-scaffold.json"
+)
+
+
+def _read_aida_plugin_version() -> str:
+    """Read this aida-core-plugin's own version from plugin.json.
+
+    Returns ``"unknown"`` if the manifest can't be located or
+    parsed — recorded metadata should be best-effort, never fatal.
+    """
+    plugin_json = (
+        _PROJECT_ROOT / ".claude-plugin" / "plugin.json"
+    )
+    try:
+        data = json.loads(plugin_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return "unknown"
+    version = data.get("version") if isinstance(data, dict) else None
+    return str(version) if version else "unknown"
+
+
+def _write_scaffold_metadata(
+    target: Path,
+    *,
+    plugin_name: str,
+    language: str,
+    license_id: str,
+    include_agent_stub: bool,
+    include_skill_stub: bool,
+    timestamp: str,
+) -> None:
+    """Record what was scaffolded so re-runs / upgrades can be precise.
+
+    Writes ``.claude-plugin/aida-scaffold.json``. Update operations
+    read this in preference to file-presence inference so e.g. a
+    markdown-only plugin doesn't get a Python toolchain applied on
+    upgrade (#96 / #110).
+    """
+    generator_version = _read_aida_plugin_version()
+
+    metadata = {
+        "schema_version": 1,
+        "plugin_name": plugin_name,
+        "generator_version": generator_version,
+        "language": language,
+        "license_id": license_id,
+        "include_agent_stub": include_agent_stub,
+        "include_skill_stub": include_skill_stub,
+        "created_at": timestamp,
+        "last_upgraded_at": timestamp,
+    }
+
+    metadata_path = target / SCAFFOLD_METADATA_RELATIVE
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.write_text(
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def read_scaffold_metadata(target: Path) -> dict[str, Any] | None:
+    """Read ``.claude-plugin/aida-scaffold.json`` if present.
+
+    Returns ``None`` if the file doesn't exist or fails to parse —
+    callers should fall back to file-presence inference for plugins
+    scaffolded before this metadata existed.
+    """
+    metadata_path = target / SCAFFOLD_METADATA_RELATIVE
+    if not metadata_path.exists():
+        return None
+    try:
+        data = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data

--- a/skills/plugin-manager/scripts/operations/scaffold.py
+++ b/skills/plugin-manager/scripts/operations/scaffold.py
@@ -16,6 +16,8 @@ Usage (via manage.py):
     python manage.py --execute --context='{"operation": "scaffold", ...}'
 """
 
+from __future__ import annotations
+
 import json
 import shlex
 import logging

--- a/skills/plugin-manager/scripts/operations/scaffold_ops/context.py
+++ b/skills/plugin-manager/scripts/operations/scaffold_ops/context.py
@@ -12,6 +12,19 @@ from pathlib import Path
 from typing import Optional
 
 
+def is_existing_aida_plugin(target: Path) -> bool:
+    """Return True if ``target`` already contains an AIDA plugin.
+
+    A directory is an existing AIDA plugin when it contains
+    ``.claude-plugin/plugin.json``. The scaffold wizard treats those
+    differently from unrelated non-empty directories — instead of
+    failing with "directory not empty", it offers to upgrade the
+    plugin via the standards-migration flow (#110).
+    """
+    marker = target / ".claude-plugin" / "plugin.json"
+    return marker.exists() and marker.is_file()
+
+
 def infer_git_config() -> dict[str, str]:
     """Infer author name and email from git config.
 
@@ -93,6 +106,15 @@ def validate_target_directory(
                 f"{target}",
             )
         if any(target.iterdir()):
+            # An existing AIDA plugin gets handled separately
+            # (the wizard offers to upgrade it); this validator
+            # only signals "unrelated non-empty directory".
+            if is_existing_aida_plugin(target):
+                return (
+                    False,
+                    f"Target directory already contains an "
+                    f"AIDA plugin: {target}",
+                )
             return (
                 False,
                 f"Target directory is not empty: "

--- a/skills/plugin-manager/scripts/operations/update_ops/scanner.py
+++ b/skills/plugin-manager/scripts/operations/update_ops/scanner.py
@@ -162,22 +162,45 @@ def _read_generator_version(plugin_path: Path) -> str:
 
 
 def _detect_language(plugin_path: Path) -> str:
-    """Detect the plugin language from filesystem markers.
+    """Detect the plugin language.
 
-    Checks for language-specific files in order of
-    specificity:
-    - pyproject.toml -> "python"
-    - package.json -> "typescript"
-    - scripts/ directory -> "python"
-    - src/ directory -> "typescript"
-    - default: "python"
+    Prefers ``.claude-plugin/aida-scaffold.json`` (#110) — that
+    records the exact language chosen at scaffold time, including
+    ``"none"`` for skills-only plugins. Falls back to filesystem
+    inference for plugins scaffolded before the metadata existed:
+
+    - ``pyproject.toml`` -> ``"python"``
+    - ``package.json`` -> ``"typescript"``
+    - ``scripts/`` directory -> ``"python"``
+    - ``src/`` directory -> ``"typescript"``
+    - default: ``"python"``
+
+    Note: filesystem inference cannot detect ``"none"`` (skills-only)
+    correctly — a markdown-only plugin would have been
+    misidentified as Python. The metadata path is what fixes the
+    #96 reporter's silent-Python-toolchain experience.
 
     Args:
         plugin_path: Absolute path to the plugin directory
 
     Returns:
-        "python" or "typescript"
+        ``"python"``, ``"typescript"``, or ``"none"``
     """
+    metadata_path = (
+        plugin_path / ".claude-plugin" / "aida-scaffold.json"
+    )
+    if metadata_path.exists():
+        try:
+            data = json.loads(
+                metadata_path.read_text(encoding="utf-8")
+            )
+        except (OSError, json.JSONDecodeError):
+            data = None
+        if isinstance(data, dict):
+            recorded = data.get("language")
+            if recorded in ("python", "typescript", "none"):
+                return recorded
+
     if (plugin_path / "pyproject.toml").exists():
         return "python"
     if (plugin_path / "package.json").exists():

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -22,6 +22,12 @@ for _mod_name in list(sys.modules):
 sys.modules.pop("_paths", None)
 
 from operations import scaffold as _scaffold_mod  # noqa: E402
+# Also pull in update so the snapshot below captures the
+# plugin-manager-bound copy. scaffold.execute()'s upgrade-routing
+# path (#110) lazy-imports operations.update; without this, a
+# different skill's test running first could leave a stale `_paths`
+# cached so update's `_paths.SCAFFOLD_TEMPLATES_DIR` lookup fails.
+from operations import update as _update_mod  # noqa: E402,F401
 
 get_questions = _scaffold_mod.get_questions
 execute = _scaffold_mod.execute
@@ -748,6 +754,165 @@ class TestExecuteWithSkillStub(unittest.TestCase):
 # REUSE-IgnoreStart — this class asserts on literal SPDX-License-Identifier
 # strings inside test source; REUSE shouldn't try to parse those as real
 # expressions.
+class TestScaffoldDetectsExistingPlugin(unittest.TestCase):
+    """Test the existing-plugin detection + upgrade routing (#110).
+
+    Before this work, pointing `scaffold` at a directory that already
+    contained an AIDA plugin failed with "Target directory is not
+    empty" — a confusing dead-end that didn't acknowledge the plugin
+    was already there. Now scaffold detects the existing
+    `.claude-plugin/plugin.json`, surfaces a single confirmation
+    question, and routes to the standards-migration (update) flow on
+    approval. Behaviour for unrelated non-empty directories is
+    unchanged ("not empty" still surfaces).
+    """
+
+    @patch.object(_scaffold_mod, "initialize_git", return_value=True)
+    @patch.object(_scaffold_mod, "create_initial_commit", return_value=True)
+    def test_metadata_is_written_on_scaffold(
+        self, mock_commit, mock_git
+    ):
+        """A successful scaffold writes aida-scaffold.json so a
+        future re-run can be precise about what was created.
+        """
+        import json as _json
+        with tempfile.TemporaryDirectory() as tmp:
+            target = str(Path(tmp) / "demo")
+            context = {
+                "plugin_name": "demo",
+                "description": "Plugin for #110 metadata test",
+                "license": "MIT",
+                "language": "python",
+                "target_directory": target,
+                "author_name": "Test",
+                "author_email": "t@example.com",
+                "keywords": "",
+                "version": "0.1.0",
+            }
+            result = execute(context)
+            self.assertTrue(result["success"], result.get("message"))
+
+            meta_path = (
+                Path(result["path"])
+                / ".claude-plugin"
+                / "aida-scaffold.json"
+            )
+            self.assertTrue(
+                meta_path.exists(),
+                "aida-scaffold.json should be written on scaffold",
+            )
+            md = _json.loads(meta_path.read_text(encoding="utf-8"))
+            self.assertEqual(md["language"], "python")
+            self.assertEqual(md["license_id"], "MIT")
+            self.assertEqual(md["plugin_name"], "demo")
+            self.assertIn("created_at", md)
+            self.assertIn("last_upgraded_at", md)
+            self.assertIn("generator_version", md)
+            self.assertEqual(md["schema_version"], 1)
+
+    def test_get_questions_detects_existing_plugin(self):
+        """When target_directory points at an existing plugin,
+        get_questions returns only the upgrade_existing question."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "existing"
+            (target / ".claude-plugin").mkdir(parents=True)
+            (target / ".claude-plugin" / "plugin.json").write_text(
+                '{"name": "existing", "version": "0.1.0"}\n'
+            )
+
+            result = _scaffold_mod.get_questions(
+                {"target_directory": str(target)}
+            )
+            question_ids = [q["id"] for q in result["questions"]]
+            self.assertEqual(question_ids, ["upgrade_existing"])
+            self.assertTrue(
+                result["inferred"].get("existing_plugin")
+            )
+            self.assertEqual(
+                result["inferred"].get("existing_plugin_path"),
+                str(target.resolve()),
+            )
+
+    def test_get_questions_ignores_non_plugin_non_empty(self):
+        """A non-empty directory without plugin.json is NOT treated
+        as an existing plugin — that path still falls through to the
+        normal scaffold questions (validate_target_directory will
+        reject it later with "directory not empty")."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "junk"
+            target.mkdir()
+            (target / "README.txt").write_text("unrelated\n")
+
+            result = _scaffold_mod.get_questions(
+                {"target_directory": str(target)}
+            )
+            # The existing-plugin short-circuit must NOT trigger;
+            # we get the normal full question set (plugin_name,
+            # description, license, language, …).
+            question_ids = {q["id"] for q in result["questions"]}
+            self.assertNotIn("upgrade_existing", question_ids)
+            self.assertFalse(
+                result.get("inferred", {}).get("existing_plugin")
+            )
+
+    def test_execute_declines_upgrade_returns_cancel(self):
+        """upgrade_existing='No, cancel' returns a clean cancel
+        message without touching the existing plugin."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "existing"
+            (target / ".claude-plugin").mkdir(parents=True)
+            (target / ".claude-plugin" / "plugin.json").write_text(
+                '{"name": "existing", "version": "0.1.0"}\n'
+            )
+
+            result = execute({
+                "target_directory": str(target),
+                "upgrade_existing": "No, cancel",
+            })
+            self.assertTrue(result["success"])
+            self.assertFalse(result["upgrade_routed"])
+            self.assertIn("Upgrade declined", result["message"])
+
+    @patch.object(_scaffold_mod, "initialize_git", return_value=True)
+    @patch.object(_scaffold_mod, "create_initial_commit", return_value=True)
+    def test_execute_confirms_upgrade_routes_to_update(
+        self, mock_commit, mock_git
+    ):
+        """upgrade_existing='Yes, upgrade in place' calls update.execute.
+
+        We verify by scaffolding a plugin first (so metadata + files
+        exist) and then re-running scaffold with the upgrade flag.
+        The result should bear `upgrade_routed=True` and come from
+        the update operation, not the scaffold operation.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            target = str(Path(tmp) / "demo")
+            initial_context = {
+                "plugin_name": "demo",
+                "description": (
+                    "Plugin for #110 upgrade-routing test"
+                ),
+                "license": "MIT",
+                "language": "python",
+                "target_directory": target,
+                "author_name": "Test",
+                "author_email": "t@example.com",
+                "keywords": "",
+                "version": "0.1.0",
+            }
+            initial = execute(initial_context)
+            self.assertTrue(
+                initial["success"], initial.get("message")
+            )
+
+            upgrade = execute({
+                "target_directory": target,
+                "upgrade_existing": "Yes, upgrade in place",
+            })
+            self.assertTrue(upgrade["success"])
+            self.assertTrue(upgrade["upgrade_routed"])
+
+
 class TestExecuteCustomLicense(unittest.TestCase):
     """Test execute with a custom (Other) SPDX license id.
 

--- a/tests/unit/test_update_scanner.py
+++ b/tests/unit/test_update_scanner.py
@@ -234,6 +234,79 @@ class TestDetectLanguage(unittest.TestCase):
                 _detect_language(plugin_dir), "python"
             )
 
+    def test_metadata_overrides_inference(self):
+        """`.claude-plugin/aida-scaffold.json` is preferred over
+        filesystem inference (#110).
+
+        Crucially, this lets the update flow honor `language="none"`
+        on a skills-only plugin — file-presence inference can't
+        distinguish "skills-only" from "Python" since both lack the
+        typical TS markers. Without this, `/aida plugin update` on
+        a markdown-only plugin would re-scaffold a Python toolchain
+        the author explicitly didn't want (#96).
+        """
+        import json as _json
+
+        # Plugin has pyproject.toml on disk (would infer "python"),
+        # but the recorded metadata says "none". Metadata wins.
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "skills-plugin"
+            (plugin_dir / ".claude-plugin").mkdir(parents=True)
+            (plugin_dir / "pyproject.toml").write_text("")
+            (
+                plugin_dir / ".claude-plugin" / "aida-scaffold.json"
+            ).write_text(
+                _json.dumps({
+                    "schema_version": 1,
+                    "language": "none",
+                    "license_id": "MIT",
+                })
+            )
+            self.assertEqual(
+                _detect_language(plugin_dir),
+                "none",
+                "Metadata-recorded language must take precedence "
+                "over filesystem inference",
+            )
+
+    def test_metadata_with_invalid_language_falls_back(self):
+        """If the metadata file has a language we don't recognize
+        (typo, future value, etc.), fall back to filesystem
+        inference rather than propagating an invalid value.
+        """
+        import json as _json
+
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "weird-plugin"
+            (plugin_dir / ".claude-plugin").mkdir(parents=True)
+            (plugin_dir / "package.json").write_text("{}")
+            (
+                plugin_dir / ".claude-plugin" / "aida-scaffold.json"
+            ).write_text(
+                _json.dumps({
+                    "schema_version": 1,
+                    "language": "rust",  # not in our supported set
+                })
+            )
+            self.assertEqual(
+                _detect_language(plugin_dir),
+                "typescript",  # falls back to package.json
+            )
+
+    def test_malformed_metadata_file_falls_back(self):
+        """A corrupt aida-scaffold.json must not crash detection."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "broken-plugin"
+            (plugin_dir / ".claude-plugin").mkdir(parents=True)
+            (plugin_dir / "scripts").mkdir()
+            (
+                plugin_dir / ".claude-plugin" / "aida-scaffold.json"
+            ).write_text("{not valid json")
+            self.assertEqual(
+                _detect_language(plugin_dir),
+                "python",  # falls back to scripts/ heuristic
+            )
+
 
 class TestScanPluginValid(unittest.TestCase):
     """Test scan_plugin with a valid plugin directory."""


### PR DESCRIPTION
## Summary

Closes the last open issue in **Scaffold v2** (7/7).

Previously, pointing \`/aida plugin scaffold\` at a directory that already contained \`.claude-plugin/plugin.json\` failed with "Target directory is not empty" — a confusing dead-end that didn't acknowledge the plugin was already there. This PR ships three pieces that together turn that into a proper upgrade flow.

### 1. Existing-plugin detection + auto-route

- New \`is_existing_aida_plugin(target)\` helper in \`scaffold_ops/context.py\` — single source of truth for "this is an AIDA plugin"
- \`scaffold.get_questions\` short-circuits to a single \`upgrade_existing\` confirmation question when \`target_directory\` points at an existing plugin
- \`scaffold.execute\` routes "Yes, upgrade in place" into \`update.execute\` (lazy import to avoid circular load) and returns the result with \`upgrade_routed=True\`
- "No, cancel" returns a clean cancel message; behavior for unrelated non-empty directories is unchanged

### 2. Scaffold metadata

Successful scaffolds now write \`.claude-plugin/aida-scaffold.json\`:

\`\`\`json
{
  "schema_version": 1,
  "plugin_name": "demo",
  "generator_version": "1.5.13",
  "language": "python",
  "license_id": "MIT",
  "include_agent_stub": false,
  "include_skill_stub": false,
  "created_at": "...",
  "last_upgraded_at": "..."
}
\`\`\`

\`generator_version\` is read at runtime from this plugin's own \`plugin.json\` so it always reflects the actual aida-core version, not a hardcoded constant that can drift.

### 3. Update flow honors the recorded language

This is the piece that closes the **#96 reporter's pain end-to-end**. \`update_ops/scanner._detect_language\` previously inferred from file presence (\`pyproject.toml\` → python, default python) and couldn't distinguish a \`language="none"\` (skills-only) plugin from a Python one. Now metadata wins; filesystem inference is the fallback for pre-metadata plugins.

- \`_detect_language\` now returns \`"none"\` as a valid value (was python/typescript only)
- Invalid metadata values (e.g., \`"rust"\`) fall back to filesystem inference rather than propagating
- Malformed metadata files (corrupt JSON) also fall back cleanly

## Test plan

- [x] \`pytest tests/unit/test_scaffold.py::TestScaffoldDetectsExistingPlugin\` — 5 pass (new)
- [x] \`pytest tests/unit/test_update_scanner.py::TestDetectLanguage\` — 8 pass (3 new, covering metadata-overrides, invalid-metadata fallback, malformed-metadata fallback)
- [x] \`pytest\` full suite — 956 pass (was 948, +8 new)
- [x] \`ruff check\` clean
- [x] \`reuse lint\` — 321/321 files REUSE 3.3 compliant
- [x] \`yamllint -c .yamllint.yml skills/\` clean
- [x] **End-to-end**: scaffolded a fresh plugin → metadata written → re-ran scaffold at same path → confirmation surfaced → "No" returns cancel, "Yes" routes to update with success
- [x] Version bump 1.5.12 → 1.5.13 + CHANGELOG entry

## Followup notes

- Future schema-bumps to \`aida-scaffold.json\` can read the \`schema_version\` field and dispatch migrators
- The recorded metadata also unblocks a future "show me what's outdated" report — knowing the scaffolder version that produced a plugin makes diffs precise

Closes #110