### PR TITLE
docs: .frontmatter-schema.json is a downstream-reusable contract (#88, 1.5.14)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.13",
+  "version": "1.5.14",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,31 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.14] - 2026-05-23
+
+### Added
+
+- **`docs/FRONTMATTER_SCHEMA.md`** documenting `.frontmatter-schema.json`
+  as a reusable contract for downstream plugins and marketplaces
+  (#88). Covers: the 10 supported `type` values and their
+  required fields, two consumption patterns (vendor + pin via
+  `curl`, or `$ref` the tagged raw URL), the type-enum expansion
+  policy (how to propose a new type vs add custom fields), and
+  the pain pattern that motivated the docs (a downstream wrote a
+  duplicate schema and spent ~2h discovering AIDA Core already
+  shipped the right one)
+- **README link** to the new docs page from the Reference section
+
+### Notes
+
+- The new docs page self-validates: its own frontmatter (`type:
+  reference`, `title`, `description`) passes the AIDA schema
+- Downstream consumers can pin against `v1.5.14` immediately;
+  earlier tagged URLs also work, just with the older type set
+- Milestone: `Config & Schema Quality`
+
+---
+
 ## [1.5.13] - 2026-05-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ For detailed walkthrough, see the [Getting Started Guide](docs/GETTING_STARTED.m
 
 - **[Examples](docs/EXAMPLES.md)** - Real-world usage scenarios
 - **[Extension Framework](docs/EXTENSION_FRAMEWORK.md)** - Architecture and design
+- **[Frontmatter Schema](docs/FRONTMATTER_SCHEMA.md)** - Reusable JSON Schema downstream plugins and marketplaces should adopt verbatim
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ For detailed walkthrough, see the [Getting Started Guide](docs/GETTING_STARTED.m
 
 - **[Examples](docs/EXAMPLES.md)** - Real-world usage scenarios
 - **[Extension Framework](docs/EXTENSION_FRAMEWORK.md)** - Architecture and design
-- **[Frontmatter Schema](docs/FRONTMATTER_SCHEMA.md)** - Reusable JSON Schema downstream plugins and marketplaces should adopt verbatim
+- **[Frontmatter Schema](docs/FRONTMATTER_SCHEMA.md)** - Reusable JSON Schema for downstream plugins / marketplaces
 
 ## Requirements
 

--- a/docs/FRONTMATTER_SCHEMA.md
+++ b/docs/FRONTMATTER_SCHEMA.md
@@ -1,0 +1,128 @@
+---
+type: reference
+title: "Frontmatter Schema"
+description: "Reusable JSON Schema for AIDA markdown frontmatter — types, required fields, consumption guide for downstream plugins and marketplaces."
+---
+
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# Frontmatter Schema
+
+AIDA Core ships a JSON Schema at the repo root,
+[`.frontmatter-schema.json`](../.frontmatter-schema.json), that
+validates the YAML frontmatter of every markdown file in this plugin
+and is **intended to be reused verbatim by downstream plugins and
+marketplaces**.
+
+If you maintain a plugin or a marketplace, please consume this schema
+rather than writing your own. Consistency across the ecosystem makes
+search, indexing, and contributor tooling work the same way
+everywhere.
+
+## What it covers
+
+The schema is type-driven. Every frontmatter block must declare a
+`type`, and the schema applies type-specific required-field rules.
+Ten types are supported today:
+
+| `type` | Required fields | Used for |
+| --- | --- | --- |
+| `skill` | `name`, `description`, `version`, `tags` | SKILL.md files |
+| `agent` | `name`, `description`, `version`, `tags` | Agent definitions |
+| `adr` | `title`, `status`, `date` | Architecture Decision Records |
+| `diagram` | `title`, `diagram-type` | Diagram markdown wrappers |
+| `documentation` | `title` | General documentation pages |
+| `guide` | `title` | How-to guides |
+| `reference` | `title` | Reference docs |
+| `changelog` | `title` | Changelog files |
+| `readme` | `title` | README files |
+| `issue` | `title`, `issue` | Issue-style notes |
+
+The schema also constrains shapes: `name` must be kebab-case
+(`^[a-z][a-z0-9-]*$`, 2-50 chars), `version` must be semver
+(`^\d+\.\d+\.\d+$`), `description` is 10-500 chars, etc. Run
+[`ajv`](https://ajv.js.org/) or
+[`jsonschema`](https://python-jsonschema.readthedocs.io/) against
+your frontmatter to see the full validation surface.
+
+## How to consume it
+
+### Option 1: Vendor the schema into your repo (recommended for now)
+
+Copy `.frontmatter-schema.json` into your repo (`schemas/`
+directory works) and validate against the local copy. Pin to a
+specific aida-core release so the schema can't change under you.
+
+```bash
+# Pull the schema at a specific aida-core tag
+curl -L https://raw.githubusercontent.com/aida-core/aida-core-plugin/v1.5.13/.frontmatter-schema.json \
+  -o schemas/frontmatter.schema.json
+```
+
+Re-pull when you upgrade aida-core; review the diff to see what types
+or required fields changed.
+
+### Option 2: Reference the raw URL directly
+
+If your validator supports HTTP `$ref`, point at the tagged raw URL.
+Don't use `main` — that moves under you:
+
+```json
+{
+  "$ref": "https://raw.githubusercontent.com/aida-core/aida-core-plugin/v1.5.13/.frontmatter-schema.json"
+}
+```
+
+A future release may expose a stable URL via GitHub Pages; until then
+the tagged raw URL is the contract.
+
+## Type-enum expansion policy
+
+The `type` enum grows when AIDA Core adds a new artifact category
+that needs distinct required fields. Today's set covers the existing
+artifacts; new entries are added carefully because every downstream
+consumer that pinned a specific version inherits the new shape on
+upgrade.
+
+If you have an artifact that doesn't fit any existing type, you have
+two options:
+
+1. **Propose a new type upstream.** Open an issue with a brief
+   description of what the artifact is, what fields it needs, and
+   why an existing type doesn't fit. New types land in a minor
+   release.
+2. **Use `documentation` or `reference` and add custom fields.**
+   The schema doesn't reject unknown properties, so you can add
+   `team_owner`, `audience`, etc., on top of the documented
+   required set. Validation still works against the AIDA-known
+   fields; your extras are just ignored.
+
+Generally prefer (1) when the new shape is something other plugins
+might also want; prefer (2) when it's truly your project's concern.
+
+## Why this matters
+
+Without the shared schema, every downstream plugin reinvents
+frontmatter conventions. The pain pattern that motivated this
+contract (see issue #88):
+
+- A marketplace maintainer wrote their own `schemas/frontmatter.schema.json`
+- It required `title` + `description` for everything
+- That broke the auto-generated SKILL.md (which uses `name`, not
+  `title`, per AIDA convention)
+- ~2 hours of debugging before discovering that AIDA Core already
+  shipped the right schema
+
+Sharing the schema avoids re-deriving the same field set across
+repos and keeps tooling that reads frontmatter (search, listings,
+knowledge indexes, automated routing) predictable.
+
+## Related
+
+- The validator in
+  [splash-ai-marketplace](https://github.com/Splash-AI/splash-ai-marketplace)
+  reads this schema for marketplace-wide validation
+- Issue #89 tracks recommending `description` on documentation
+  types (`adr`, `documentation`, `guide`, `reference`, `readme`)
+  to improve search-quality across the ecosystem


### PR DESCRIPTION
## Summary

\`aida-core-plugin\` ships an excellent type-driven JSON Schema at the repo root that downstream plugins and marketplaces should adopt verbatim — but there was no documentation calling it out as a supported, reusable contract. Discovery was accidental: the #88 reporter wrote their own schema, broke their auto-generated SKILL.md (which uses \`name\` not \`title\` per the AIDA convention), and spent ~2h debugging before finding the one we already shipped.

## What's new

**\`docs/FRONTMATTER_SCHEMA.md\`** — full contract reference covering:

- The 10 supported \`type\` values (\`skill\`, \`agent\`, \`adr\`, \`diagram\`, \`documentation\`, \`guide\`, \`reference\`, \`changelog\`, \`readme\`, \`issue\`) and their per-type required fields
- Two consumption patterns:
  - **Vendor + pin**: \`curl -L https://raw.githubusercontent.com/aida-core/aida-core-plugin/v1.5.14/.frontmatter-schema.json -o schemas/frontmatter.schema.json\`
  - **\`$ref\` the tagged raw URL** (for validators that support remote refs)
- Type-enum expansion policy (propose a new type upstream vs add custom fields)
- The pain pattern that motivated this contract

**README link** to the new doc from the Reference section.

## Test plan

- [x] \`pytest\` — 956 pass (no test changes — pure docs)
- [x] \`ruff check\` clean
- [x] \`yamllint -c .yamllint.yml skills/\` clean
- [x] \`reuse lint\` — 322/322 files clean (was 321 + the new doc)
- [x] **Dogfood check**: the new doc's own frontmatter (\`type: reference\`, \`title\`, \`description\`) validates against \`.frontmatter-schema.json\` via \`jsonschema\`
- [x] Version bump 1.5.13 → 1.5.14 + CHANGELOG entry

## Notes

- Downstream consumers can pin against \`v1.5.14\` immediately; earlier tagged URLs also work, just with the older type set
- Pure docs PR — no scaffold / runtime behavior changes
- Part of milestone **Config & Schema Quality**

Closes #88