### PR TITLE
feat: SKILL.md references existing CLAUDE.md / knowledge (#84, 1.5.17)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.16",
+  "version": "1.5.17",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,50 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.17] - 2026-05-23
+
+### Added
+
+- **Project-context SKILL.md references existing CLAUDE.md /
+  knowledge files** (#84). Previously, running `/aida config` on a
+  project with a rich hand-written `CLAUDE.md` and a `knowledge/`
+  directory still generated a SKILL.md that re-claimed "no specific
+  conventions documented" — confusing on projects where the
+  conventions were obviously written down somewhere else. Now the
+  generator detects existing context files and points at them:
+  - **CLAUDE.md callout** near the top of the rendered SKILL.md:
+    "Authoritative rules live in `<path>`. When that file and this
+    auto-generated skill conflict, follow the CLAUDE.md."
+  - **Project Conventions section** points at the CLAUDE.md when
+    `project_conventions` is otherwise empty, instead of the
+    generic fallback text
+  - **Knowledge Index / Knowledge Directory** section appears
+    when `knowledge/index.md`, `knowledge/README.md`, or
+    `docs/index.md` is detected
+- **`_detect_existing_context`** helper in `configure.py` returns
+  six new template variables (`has_claude_md`, `claude_md_path`,
+  `has_knowledge_dir`, `knowledge_dir`, `has_knowledge_index`,
+  `knowledge_index_path`). Search order: project-root CLAUDE.md
+  takes precedence over `.claude/CLAUDE.md`; knowledge/index.md
+  beats knowledge/README.md beats docs/index.md
+- Regression tests:
+  - `TestDetectExistingContext` (7 cases) in
+    `tests/unit/test_utils.py` — covers the detection precedence
+    and fallbacks
+  - `TestProjectContextReferencesExistingFiles` (6 cases) in
+    `tests/unit/test_project_context_template.py` — covers the
+    template's rendering of references and the no-CLAUDE.md
+    fallback (no regression on existing behavior)
+
+### Notes
+
+- Pairs with #86 (1.5.16) — together they make the auto-generated
+  SKILL.md actually useful instead of a noisy "Unknown / not
+  documented" stub
+- Milestone: `Config & Schema Quality` (4/6 closed after merge)
+
+---
+
 ## [1.5.16] - 2026-05-23
 
 ### Added

--- a/skills/aida/scripts/configure.py
+++ b/skills/aida/scripts/configure.py
@@ -282,6 +282,71 @@ def detect_vcs_info(project_root: Path) -> Dict[str, Any]:
     return vcs
 
 
+def _detect_existing_context(
+    project_root: Path,
+) -> Dict[str, str]:
+    """Detect existing project-context files (#84).
+
+    The generated project-context SKILL.md should reference rich
+    hand-written context the user has already provided rather than
+    re-claiming "no conventions documented". This helper returns a
+    flat dict of template variables that the SKILL.md template
+    consumes:
+
+      - has_claude_md: 'true' / 'false'
+      - claude_md_path: relative path to the CLAUDE.md (or '')
+      - has_knowledge_dir: 'true' / 'false'
+      - knowledge_dir: directory name like 'knowledge/' (or '')
+      - has_knowledge_index: 'true' / 'false'
+      - knowledge_index_path: relative path to the index (or '')
+
+    Search order:
+      - CLAUDE.md: project root, then .claude/CLAUDE.md
+      - knowledge index: knowledge/index.md, then
+        knowledge/README.md, then docs/index.md
+    """
+    result: Dict[str, str] = {
+        "has_claude_md": "false",
+        "claude_md_path": "",
+        "has_knowledge_dir": "false",
+        "knowledge_dir": "",
+        "has_knowledge_index": "false",
+        "knowledge_index_path": "",
+    }
+
+    claude_md_candidates = (
+        project_root / "CLAUDE.md",
+        project_root / ".claude" / "CLAUDE.md",
+    )
+    for candidate in claude_md_candidates:
+        if candidate.is_file():
+            result["has_claude_md"] = "true"
+            result["claude_md_path"] = str(
+                candidate.relative_to(project_root)
+            )
+            break
+
+    knowledge_root = project_root / "knowledge"
+    if knowledge_root.is_dir():
+        result["has_knowledge_dir"] = "true"
+        result["knowledge_dir"] = "knowledge/"
+
+    index_candidates = (
+        project_root / "knowledge" / "index.md",
+        project_root / "knowledge" / "README.md",
+        project_root / "docs" / "index.md",
+    )
+    for candidate in index_candidates:
+        if candidate.is_file():
+            result["has_knowledge_index"] = "true"
+            result["knowledge_index_path"] = str(
+                candidate.relative_to(project_root)
+            )
+            break
+
+    return result
+
+
 def detect_files(project_root: Path) -> Dict[str, bool]:
     """Detect presence of common project files.
 
@@ -974,6 +1039,13 @@ def configure(responses: Dict[str, Any], inferred: Dict[str, Any] = None) -> Dic
             # Timestamp
             'timestamp': datetime.now().isoformat(),
         }
+
+        # Existing-context detection (#84): when the project already
+        # has a CLAUDE.md / knowledge index / docs, the generated
+        # SKILL.md should reference them rather than re-claiming
+        # "no conventions documented".
+        existing_context = _detect_existing_context(project_root)
+        template_vars.update(existing_context)
 
         # Get actual README length (not hardcoded)
         if config['files']['has_readme']:

--- a/skills/aida/templates/blueprints/project-context/SKILL.md.jinja2
+++ b/skills/aida/templates/blueprints/project-context/SKILL.md.jinja2
@@ -16,6 +16,13 @@ tags:
 This skill provides factual information about {{ project_name }}'s
 structure, tooling, and conventions. All information here is either
 auto-detected or explicitly configured for this project.
+{% if has_claude_md == 'true' %}
+
+> **Authoritative rules live in [`{{ claude_md_path }}`]({{ claude_md_path }}).**
+> When that file and this auto-generated skill conflict, follow the
+> CLAUDE.md. This skill summarizes detectable facts; CLAUDE.md
+> captures intent.
+{% endif %}
 
 ## Project Facts
 
@@ -233,10 +240,28 @@ Claude should:
 {% if project_conventions %}
 
 {{ project_conventions }}
+{% elif has_claude_md == 'true' %}
+
+See [`{{ claude_md_path }}`]({{ claude_md_path }}) for the project's
+hard rules and conventions. The hand-written context there takes
+precedence over anything inferred from file structure.
 {% else %}
 
 No specific conventions documented. Follow general best practices
 for {{ languages | default("this tech stack") }}.
+{% endif %}
+{% if has_knowledge_index == 'true' %}
+
+## Knowledge Index
+
+See [`{{ knowledge_index_path }}`]({{ knowledge_index_path }}) for
+the project's curated knowledge entries.
+{% elif has_knowledge_dir == 'true' %}
+
+## Knowledge Directory
+
+The project has a `{{ knowledge_dir }}` directory — browse it for
+deeper context that didn't fit into CLAUDE.md or the README.
 {% endif %}
 
 ## API Documentation

--- a/tests/unit/test_project_context_template.py
+++ b/tests/unit/test_project_context_template.py
@@ -83,6 +83,15 @@ def _base_vars(**overrides: str) -> dict[str, str]:
         "code_organization": "Modular",
         "documentation_level": "Standard",
         "timestamp": "2026-01-01T00:00:00",
+        # Existing-context flags (#84). Default to 'false' / '' so
+        # the existing tests render the no-CLAUDE.md / no-knowledge
+        # branches; per-test overrides flip these on as needed.
+        "has_claude_md": "false",
+        "claude_md_path": "",
+        "has_knowledge_dir": "false",
+        "knowledge_dir": "",
+        "has_knowledge_index": "false",
+        "knowledge_index_path": "",
     }
     base.update(overrides)
     return base
@@ -223,6 +232,92 @@ class TestProjectContextTemplateWhitespace(unittest.TestCase):
                     line,
                     f"Line {i} has trailing whitespace: {line!r}",
                 )
+
+
+class TestProjectContextReferencesExistingFiles(unittest.TestCase):
+    """Test the #84 fix: template references existing CLAUDE.md /
+    knowledge files instead of claiming 'no conventions documented'.
+    """
+
+    def test_claude_md_reference_appears_at_top(self):
+        """has_claude_md=true surfaces an authoritative-rules
+        callout near the top of the rendered SKILL.md.
+        """
+        output = _render(
+            has_claude_md="true",
+            claude_md_path="CLAUDE.md",
+        )
+        self.assertIn(
+            "Authoritative rules live in [`CLAUDE.md`](CLAUDE.md)",
+            output,
+        )
+
+    def test_claude_md_referenced_in_conventions_section(self):
+        """When project_conventions is empty but a CLAUDE.md exists,
+        the Project Conventions section points at the CLAUDE.md
+        rather than re-claiming 'no specific conventions documented'.
+        """
+        output = _render(
+            has_claude_md="true",
+            claude_md_path=".claude/CLAUDE.md",
+            project_conventions="",
+        )
+        # Friendly pointer
+        self.assertIn(
+            "[`.claude/CLAUDE.md`](.claude/CLAUDE.md)", output
+        )
+        # The no-conventions fallback must NOT also appear
+        self.assertNotIn(
+            "No specific conventions documented", output
+        )
+
+    def test_conventions_fallback_when_no_claude_md(self):
+        """Without a CLAUDE.md, the existing 'no conventions
+        documented' fallback still surfaces (no regression).
+        """
+        output = _render(
+            has_claude_md="false",
+            project_conventions="",
+        )
+        self.assertIn("No specific conventions documented", output)
+
+    def test_knowledge_index_surfaces_section(self):
+        """has_knowledge_index=true renders a Knowledge Index
+        section pointing at the index file.
+        """
+        output = _render(
+            has_knowledge_dir="true",
+            knowledge_dir="knowledge/",
+            has_knowledge_index="true",
+            knowledge_index_path="knowledge/index.md",
+        )
+        self.assertIn("## Knowledge Index", output)
+        self.assertIn(
+            "[`knowledge/index.md`](knowledge/index.md)", output
+        )
+
+    def test_knowledge_dir_without_index_surfaces_directory(self):
+        """If knowledge/ exists but has no index.md / README.md,
+        the template surfaces a 'Knowledge Directory' section.
+        """
+        output = _render(
+            has_knowledge_dir="true",
+            knowledge_dir="knowledge/",
+            has_knowledge_index="false",
+        )
+        self.assertIn("## Knowledge Directory", output)
+        self.assertIn("`knowledge/`", output)
+
+    def test_no_knowledge_section_when_nothing_present(self):
+        """If neither knowledge index nor directory exists, neither
+        section renders (no empty headings).
+        """
+        output = _render(
+            has_knowledge_dir="false",
+            has_knowledge_index="false",
+        )
+        self.assertNotIn("Knowledge Index", output)
+        self.assertNotIn("Knowledge Directory", output)
 
 
 class TestSandboxedRenderer(unittest.TestCase):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -695,6 +695,92 @@ class TestDetectProjectType(unittest.TestCase):
         )
 
 
+class TestDetectExistingContext(unittest.TestCase):
+    """Test _detect_existing_context (#84).
+
+    The generated project-context SKILL.md should reference any
+    hand-written CLAUDE.md / knowledge index the user has already
+    provided rather than re-claiming "no conventions documented".
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.root = Path(self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _detect(self):
+        from configure import _detect_existing_context
+        return _detect_existing_context(self.root)
+
+    def test_no_context_files(self):
+        """Empty project returns 'false' for everything."""
+        ctx = self._detect()
+        self.assertEqual(ctx["has_claude_md"], "false")
+        self.assertEqual(ctx["claude_md_path"], "")
+        self.assertEqual(ctx["has_knowledge_dir"], "false")
+        self.assertEqual(ctx["has_knowledge_index"], "false")
+
+    def test_root_claude_md_detected(self):
+        """Top-level CLAUDE.md is detected and path is relative."""
+        (self.root / "CLAUDE.md").write_text("# rules\n")
+        ctx = self._detect()
+        self.assertEqual(ctx["has_claude_md"], "true")
+        self.assertEqual(ctx["claude_md_path"], "CLAUDE.md")
+
+    def test_dot_claude_claude_md_detected(self):
+        """.claude/CLAUDE.md is the second-choice search path."""
+        (self.root / ".claude").mkdir()
+        (self.root / ".claude" / "CLAUDE.md").write_text("# rules\n")
+        ctx = self._detect()
+        self.assertEqual(ctx["has_claude_md"], "true")
+        self.assertEqual(
+            ctx["claude_md_path"], ".claude/CLAUDE.md"
+        )
+
+    def test_root_wins_over_dot_claude(self):
+        """If both exist, the root CLAUDE.md is reported."""
+        (self.root / "CLAUDE.md").write_text("# root\n")
+        (self.root / ".claude").mkdir()
+        (self.root / ".claude" / "CLAUDE.md").write_text("# nested\n")
+        ctx = self._detect()
+        self.assertEqual(ctx["claude_md_path"], "CLAUDE.md")
+
+    def test_knowledge_dir_and_index_detected(self):
+        """knowledge/ directory + knowledge/index.md both surface."""
+        (self.root / "knowledge").mkdir()
+        (self.root / "knowledge" / "index.md").write_text("# index\n")
+        ctx = self._detect()
+        self.assertEqual(ctx["has_knowledge_dir"], "true")
+        self.assertEqual(ctx["knowledge_dir"], "knowledge/")
+        self.assertEqual(ctx["has_knowledge_index"], "true")
+        self.assertEqual(
+            ctx["knowledge_index_path"], "knowledge/index.md"
+        )
+
+    def test_knowledge_readme_as_fallback_index(self):
+        """knowledge/README.md is accepted when index.md is absent."""
+        (self.root / "knowledge").mkdir()
+        (self.root / "knowledge" / "README.md").write_text("# r\n")
+        ctx = self._detect()
+        self.assertEqual(ctx["has_knowledge_index"], "true")
+        self.assertEqual(
+            ctx["knowledge_index_path"], "knowledge/README.md"
+        )
+
+    def test_docs_index_as_fallback(self):
+        """docs/index.md is accepted when no knowledge/ exists."""
+        (self.root / "docs").mkdir()
+        (self.root / "docs" / "index.md").write_text("# d\n")
+        ctx = self._detect()
+        self.assertEqual(ctx["has_knowledge_dir"], "false")
+        self.assertEqual(ctx["has_knowledge_index"], "true")
+        self.assertEqual(
+            ctx["knowledge_index_path"], "docs/index.md"
+        )
+
+
 class TestQuestionnaire(unittest.TestCase):
     """Test questionnaire system."""
 
@@ -1442,6 +1528,7 @@ def run_tests():
     suite.addTests(loader.loadTestsFromTestCase(TestAidaYmlRenderers))
     suite.addTests(loader.loadTestsFromTestCase(TestConfigureQuestionOptions))
     suite.addTests(loader.loadTestsFromTestCase(TestDetectProjectType))
+    suite.addTests(loader.loadTestsFromTestCase(TestDetectExistingContext))
     suite.addTests(loader.loadTestsFromTestCase(TestQuestionnaire))
     suite.addTests(loader.loadTestsFromTestCase(TestTemplateRendering))
     suite.addTests(loader.loadTestsFromTestCase(TestIntegration))


### PR DESCRIPTION
## Summary

Previously, running \`/aida config\` on a project with a rich hand-written \`CLAUDE.md\` and a \`knowledge/\` directory still generated a project-context SKILL.md that re-claimed \"no specific conventions documented\". That made the auto-generated skill a noisy duplicate that contradicted the better hand-written context — the #84 reporter's exact pain.

Now the generator detects existing context files and points at them.

## What's new

**1. Detection** — new \`_detect_existing_context(project_root)\` helper in \`configure.py\` returns six template variables:

| Variable | Source |
| --- | --- |
| \`has_claude_md\`, \`claude_md_path\` | project-root \`CLAUDE.md\` (preferred) or \`.claude/CLAUDE.md\` |
| \`has_knowledge_dir\`, \`knowledge_dir\` | presence of \`knowledge/\` |
| \`has_knowledge_index\`, \`knowledge_index_path\` | \`knowledge/index.md\` > \`knowledge/README.md\` > \`docs/index.md\` |

**2. Template updates** — three places in the rendered SKILL.md now reflect existing context:

- **Authoritative-rules callout** near the top: *\"Authoritative rules live in [\`CLAUDE.md\`](CLAUDE.md). When that file and this auto-generated skill conflict, follow the CLAUDE.md.\"*
- **Project Conventions** section points at the CLAUDE.md when \`project_conventions\` is otherwise empty (instead of the generic *\"No specific conventions documented\"* fallback)
- **Knowledge Index / Knowledge Directory** section appears when knowledge files are detected

The no-CLAUDE.md path is preserved — existing tests still pass.

## Test plan

- [x] \`pytest tests/unit/test_utils.py::TestDetectExistingContext\` — 7 pass (new)
- [x] \`pytest tests/unit/test_project_context_template.py::TestProjectContextReferencesExistingFiles\` — 6 pass (new)
- [x] \`pytest\` full suite — 977 pass (was 964, +13)
- [x] \`ruff check\` clean
- [x] \`yamllint -c .yamllint.yml skills/\` clean
- [x] \`reuse lint\` — 322/322 files clean
- [x] Version bump 1.5.16 → 1.5.17 + CHANGELOG entry

## Notes

- Pairs naturally with #86 (1.5.16) — together they make the auto-generated SKILL.md actually useful instead of a noisy \"Unknown / not documented\" stub
- Strict-undefined-safe: also updated \`tests/unit/test_project_context_template.py::_base_vars\` to provide the new variables with \`false\` / \`\"\"\` defaults so existing tests render the no-CLAUDE.md branches
- Part of milestone **Config & Schema Quality** (4/6 closed after merge)

Closes #84