### PR TITLE
feat: /aida config validate — non-interactive health check (#87, 1.5.18)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.17",
+  "version": "1.5.18",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,51 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.18] - 2026-05-23
+
+### Added
+
+- **`/aida config validate` command** (#87) — non-interactive
+  health check for an AIDA-configured project. Three checks:
+  - `global_install`: `~/.claude/aida.yml` exists
+  - `project_marker`: `.claude/aida.yml` exists, parses as YAML,
+    has `version` + `project` mapping
+  - `project_context`: `.claude/aida-project-context.yml` (+
+    optional `.local` overlay) parses, has the expected
+    top-level keys, and sub-sections (`vcs`, `files`,
+    `preferences`) are mappings
+
+  Exits **0 on success, 1 on failure** — CI-gateable. Pass
+  `--json` for a machine-consumable report (suitable for piping
+  into a workflow step that posts a PR comment).
+- **`skills/aida/scripts/validate.py`** — the validator
+  implementation. Uses the same `load_project_context()` loader
+  as the rest of AIDA so the validator can never disagree with
+  what consumers actually read
+- **`skills/aida/references/validate.md`** — workflow docs for
+  the new command (loaded by SKILL.md when `/aida config validate`
+  is invoked)
+- **`tests/unit/test_validate.py`** — 7 cases covering happy
+  path, each missing-file failure, malformed YAML, missing
+  expected keys, and wrong section types
+
+### Changed
+
+- `skills/aida/SKILL.md` routes `config validate` to the new
+  script, distinct from interactive `config`. The help text
+  surfaces `/aida config validate` as a separate command
+
+### Notes
+
+- Does not yet check for drift between
+  `.claude/aida-project-context.yml` and the rendered
+  `project-context/SKILL.md`. Schema-version migration also still
+  belongs to #39. Both are noted as out-of-scope follow-ups in
+  the new docs
+- Milestone: `Config & Schema Quality` (5/6 closed after merge)
+
+---
+
 ## [1.5.17] - 2026-05-23
 
 ### Added

--- a/skills/aida/SKILL.md
+++ b/skills/aida/SKILL.md
@@ -42,7 +42,7 @@ For `status`, `doctor`, or `upgrade` commands:
 
 ### Configuration Commands
 
-For `config` command:
+For `config` command (alone):
 
 - Read `references/config.md` for YAML-based configuration workflow
 - This is an interactive command with:
@@ -50,6 +50,14 @@ For `config` command:
   - Auto-detection of project facts (saved to YAML)
   - Minimal questions (0-3) for unknown preferences only
   - Automatic skill generation from YAML config
+
+For `config validate` command:
+
+- Read `references/validate.md` for the workflow
+- This is a **non-interactive** CI-friendly health check
+- Run `~/.aida/venv/bin/python3 {base_directory}/scripts/validate.py`
+- Exits 0 on success, 1 on failure — suitable for `make` / CI gates
+- Pass `--json` for machine-consumable output
 
 ### Permissions Commands
 
@@ -333,6 +341,7 @@ When displaying help (for `help` command or no arguments), show:
 
 ### Configuration & Setup
 - `/aida config` - Configure AIDA settings (global or project-level)
+- `/aida config validate` - Non-interactive CI-friendly health check
 - `/aida config permissions` - Configure Claude Code permissions from plugin recommendations
 - `/aida status` - Check AIDA installation and configuration status
 - `/aida doctor` - Run diagnostics to troubleshoot AIDA issues

--- a/skills/aida/references/validate.md
+++ b/skills/aida/references/validate.md
@@ -1,0 +1,107 @@
+---
+type: reference
+title: "Validate Action"
+description: "Handles /aida config validate — non-interactive health check for AIDA configuration."
+---
+
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# Validate Action
+
+Handles `/aida config validate` — a **non-interactive** check that
+the project's AIDA configuration is coherent. Designed for CI gates
+and post-version-bump sanity checks.
+
+## Quick start
+
+Just run the script and surface its output:
+
+```bash
+~/.aida/venv/bin/python3 {base_directory}/scripts/validate.py
+```
+
+For machine-consumable output (CI):
+
+```bash
+~/.aida/venv/bin/python3 {base_directory}/scripts/validate.py --json
+```
+
+The script exits **0 on success, 1 on failure** — suitable for
+`make`, GitHub Actions, and any other tool that checks exit codes.
+
+## What it checks
+
+1. **Global install marker** — `~/.claude/aida.yml` exists. Without
+   it, no project-level configuration makes sense.
+2. **Project marker** — `.claude/aida.yml` exists, parses as YAML,
+   has `version` and a `project` mapping.
+3. **Project context** — `.claude/aida-project-context.yml`
+   (committed) and `.claude/aida-project-context.local.yml`
+   (gitignored overlay if present) both parse. The merged context
+   has the expected top-level keys (`version`, `project_name`,
+   `vcs`, `files`, `languages`, `tools`, `inferred`, `preferences`)
+   and the sub-mappings are dicts (not strings or lists from a bad
+   edit).
+
+The validator uses the same `load_project_context()` loader that
+the rest of AIDA reads through, so it can't disagree with what
+consumers actually see.
+
+## When to use it
+
+- **After bumping aida-core** — does the existing project config
+  still validate against the (potentially updated) shape?
+- **In CI** — gate PRs that touch `.claude/aida-project-context.yml`
+  on it passing
+- **After manual edits** — quick sanity check before committing
+
+## What it does NOT check (yet)
+
+- Drift between the YAML and the rendered
+  `.claude/skills/project-context/SKILL.md` — that's a future
+  follow-up
+- Schema-version migration — tracked in #39
+
+## Output
+
+Human-readable (default):
+
+```text
+AIDA Configuration Validation
+============================================================
+Project: /path/to/project
+
+✓ Global Install
+✓ Project Marker
+✓ Project Context
+
+✓ Configuration is valid.
+```
+
+JSON (`--json`):
+
+```json
+{
+  "valid": true,
+  "errors": [],
+  "checks": {
+    "global_install": { "pass": true, "errors": [] },
+    "project_marker": { "pass": true, "errors": [] },
+    "project_context": { "pass": true, "errors": [] }
+  },
+  "project_root": "/path/to/project"
+}
+```
+
+## Error handling
+
+The script never raises — every failure mode (missing file, bad
+YAML, wrong shape) becomes a string in the `errors` array. CI
+should branch on the exit code, not stderr.
+
+## Related
+
+- #39 — schema-version migration (future work; this validator
+  doesn't migrate, it only reports)
+- #87 — this issue

--- a/skills/aida/scripts/validate.py
+++ b/skills/aida/scripts/validate.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+"""Validate AIDA configuration files for a project.
+
+Non-interactive, CI-friendly. Checks:
+
+  - `.claude/aida.yml` (project marker) exists and parses as valid YAML
+  - `.claude/aida-project-context.yml` (+ optional .local overlay)
+    exists, parses, and has the expected top-level shape
+  - The merged project context has the keys the rest of AIDA expects
+    (vcs, files, languages, etc.)
+
+Exits 0 on success, 1 on any validation failure. Prints a structured
+JSON report on stdout when --json is passed, otherwise a human report.
+
+Usage:
+    python validate.py [--project-root PATH] [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+# Path setup so this can run standalone or via /aida config validate
+SCRIPT_DIR = Path(__file__).parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+# Re-use the existing loader so validation never disagrees with what
+# AIDA actually reads.
+import _paths  # noqa: F401, E402 — adds shared/ to sys.path
+from utils.project_context import (  # noqa: E402
+    PROJECT_CONTEXT_FILE,
+    PROJECT_CONTEXT_LOCAL_FILE,
+    load_project_context,
+)
+
+import yaml  # noqa: E402
+
+
+# Top-level keys we expect to find in a complete project-context YAML.
+# These mirror what `configure.py` writes. The validator only cares
+# that they're present and well-shaped; specific value enums get
+# checked in the value-shape section.
+EXPECTED_TOP_LEVEL_KEYS = {
+    "version",
+    "project_name",
+    "vcs",
+    "files",
+    "languages",
+    "tools",
+    "inferred",
+    "preferences",
+}
+
+
+def _check_global_install(home: Path) -> List[str]:
+    """Return a list of issue strings for the global install marker.
+
+    Empty list = pass.
+    """
+    issues: List[str] = []
+    marker = home / ".claude" / "aida.yml"
+    if not marker.is_file():
+        issues.append(
+            f"Global AIDA marker missing: {marker} "
+            "(run /aida config and choose 'Set up AIDA globally')"
+        )
+    return issues
+
+
+def _check_project_marker(project_root: Path) -> List[str]:
+    """Validate `.claude/aida.yml` (the project-level marker)."""
+    issues: List[str] = []
+    marker = project_root / ".claude" / "aida.yml"
+    if not marker.is_file():
+        issues.append(
+            f"Project marker missing: {marker} "
+            "(run /aida config and choose 'Configure this project')"
+        )
+        return issues
+    try:
+        data = yaml.safe_load(marker.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        issues.append(f"Project marker fails YAML parse: {exc}")
+        return issues
+    if not isinstance(data, dict):
+        issues.append(
+            f"Project marker is not a mapping: got "
+            f"{type(data).__name__}"
+        )
+        return issues
+    if "version" not in data:
+        issues.append("Project marker missing 'version' field")
+    if "project" not in data or not isinstance(
+        data.get("project"), dict
+    ):
+        issues.append(
+            "Project marker missing 'project' mapping"
+        )
+    return issues
+
+
+def _check_project_context(
+    project_root: Path,
+) -> List[str]:
+    """Validate the project-context YAML pair.
+
+    Loads via the same path AIDA's runtime uses (committed file +
+    optional `.local` overlay) so the validator never disagrees with
+    what consumers actually read.
+    """
+    issues: List[str] = []
+    claude_dir = project_root / ".claude"
+    committed = claude_dir / PROJECT_CONTEXT_FILE
+    local = claude_dir / PROJECT_CONTEXT_LOCAL_FILE
+
+    if not committed.is_file():
+        issues.append(
+            f"Project context missing: {committed}"
+        )
+        return issues
+
+    # YAML parse — separate from the merged-load to surface parse
+    # errors with file-specific context.
+    for path in (committed, local):
+        if not path.is_file():
+            continue
+        try:
+            yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            issues.append(
+                f"{path.name} fails YAML parse: {exc}"
+            )
+
+    if issues:
+        return issues
+
+    merged = load_project_context(project_root)
+    if not isinstance(merged, dict):
+        issues.append(
+            "Merged project context is not a mapping: got "
+            f"{type(merged).__name__}"
+        )
+        return issues
+
+    missing = EXPECTED_TOP_LEVEL_KEYS - set(merged.keys())
+    if missing:
+        issues.append(
+            "Merged project context missing expected keys: "
+            + ", ".join(sorted(missing))
+        )
+
+    # Specific value shapes
+    vcs = merged.get("vcs")
+    if vcs is not None and not isinstance(vcs, dict):
+        issues.append(
+            f"vcs section must be a mapping, got "
+            f"{type(vcs).__name__}"
+        )
+    files = merged.get("files")
+    if files is not None and not isinstance(files, dict):
+        issues.append(
+            f"files section must be a mapping, got "
+            f"{type(files).__name__}"
+        )
+    prefs = merged.get("preferences")
+    if prefs is not None and not isinstance(prefs, dict):
+        issues.append(
+            f"preferences section must be a mapping, got "
+            f"{type(prefs).__name__}"
+        )
+
+    return issues
+
+
+def validate(
+    project_root: Path, home: Path
+) -> Dict[str, Any]:
+    """Run all validation checks and return a structured report.
+
+    Args:
+        project_root: Project to validate
+        home: User's home dir (for global marker check)
+
+    Returns:
+        Dict with `valid`, `errors`, and per-check details
+    """
+    global_issues = _check_global_install(home)
+    marker_issues = _check_project_marker(project_root)
+    context_issues = _check_project_context(project_root)
+
+    all_errors = (
+        global_issues + marker_issues + context_issues
+    )
+    return {
+        "valid": not all_errors,
+        "errors": all_errors,
+        "checks": {
+            "global_install": {
+                "pass": not global_issues,
+                "errors": global_issues,
+            },
+            "project_marker": {
+                "pass": not marker_issues,
+                "errors": marker_issues,
+            },
+            "project_context": {
+                "pass": not context_issues,
+                "errors": context_issues,
+            },
+        },
+        "project_root": str(project_root),
+    }
+
+
+def _format_human(report: Dict[str, Any]) -> str:
+    """Format a validation report as human-readable text."""
+    lines = ["AIDA Configuration Validation"]
+    lines.append("=" * 60)
+    lines.append(f"Project: {report['project_root']}")
+    lines.append("")
+    for name, check in report["checks"].items():
+        marker = "✓" if check["pass"] else "✗"
+        lines.append(
+            f"{marker} {name.replace('_', ' ').title()}"
+        )
+        for err in check["errors"]:
+            lines.append(f"    {err}")
+    lines.append("")
+    if report["valid"]:
+        lines.append("✓ Configuration is valid.")
+    else:
+        lines.append(
+            f"✗ Configuration has {len(report['errors'])} "
+            "issue(s). See above."
+        )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="validate.py",
+        description=(
+            "Validate AIDA configuration files for a project."
+        ),
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Project root (default: current directory)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output the report as JSON (CI-friendly)",
+    )
+    args = parser.parse_args()
+
+    project_root = args.project_root.resolve()
+    home = Path.home()
+
+    report = validate(project_root, home)
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(_format_human(report))
+
+    return 0 if report["valid"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for /aida config validate (#87).
+
+Covers the validator's structured report shape and exit-code
+contract — the latter matters because CI gates depend on it.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Add aida scripts to path
+_project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(_project_root / "scripts"))
+sys.path.insert(0, str(_project_root / "skills" / "aida" / "scripts"))
+
+# Clear any cached operations modules from prior test files
+sys.modules.pop("_paths", None)
+for _name in list(sys.modules):
+    if _name == "operations" or _name.startswith("operations."):
+        del sys.modules[_name]
+
+import validate as _validator  # noqa: E402
+
+_ops_snapshot = {
+    k: v for k, v in sys.modules.items()
+    if k == "operations" or k.startswith("operations.")
+}
+
+
+def _write_minimal_project_marker(project_root: Path) -> None:
+    """Write a minimally-valid .claude/aida.yml for the project."""
+    claude_dir = project_root / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    (claude_dir / "aida.yml").write_text(
+        '---\nversion: "1.5.17"\nproject:\n  name: "demo"\n',
+        encoding="utf-8",
+    )
+
+
+def _write_minimal_project_context(project_root: Path) -> None:
+    """Write a minimally-valid aida-project-context.yml."""
+    claude_dir = project_root / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    (claude_dir / "aida-project-context.yml").write_text(
+        "---\n"
+        'version: "0.2.0"\n'
+        'project_name: "demo"\n'
+        "vcs:\n  type: git\n"
+        "files:\n  has_readme: true\n"
+        "languages:\n  primary: Python\n"
+        "tools:\n  detected: []\n"
+        "inferred:\n  project_type: Unknown\n"
+        "preferences:\n  branching_model: null\n",
+        encoding="utf-8",
+    )
+
+
+def _write_minimal_global_marker(home: Path) -> None:
+    (home / ".claude").mkdir(parents=True, exist_ok=True)
+    (home / ".claude" / "aida.yml").write_text(
+        '---\nversion: "1.5.17"\n', encoding="utf-8"
+    )
+
+
+class TestValidate(unittest.TestCase):
+    """Test the validator's structured report."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.root = Path(self.tmp) / "proj"
+        self.root.mkdir(parents=True)
+        self.home = Path(self.tmp) / "home"
+        self.home.mkdir()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_clean_project_validates(self):
+        _write_minimal_global_marker(self.home)
+        _write_minimal_project_marker(self.root)
+        _write_minimal_project_context(self.root)
+
+        report = _validator.validate(self.root, self.home)
+        self.assertTrue(
+            report["valid"],
+            f"Expected valid; got errors: {report['errors']}",
+        )
+        self.assertEqual(report["errors"], [])
+        for name in (
+            "global_install",
+            "project_marker",
+            "project_context",
+        ):
+            self.assertTrue(report["checks"][name]["pass"])
+
+    def test_missing_global_marker_fails(self):
+        # Project marker + context present, global marker absent.
+        _write_minimal_project_marker(self.root)
+        _write_minimal_project_context(self.root)
+
+        report = _validator.validate(self.root, self.home)
+        self.assertFalse(report["valid"])
+        self.assertFalse(report["checks"]["global_install"]["pass"])
+        self.assertTrue(
+            any(
+                "Global AIDA marker missing" in e
+                for e in report["errors"]
+            )
+        )
+
+    def test_missing_project_marker_fails(self):
+        _write_minimal_global_marker(self.home)
+        _write_minimal_project_context(self.root)
+
+        report = _validator.validate(self.root, self.home)
+        self.assertFalse(report["valid"])
+        self.assertFalse(report["checks"]["project_marker"]["pass"])
+        self.assertTrue(
+            any(
+                "Project marker missing" in e
+                for e in report["errors"]
+            )
+        )
+
+    def test_missing_project_context_fails(self):
+        _write_minimal_global_marker(self.home)
+        _write_minimal_project_marker(self.root)
+
+        report = _validator.validate(self.root, self.home)
+        self.assertFalse(report["valid"])
+        self.assertFalse(
+            report["checks"]["project_context"]["pass"]
+        )
+        self.assertTrue(
+            any(
+                "Project context missing" in e
+                for e in report["errors"]
+            )
+        )
+
+    def test_bad_yaml_in_project_context_surfaces_parse_error(self):
+        _write_minimal_global_marker(self.home)
+        _write_minimal_project_marker(self.root)
+        # Malformed YAML
+        (self.root / ".claude").mkdir(parents=True, exist_ok=True)
+        (
+            self.root / ".claude" / "aida-project-context.yml"
+        ).write_text(":\n: not: valid: yaml\n", encoding="utf-8")
+
+        report = _validator.validate(self.root, self.home)
+        self.assertFalse(report["valid"])
+        self.assertTrue(
+            any(
+                "fails YAML parse" in e
+                for e in report["errors"]
+            )
+        )
+
+    def test_missing_expected_keys_flagged(self):
+        """A project context that loads but lacks expected
+        top-level keys flags them by name."""
+        _write_minimal_global_marker(self.home)
+        _write_minimal_project_marker(self.root)
+        (self.root / ".claude").mkdir(parents=True, exist_ok=True)
+        # Just version + project_name; missing vcs/files/etc.
+        (
+            self.root / ".claude" / "aida-project-context.yml"
+        ).write_text(
+            "---\nversion: '0.2.0'\nproject_name: 'demo'\n",
+            encoding="utf-8",
+        )
+
+        report = _validator.validate(self.root, self.home)
+        self.assertFalse(report["valid"])
+        joined = " ".join(report["errors"])
+        for required in (
+            "vcs",
+            "files",
+            "languages",
+            "tools",
+            "inferred",
+            "preferences",
+        ):
+            self.assertIn(required, joined)
+
+    def test_wrong_section_type_flagged(self):
+        """vcs / files / preferences must be mappings, not strings."""
+        _write_minimal_global_marker(self.home)
+        _write_minimal_project_marker(self.root)
+        (self.root / ".claude").mkdir(parents=True, exist_ok=True)
+        (
+            self.root / ".claude" / "aida-project-context.yml"
+        ).write_text(
+            "---\n"
+            "version: '0.2.0'\n"
+            "project_name: 'demo'\n"
+            "vcs: 'this should be a mapping'\n"
+            "files: {}\n"
+            "languages: {}\n"
+            "tools: {}\n"
+            "inferred: {}\n"
+            "preferences: {}\n",
+            encoding="utf-8",
+        )
+        report = _validator.validate(self.root, self.home)
+        self.assertFalse(report["valid"])
+        self.assertTrue(
+            any(
+                "vcs section must be a mapping" in e
+                for e in report["errors"]
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a CI-friendly \`/aida config validate\` command that exits **0 on success, 1 on failure**. Designed for the use cases the #87 reporter called out:

- **After bumping aida-core** — does the existing project config still validate?
- **In CI** — gate PRs that touch \`.claude/aida-project-context.yml\`
- **After manual edits** — quick sanity check before committing

## Three checks

| Check | Validates |
| --- | --- |
| \`global_install\` | \`~/.claude/aida.yml\` exists |
| \`project_marker\` | \`.claude/aida.yml\` exists, parses as YAML, has \`version\` + \`project\` mapping |
| \`project_context\` | \`.claude/aida-project-context.yml\` (+ optional \`.local\` overlay) parses, has the expected top-level keys (\`version\`, \`project_name\`, \`vcs\`, \`files\`, \`languages\`, \`tools\`, \`inferred\`, \`preferences\`), and \`vcs\` / \`files\` / \`preferences\` are mappings (not strings) |

The validator uses the same \`load_project_context()\` loader as the rest of AIDA, so it can't disagree with what consumers actually read.

## Output

**Human (default):**

\`\`\`text
AIDA Configuration Validation
============================================================
Project: /path/to/project

✓ Global Install
✓ Project Marker
✓ Project Context

✓ Configuration is valid.
\`\`\`

**JSON (\`--json\`):** structured \`{valid, errors, checks, project_root}\` for piping into a CI step that posts a PR comment.

## What it does NOT do (yet, noted in docs)

- Drift detection between \`.claude/aida-project-context.yml\` and the rendered \`.claude/skills/project-context/SKILL.md\` — future follow-up
- Schema-version migration — belongs to #39

## Test plan

- [x] \`pytest tests/unit/test_validate.py\` — 7 pass (new)
- [x] \`pytest\` full suite — 984 pass (was 977, +7)
- [x] \`ruff check\` clean
- [x] \`reuse lint\` — 325/325 files clean
- [x] Smoke test: ran against this repo (no project config) → exit 1, clean error messages
- [x] Version bump 1.5.17 → 1.5.18 + CHANGELOG entry

## New files

- \`skills/aida/scripts/validate.py\` — the validator
- \`skills/aida/references/validate.md\` — workflow docs (loaded by SKILL.md when the command runs)
- \`tests/unit/test_validate.py\` — happy path + every failure mode

\`skills/aida/SKILL.md\` routes \`config validate\` distinct from interactive \`config\` and surfaces \`/aida config validate\` in the help text.

## Notes

- Part of milestone **Config & Schema Quality** (5/6 closed after merge)
- Closes the auditing/CI gap that's been blocking teams from committing \`.claude/aida-project-context.yml\` to shared repos

Closes #87