### PR TITLE
feat: language-family fallback for project_type detection (#86, 1.5.16)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,44 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.16] - 2026-05-23
+
+### Added
+
+- **Language-family fallback for `detect_project_type`** (#86).
+  When a project doesn't match any of the framework-specific
+  signatures (React / Next / Express / Django / Flask / FastAPI /
+  console_scripts / library), the inference now scans for
+  canonical manifest files and returns a useful language string:
+  - `package.json` + `tsconfig.json` → `Node/TypeScript`
+  - `package.json` (no tsconfig) → `Node/JavaScript`
+  - `pyproject.toml` → `Python` (pyproject takes precedence over
+    `setup.py` / `requirements.txt` — no double-counting)
+  - `setup.py` or `requirements.txt` (no pyproject) → `Python`
+  - `Cargo.toml` → `Rust`
+  - `go.mod` → `Go`
+  - `Gemfile` → `Ruby`
+  - `composer.json` → `PHP`
+
+  Multi-language projects return a sorted `+`-joined string (e.g.,
+  `"Node/TypeScript + Python"`), deterministic for testing.
+  Framework-specific detection still wins over language-family
+  fallback — a React project returns `"Web application
+  (frontend)"`, not `"Node/TypeScript"`. Previously these
+  multi-language repos returned `None`, which surfaced as
+  `"Unknown"` in the auto-generated SKILL.md and led to confusing
+  "Project Type: Unknown" claims on projects the author clearly
+  knew the type of
+
+### Notes
+
+- New `TestDetectProjectType` (8 cases) covers each ecosystem,
+  the multi-language repro case from #86, the empty-project None
+  return, and the framework-detection precedence
+- Milestone: `Config & Schema Quality`
+
+---
+
 ## [1.5.15] - 2026-05-23
 
 ### Added

--- a/skills/aida/scripts/utils/inference.py
+++ b/skills/aida/scripts/utils/inference.py
@@ -248,6 +248,52 @@ def detect_testing_approach(project_root: Path) -> Optional[str]:
     return None
 
 
+def _detect_language_families(project_root: Path) -> list:
+    """Detect language ecosystems present in the project (#86).
+
+    Scans for canonical manifest files and returns the set of
+    language families found. Used as a fallback when framework-
+    specific detection doesn't match a recognizable pattern.
+
+    Returns:
+        Sorted list of language family strings (deterministic
+        order for multi-language repos). Empty list if no
+        manifest files are found.
+    """
+    langs = []
+
+    # Node ecosystem: distinguish TypeScript vs JavaScript by
+    # tsconfig.json presence. Both share package.json.
+    if (project_root / "package.json").exists():
+        if (project_root / "tsconfig.json").exists():
+            langs.append("Node/TypeScript")
+        else:
+            langs.append("Node/JavaScript")
+
+    # Python: pyproject.toml is the modern marker; fall back to
+    # legacy setup.py / requirements.txt without double-counting
+    # if pyproject.toml is also present.
+    if (project_root / "pyproject.toml").exists():
+        langs.append("Python")
+    elif (
+        (project_root / "setup.py").exists()
+        or (project_root / "requirements.txt").exists()
+    ):
+        langs.append("Python")
+
+    # Other ecosystems — single canonical manifest per language
+    if (project_root / "Cargo.toml").exists():
+        langs.append("Rust")
+    if (project_root / "go.mod").exists():
+        langs.append("Go")
+    if (project_root / "Gemfile").exists():
+        langs.append("Ruby")
+    if (project_root / "composer.json").exists():
+        langs.append("PHP")
+
+    return sorted(langs)
+
+
 def detect_project_type(project_root: Path) -> Optional[str]:
     """Infer project type from structure and configuration.
 
@@ -300,6 +346,15 @@ def detect_project_type(project_root: Path) -> Optional[str]:
     # Library
     if (project_root / "setup.py").exists() or (project_root / "__init__.py").exists():
         return "Library or framework"
+
+    # Language-family fallback (#86): when no specific framework
+    # / artifact pattern matches but the project clearly uses one
+    # or more known languages, return that rather than letting
+    # the auto-generated SKILL.md claim "Unknown" on every
+    # multi-language repo.
+    langs = _detect_language_families(project_root)
+    if langs:
+        return " + ".join(langs)
 
     return None
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -8,6 +8,7 @@ version checking, path resolution, file operations, and error handling.
 """
 
 import sys
+import shutil
 import tempfile
 import unittest
 from pathlib import Path
@@ -597,6 +598,100 @@ class TestConfigureQuestionOptions(unittest.TestCase):
                 f"  {path} :: {qid}: {n} options ({opts})"
                 for path, qid, n, opts in offenders
             ),
+        )
+
+
+class TestDetectProjectType(unittest.TestCase):
+    """Test detect_project_type's language-family fallback (#86).
+
+    Previously, projects without a recognizable framework signature
+    returned None (which then surfaced as 'Unknown' in the auto-
+    generated SKILL.md). The fallback now detects the language
+    ecosystem from canonical manifest files and returns a useful
+    string (or a `+`-joined combination for multi-language repos).
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.root = Path(self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_typescript_only(self):
+        """package.json + tsconfig.json -> Node/TypeScript."""
+        from utils import detect_project_type
+        (self.root / "package.json").write_text('{"name": "x"}')
+        (self.root / "tsconfig.json").write_text("{}")
+        self.assertEqual(
+            detect_project_type(self.root), "Node/TypeScript"
+        )
+
+    def test_javascript_only(self):
+        """package.json without tsconfig -> Node/JavaScript."""
+        from utils import detect_project_type
+        (self.root / "package.json").write_text('{"name": "x"}')
+        self.assertEqual(
+            detect_project_type(self.root), "Node/JavaScript"
+        )
+
+    def test_python_modern(self):
+        """pyproject.toml -> Python (no double-counting with
+        requirements.txt)."""
+        from utils import detect_project_type
+        (self.root / "pyproject.toml").write_text(
+            "[project]\nname = 'x'\n"
+        )
+        (self.root / "requirements.txt").write_text("flask\n")
+        # pyproject takes precedence; only one 'Python' entry.
+        self.assertEqual(detect_project_type(self.root), "Python")
+
+    def test_rust(self):
+        from utils import detect_project_type
+        (self.root / "Cargo.toml").write_text(
+            "[package]\nname = 'x'\n"
+        )
+        self.assertEqual(detect_project_type(self.root), "Rust")
+
+    def test_go(self):
+        from utils import detect_project_type
+        (self.root / "go.mod").write_text("module x\n")
+        self.assertEqual(detect_project_type(self.root), "Go")
+
+    def test_multi_language_python_and_typescript(self):
+        """The repro case from #86: TS + Python + workflows.
+
+        Returns a `+`-joined sorted list rather than 'Unknown'.
+        """
+        from utils import detect_project_type
+        (self.root / "package.json").write_text('{"name": "x"}')
+        (self.root / "tsconfig.json").write_text("{}")
+        (self.root / "requirements.txt").write_text(
+            "flask\n"
+        )
+        (self.root / ".github" / "workflows").mkdir(parents=True)
+        result = detect_project_type(self.root)
+        # Sorted alphabetically for determinism.
+        self.assertEqual(result, "Node/TypeScript + Python")
+
+    def test_returns_none_for_empty_project(self):
+        """Empty directory still returns None (not a string)."""
+        from utils import detect_project_type
+        self.assertIsNone(detect_project_type(self.root))
+
+    def test_framework_detection_still_wins(self):
+        """If a known framework signature matches, it still beats
+        the language-family fallback (no regression).
+        """
+        from utils import detect_project_type
+        (self.root / "package.json").write_text(
+            '{"name": "x", "dependencies": {"react": "^18"}}'
+        )
+        (self.root / "tsconfig.json").write_text("{}")
+        # React framework is more specific than Node/TypeScript.
+        self.assertEqual(
+            detect_project_type(self.root),
+            "Web application (frontend)",
         )
 
 
@@ -1346,6 +1441,7 @@ def run_tests():
     suite.addTests(loader.loadTestsFromTestCase(TestFiles))
     suite.addTests(loader.loadTestsFromTestCase(TestAidaYmlRenderers))
     suite.addTests(loader.loadTestsFromTestCase(TestConfigureQuestionOptions))
+    suite.addTests(loader.loadTestsFromTestCase(TestDetectProjectType))
     suite.addTests(loader.loadTestsFromTestCase(TestQuestionnaire))
     suite.addTests(loader.loadTestsFromTestCase(TestTemplateRendering))
     suite.addTests(loader.loadTestsFromTestCase(TestIntegration))


### PR DESCRIPTION
## Summary

The #86 reporter hit a frustrating gap: a project with \`package.json\` + \`tsconfig.json\` + \`requirements.txt\` + \`.github/workflows/\` returned \`"Unknown"\` for \`project_type\`, which then surfaced as \`"Project Type: Unknown"\` in the auto-generated SKILL.md — confusing on a project the author clearly knew the type of.

The detector had all the inputs needed to do better. This PR adds a **language-family fallback** that runs when no framework-specific signature matches.

## Detection rules

| Files present | Returns |
| --- | --- |
| \`package.json\` + \`tsconfig.json\` | \`Node/TypeScript\` |
| \`package.json\` (no tsconfig) | \`Node/JavaScript\` |
| \`pyproject.toml\` | \`Python\` (precedence over \`setup.py\`/\`requirements.txt\`) |
| \`setup.py\` or \`requirements.txt\` (no pyproject) | \`Python\` |
| \`Cargo.toml\` | \`Rust\` |
| \`go.mod\` | \`Go\` |
| \`Gemfile\` | \`Ruby\` |
| \`composer.json\` | \`PHP\` |

Multi-language projects return a sorted \`+\`-joined string (\`"Node/TypeScript + Python"\`), deterministic for indexing.

## Important: framework detection still wins

A React project still returns \`"Web application (frontend)"\`, not \`"Node/TypeScript"\`. The fallback only fires when nothing more specific matched. Test \`test_framework_detection_still_wins\` pins this precedence.

## Test plan

- [x] \`pytest tests/unit/test_utils.py::TestDetectProjectType\` — 8 pass (new)
- [x] \`pytest\` full suite — 964 pass (was 956, +8)
- [x] \`ruff check\` clean
- [x] Version bump 1.5.15 → 1.5.16 + CHANGELOG entry

## New tests

\`TestDetectProjectType\` (8 cases):

- \`test_typescript_only\` — pkg + tsconfig
- \`test_javascript_only\` — pkg without tsconfig
- \`test_python_modern\` — pyproject precedence over requirements
- \`test_rust\` — Cargo.toml
- \`test_go\` — go.mod
- \`test_multi_language_python_and_typescript\` — the #86 repro
- \`test_returns_none_for_empty_project\` — None preserved when nothing matches
- \`test_framework_detection_still_wins\` — React beats Node/TypeScript fallback

## Notes

- Pairs naturally with **#84** (SKILL.md should incorporate existing CLAUDE.md / docs/) — the next milestone item. Together they make the auto-generated project-context skill actually useful.
- Part of milestone **Config & Schema Quality** (3/6 closed after merge)

Closes #86