### PR TITLE
feat: description recommended on doc frontmatter types (#89, 1.5.15)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/.frontmatter-schema.json
+++ b/.frontmatter-schema.json
@@ -96,11 +96,16 @@
         "properties": { "type": { "const": "adr" } }
       },
       "then": {
+        "description": "ADR — required: title, status, date. Recommended: description (improves search-quality and knowledge-index rendering).",
         "required": ["title", "status", "date"],
         "properties": {
           "title": {
             "type": "string",
             "minLength": 5
+          },
+          "description": {
+            "type": "string",
+            "description": "Recommended: a 1-2 sentence summary of the decision. Indexers and search rely on this."
           },
           "status": {
             "type": "string",
@@ -128,6 +133,7 @@
         "properties": { "type": { "const": "documentation" } }
       },
       "then": {
+        "description": "Documentation — required: title. Recommended: description (improves search-quality and knowledge-index rendering).",
         "required": ["title"],
         "properties": {
           "title": {
@@ -135,7 +141,8 @@
             "minLength": 3
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Recommended: a 1-2 sentence summary. Indexers and search rely on this."
           },
           "audience": {
             "type": "string",
@@ -149,6 +156,7 @@
         "properties": { "type": { "const": "guide" } }
       },
       "then": {
+        "description": "Guide — required: title. Recommended: description (improves search-quality and knowledge-index rendering).",
         "required": ["title"],
         "properties": {
           "title": {
@@ -156,7 +164,8 @@
             "minLength": 3
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Recommended: a 1-2 sentence summary. Indexers and search rely on this."
           },
           "audience": {
             "type": "string",
@@ -188,6 +197,7 @@
         "properties": { "type": { "const": "reference" } }
       },
       "then": {
+        "description": "Reference — required: title. Recommended: description (improves search-quality and knowledge-index rendering).",
         "required": ["title"],
         "properties": {
           "title": {
@@ -195,7 +205,8 @@
             "minLength": 3
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Recommended: a 1-2 sentence summary. Indexers and search rely on this."
           }
         }
       }
@@ -205,6 +216,7 @@
         "properties": { "type": { "const": "changelog" } }
       },
       "then": {
+        "description": "Changelog — required: title. (No recommendations for changelogs.)",
         "required": ["title"],
         "properties": {
           "title": {
@@ -218,6 +230,7 @@
         "properties": { "type": { "const": "readme" } }
       },
       "then": {
+        "description": "Readme — required: title. Recommended: description (improves search-quality and knowledge-index rendering).",
         "required": ["title"],
         "properties": {
           "title": {
@@ -225,7 +238,8 @@
             "minLength": 3
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Recommended: a 1-2 sentence summary. Indexers and search rely on this."
           }
         }
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,38 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.15] - 2026-05-23
+
+### Added
+
+- **`description` is now flagged "recommended"** on
+  documentation-flavored frontmatter types (`adr`, `documentation`,
+  `guide`, `reference`, `readme`) via per-branch JSON Schema
+  `description` annotations in `.frontmatter-schema.json`. Not
+  enforced by validation — JSON Schema has no native "recommended"
+  keyword — so existing files without `description` still pass,
+  but knowledge indexes and search tooling can now read the
+  schema's intent (#89)
+- **"Recommended fields" section** in
+  `docs/FRONTMATTER_SCHEMA.md` explains the
+  required-vs-recommended split, shows the well-formed shape, and
+  gives marketplace-validator guidance ("warn, don't fail")
+- **Description fields added to 15 doc-flavored files we own**
+  (lead-by-example dogfood pass): 11 ADRs, 2 user guides,
+  `scaffolding-workflow.md`, and `CLAUDE.md`. Each gets a
+  one-sentence summary suitable for indexing
+
+### Notes
+
+- The 5 remaining files without `description` are historical
+  artifacts in `.issues/completed/` and `docs/superpowers/` —
+  left as frozen snapshots intentionally
+- Pure docs + schema-annotation change; no runtime behavior
+  changes
+- Milestone: `Config & Schema Quality`
+
+---
+
 ## [1.5.14] - 2026-05-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 ---
 type: readme
 title: AIDA Core Plugin
+description: "AIDA Core plugin manifest for Claude Code — project layout, conventions, and development setup."
 ---
 
 <!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->

--- a/docs/FRONTMATTER_SCHEMA.md
+++ b/docs/FRONTMATTER_SCHEMA.md
@@ -46,6 +46,34 @@ The schema also constrains shapes: `name` must be kebab-case
 [`jsonschema`](https://python-jsonschema.readthedocs.io/) against
 your frontmatter to see the full validation surface.
 
+## Recommended fields
+
+JSON Schema has no native "recommended" keyword — required is
+required, everything else is optional. AIDA Core's schema uses
+per-branch `description` annotations to flag fields that are
+**strongly encouraged but not enforced**. Validators ignore them;
+humans and tooling that index frontmatter rely on them.
+
+For documentation-flavored types (`adr`, `documentation`, `guide`,
+`reference`, `readme`), **`description` is recommended** even
+though it isn't in the `required` list. Knowledge indexes, search
+listings, and routing tools all consume `description` to summarize
+a file in one line. Files without it render as vague stubs (#89).
+
+A well-formed documentation file looks like:
+
+```yaml
+---
+type: reference
+title: "Frontmatter Schema"
+description: "Reusable JSON Schema for AIDA markdown frontmatter — types, required fields, consumption guide."
+---
+```
+
+If you maintain a marketplace validator, you can warn on missing
+recommended fields without failing the check — that's the right
+posture for the current `required` / `recommended` split.
+
 ## How to consume it
 
 ### Option 1: Vendor the schema into your repo (recommended for now)

--- a/docs/USER_GUIDE_CONFIGURE.md
+++ b/docs/USER_GUIDE_CONFIGURE.md
@@ -1,6 +1,7 @@
 ---
 type: guide
 title: "Configuration Guide"
+description: "How to configure AIDA for a project — detection flow, interactive prompts, and the generated config files."
 audience: users
 ---
 

--- a/docs/USER_GUIDE_INSTALL.md
+++ b/docs/USER_GUIDE_INSTALL.md
@@ -1,6 +1,7 @@
 ---
 type: guide
 title: "Installation Guide"
+description: "How to install AIDA Core and add it to Claude Code."
 audience: users
 ---
 

--- a/docs/architecture/adr/001-skills-first-architecture.md
+++ b/docs/architecture/adr/001-skills-first-architecture.md
@@ -1,6 +1,7 @@
 ---
 type: adr
 title: "ADR-001: Skills-First Architecture"
+description: "Skills (SKILL.md files combining process + execution) are the primary extension type; agents and knowledge layer on top."
 status: accepted
 date: "2025-11-01"
 deciders:

--- a/docs/architecture/adr/002-python-for-scripts.md
+++ b/docs/architecture/adr/002-python-for-scripts.md
@@ -1,6 +1,7 @@
 ---
 type: adr
 title: "ADR-002: Python for Installation Scripts"
+description: "Python is the runtime for AIDA's installation, configuration, and skill-execution scripts."
 status: accepted
 date: "2025-11-01"
 deciders:

--- a/docs/architecture/adr/003-jinja2-templates.md
+++ b/docs/architecture/adr/003-jinja2-templates.md
@@ -1,6 +1,7 @@
 ---
 type: adr
 title: "ADR-003: Jinja2 for Template Rendering"
+description: "Jinja2 is the template engine for scaffold and skill rendering across the plugin."
 status: accepted
 date: "2025-11-01"
 deciders:

--- a/docs/architecture/adr/004-yaml-questionnaires.md
+++ b/docs/architecture/adr/004-yaml-questionnaires.md
@@ -1,6 +1,7 @@
 ---
 type: adr
 title: "ADR-004: YAML for Questionnaire Definitions"
+description: "YAML stores questionnaire definitions consumed by the two-phase API pattern (ADR-010)."
 status: accepted
 date: "2025-11-01"
 deciders:

--- a/docs/architecture/adr/005-local-first-storage.md
+++ b/docs/architecture/adr/005-local-first-storage.md
@@ -1,6 +1,7 @@
 ---
 type: adr
 title: "ADR-005: Local-First Storage"
+description: "AIDA state lives on the user's machine (~/.claude/, .claude/); no remote or cloud storage by default."
 status: accepted
 date: "2025-11-01"
 deciders:

--- a/docs/architecture/adr/006-gh-cli-feedback.md
+++ b/docs/architecture/adr/006-gh-cli-feedback.md
@@ -1,6 +1,7 @@
 ---
 type: adr
 title: "ADR-006: GitHub CLI for Feedback System"
+description: "The `gh` CLI is the transport for the /aida feedback, /aida bug, and /aida feature-request flows."
 status: accepted
 date: "2025-11-01"
 deciders:

--- a/docs/architecture/adr/007-yaml-config-single-source-truth.md
+++ b/docs/architecture/adr/007-yaml-config-single-source-truth.md
@@ -1,6 +1,7 @@
 ---
 type: adr
 title: "ADR-007: YAML Configuration as Single Source of Truth"
+description: ".claude/aida-project-context.yml is the single source of truth for project configuration; SKILL.md is rendered from it."
 status: accepted
 date: "2025-11-05"
 deciders:

--- a/docs/architecture/adr/008-marketplace-centric-distribution.md
+++ b/docs/architecture/adr/008-marketplace-centric-distribution.md
@@ -1,6 +1,7 @@
 ---
 type: adr
 title: "ADR-008: Marketplace-Centric Distribution"
+description: "Plugins are distributed through marketplace manifests; users add marketplaces, then install plugins from them."
 status: accepted
 date: "2025-01-21"
 deciders:

--- a/docs/architecture/adr/009-input-validation-path-security.md
+++ b/docs/architecture/adr/009-input-validation-path-security.md
@@ -1,6 +1,7 @@
 ---
 type: adr
 title: "ADR-009: Input Validation and Path Security"
+description: "All paths are validated via Path.resolve() and explicit checks to prevent directory traversal and symlink attacks."
 status: accepted
 date: "2026-02-16"
 deciders:

--- a/docs/architecture/adr/010-two-phase-api-pattern.md
+++ b/docs/architecture/adr/010-two-phase-api-pattern.md
@@ -1,6 +1,7 @@
 ---
 type: adr
 title: "ADR-010: Two-Phase API Pattern for LLM Integration"
+description: "Two-phase API (get_questions then execute) lets LLM orchestrators surface questions to the user between detection and action."
 status: accepted
 date: "2026-02-16"
 deciders:

--- a/docs/architecture/adr/011-user-level-memento-storage.md
+++ b/docs/architecture/adr/011-user-level-memento-storage.md
@@ -1,6 +1,7 @@
 ---
 type: adr
 title: "ADR-011: User-Level Memento Storage with Project Namespacing"
+description: "Mementos live under ~/.claude/projects/<project>/memory/ with project namespacing — per-user, not per-checkout."
 status: accepted
 date: "2026-02-16"
 deciders:

--- a/skills/plugin-manager/references/scaffolding-workflow.md
+++ b/skills/plugin-manager/references/scaffolding-workflow.md
@@ -1,6 +1,7 @@
 ---
 type: reference
 title: Plugin Scaffolding Workflow
+description: "Two-phase plugin scaffolding workflow — questions, execution, template variables, language-specific files, error handling, and the gitignore + lint + bootstrap-ordering policies."
 ---
 
 <!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->


### PR DESCRIPTION
## Summary

JSON Schema has no native "recommended" keyword — \`required\` is required, everything else is optional. This PR flags \`description\` as **recommended (not required)** on documentation-flavored types via per-branch \`description\` annotations in \`.frontmatter-schema.json\`. Knowledge indexes, search tooling, and contributor docs can read the intent without the schema breaking existing descriptionless files.

## Three pieces

**1. Schema annotations** — \`.frontmatter-schema.json\` now carries per-branch policy descriptions on the doc-flavored types (\`adr\`, \`documentation\`, \`guide\`, \`reference\`, \`readme\`):

\`\`\`json
"then": {
  "description": "ADR — required: title, status, date. Recommended: description (improves search-quality and knowledge-index rendering).",
  "required": ["title", "status", "date"],
  "properties": {
    "description": {
      "type": "string",
      "description": "Recommended: a 1-2 sentence summary..."
    }
  }
}
\`\`\`

\`changelog\` gets a description annotation noting it has no recommendations.

**2. Docs** — new "Recommended fields" section in \`docs/FRONTMATTER_SCHEMA.md\` explaining the required-vs-recommended split, showing a well-formed shape, and giving marketplace validators the **"warn, don't fail"** guidance.

**3. Dogfood pass** — added \`description\` to 15 doc-flavored files we own:

- 11 ADRs (\`docs/architecture/adr/001-011\`)
- 2 user guides (\`docs/USER_GUIDE_CONFIGURE.md\`, \`docs/USER_GUIDE_INSTALL.md\`)
- \`skills/plugin-manager/references/scaffolding-workflow.md\`
- \`CLAUDE.md\`

Bulk-applied via a small Python script with a one-line summary per file (derived from each file's H1 / title).

## Test plan

- [x] \`pytest\` — 956 pass (no test changes — pure schema + docs)
- [x] Schema still loads as valid JSON; \`docs/FRONTMATTER_SCHEMA.md\` still validates against the updated schema
- [x] \`yamllint\` clean
- [x] \`reuse lint\` — 322/322 files clean
- [x] Audit before/after: 20 missing → 5 missing (the 5 remaining are historical artifacts in \`.issues/completed/\` and \`docs/superpowers/\` — left as frozen snapshots on purpose)
- [x] Version bump 1.5.14 → 1.5.15 + CHANGELOG entry

## Notes

- Non-breaking: any downstream file without \`description\` still validates against the schema
- The recommendation lives in the schema itself, so validators that surface schema annotations (most do, via \`description\` in error messages) will reflect it naturally
- Part of milestone **Config & Schema Quality** (2/6 closed after merge)

Closes #89