### PR TITLE
feat: project-context schema versioning + migration (#39, 1.5.19)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.18",
+  "version": "1.5.19",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,64 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.19] - 2026-05-23
+
+### Added
+
+- **Project-context schema versioning + migration framework**
+  (#39). The project-context YAML now carries a `schema_version`
+  field (currently `1.0.0`), separate from the AIDA app version:
+  - `PROJECT_CONTEXT_SCHEMA_VERSION = "1.0.0"` constant in
+    `utils/project_context.py`. Bump major for breaking changes,
+    minor for additive fields, patch for clarifications
+  - `_MIGRATIONS` registry — `Dict[str, Callable]` mapping
+    from-version to a migrator function. Empty today (schema is
+    fresh at 1.0.0), but the framework is in place so future
+    schema bumps can register migrators and the loader walks
+    them in order
+  - `migrate_to_current(data)` — public entry point. At current
+    version: stamps `schema_version`. Older: walks migrations
+    forward. Newer: logs a warning and returns as-is (best-effort
+    forward compat). Missing migration in chain: warns and stops
+    rather than crashing
+  - `load_project_context()` now calls `migrate_to_current()`
+    automatically, so consumers always see a current-version
+    dict. The next `write_project_context()` persists the
+    upgrade
+
+### Changed
+
+- **Project context now stamps `schema_version`, not `version`**.
+  The previous `version: AIDA_VERSION` stamp conflated app
+  version with schema version (#39's core bug — docs said one
+  thing, code stamped another). New configs get
+  `schema_version: "1.0.0"`. Legacy files with a `version` field
+  are treated as schema 1.0.0 (the shape didn't actually
+  change), and the original `version` field is preserved
+  in-memory + on disk for backward compat
+- `validate.py`'s expected top-level keys now require
+  `schema_version` instead of `version`. Since
+  `load_project_context()` stamps `schema_version` on read, this
+  passes for all existing configs after one round-trip
+
+### Notes
+
+- This is foundational work — no immediate user-facing behavior
+  change. Sets up safe future schema evolution
+- 7 new tests in `tests/unit/test_project_context_split.py::TestSchemaVersioning`
+  cover the migration framework: stamping current, preserving
+  current, warning on newer, empty-dict skip, legacy-version
+  treatment, and the end-to-end write-then-read round-trip
+- Two existing tests
+  (`test_legacy_single_file_returns_as_is` renamed to
+  `test_legacy_single_file_stamps_schema_version`,
+  `test_round_trip_via_disk`) updated to assert the new
+  schema-stamping contract rather than strict equality
+- Closes **Config & Schema Quality** milestone (6/6)
+- Milestone: `Config & Schema Quality`
+
+---
+
 ## [1.5.18] - 2026-05-23
 
 ### Added

--- a/skills/aida/scripts/configure.py
+++ b/skills/aida/scripts/configure.py
@@ -412,9 +412,15 @@ def detect_project_info(project_root: Path) -> Dict[str, Any]:
         >>> print(info["vcs"]["type"])
         'git'
     """
-    # Project metadata
+    # Project metadata. Note (#39): `schema_version` is the
+    # project-context schema version (independent of the AIDA app
+    # version). Bumping AIDA_VERSION does NOT bump this — only
+    # actual schema changes do, with a registered migration to keep
+    # older configs readable.
+    from utils.project_context import PROJECT_CONTEXT_SCHEMA_VERSION
+
     config = {
-        "version": AIDA_VERSION,
+        "schema_version": PROJECT_CONTEXT_SCHEMA_VERSION,
         "last_updated": datetime.now(timezone.utc).isoformat(),
         "config_complete": False,
 

--- a/skills/aida/scripts/utils/project_context.py
+++ b/skills/aida/scripts/utils/project_context.py
@@ -21,16 +21,155 @@ read transparently through `load_project_context()`; the next call to
 `write_project_context()` migrates them by emitting both files.
 """
 
+import logging
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
 import yaml
 
 from .errors import ConfigurationError, FileOperationError
 from .files import read_file, write_yaml
 
+logger = logging.getLogger(__name__)
+
 PROJECT_CONTEXT_FILE = "aida-project-context.yml"
 PROJECT_CONTEXT_LOCAL_FILE = "aida-project-context.local.yml"
+
+# Schema version for the project-context YAML pair. **Separate from
+# the AIDA app version (#39)** — apps and schemas evolve at
+# independent rates. Bump major for breaking changes (removed/renamed
+# fields), minor for additive fields, patch for clarifications.
+#
+# Migration policy:
+#   - Reading older schema_version: apply migrations in order until
+#     the file matches CURRENT. The migrated dict stays in memory;
+#     the next write_project_context() persists the upgrade.
+#   - Reading newer schema_version: log a warning and return the
+#     dict as-is. Additive fields are safe to ignore; removed or
+#     renamed fields will manifest as KeyError downstream, which is
+#     better than a silent miscompile.
+#   - Reading no schema_version (legacy files, including those that
+#     used the old `version` field with the app version): treat as
+#     1.0.0 and pass through unchanged. The shape hasn't actually
+#     changed yet, so this is safe.
+PROJECT_CONTEXT_SCHEMA_VERSION = "1.0.0"
+
+
+# Migrations registry. Each entry maps a from_version to a callable
+# that transforms a dict into the *next* schema version. The
+# orchestrator (`migrate_to_current`) walks this in sequence until
+# the dict matches PROJECT_CONTEXT_SCHEMA_VERSION.
+#
+# Convention: each migrator returns (migrated_dict, new_version).
+# Empty today because we just defined version 1.0.0; this is the
+# scaffolding for future schema changes.
+_MIGRATIONS: Dict[
+    str, Callable[[Dict[str, Any]], Tuple[Dict[str, Any], str]]
+] = {}
+
+
+def _read_schema_version(data: Dict[str, Any]) -> str:
+    """Read the schema version from a context dict.
+
+    Precedence (handles the messy real world):
+      1. `schema_version` field (new, post-#39)
+      2. `version` field (legacy — was actually the app version,
+         but we treat it as 1.0.0 since the shape didn't change)
+      3. No version field at all (pre-versioning) -> 1.0.0
+    """
+    if "schema_version" in data:
+        return str(data["schema_version"])
+    if "version" in data:
+        # Legacy `version` field carried the app version, not the
+        # schema version. The shape was identical to 1.0.0, so treat
+        # the file as 1.0.0 and let `write_project_context` rewrite
+        # with the correct field on the next save.
+        return "1.0.0"
+    return "1.0.0"
+
+
+def _compare_versions(a: str, b: str) -> int:
+    """Return -1/0/1 for a < b / a == b / a > b on semver-ish strings.
+
+    Tolerates non-semver strings by falling back to lexical compare
+    (we don't want to crash on a corrupt schema_version field).
+    """
+    def _parts(v: str) -> Tuple[int, ...]:
+        try:
+            return tuple(int(p) for p in v.split("."))
+        except ValueError:
+            return tuple()
+
+    pa, pb = _parts(a), _parts(b)
+    if not pa or not pb:
+        return (a > b) - (a < b)
+    if pa < pb:
+        return -1
+    if pa > pb:
+        return 1
+    return 0
+
+
+def migrate_to_current(
+    data: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Migrate a loaded context dict to ``PROJECT_CONTEXT_SCHEMA_VERSION``.
+
+    Returns a *new* dict (does not mutate input).
+
+    Behavior:
+      - At current version: returns the dict with schema_version
+        stamped (in case it was a legacy file)
+      - Older: walks `_MIGRATIONS` to bring the dict forward
+      - Newer: logs a warning and returns as-is (best-effort
+        forward compat; downstream code is on its own)
+      - Unknown intermediate version (no migration registered):
+        logs a warning and returns as-is rather than crashing
+    """
+    if not data:
+        return {}
+
+    current = PROJECT_CONTEXT_SCHEMA_VERSION
+    found = _read_schema_version(data)
+    cmp = _compare_versions(found, current)
+
+    if cmp > 0:
+        logger.warning(
+            "Project context schema_version %s is newer than "
+            "this AIDA install (%s). Reading anyway; missing "
+            "fields will surface as errors downstream.",
+            found,
+            current,
+        )
+        return dict(data)
+
+    # cmp <= 0: walk migrations forward.
+    migrated = dict(data)
+    visited: set[str] = set()
+    while _compare_versions(found, current) < 0:
+        if found in visited:
+            logger.warning(
+                "Migration loop detected at schema_version %s; "
+                "stopping. Loaded data may be incomplete.",
+                found,
+            )
+            break
+        visited.add(found)
+
+        migrator = _MIGRATIONS.get(found)
+        if migrator is None:
+            logger.warning(
+                "No migration registered from schema_version %s "
+                "to %s; using file as-is.",
+                found,
+                current,
+            )
+            break
+        migrated, found = migrator(migrated)
+
+    migrated["schema_version"] = current
+    return migrated
+
 
 # Top-level keys that belong in the gitignored .local overlay.
 _LOCAL_TOP_LEVEL_KEYS = frozenset(
@@ -144,11 +283,18 @@ def load_project_context(project_root: Path) -> Dict[str, Any]:
     Legacy single-file projects (no `.local.yml`) still work — the
     committed file is returned as-is; the split happens on the next
     write.
+
+    Applies any registered schema migrations (#39) so callers always
+    see a dict at the current schema version. Migrations happen
+    in-memory; the next `write_project_context()` persists them.
     """
     claude_dir = project_root / ".claude"
     project = _read_yaml_if_exists(claude_dir / PROJECT_CONTEXT_FILE) or {}
     local = _read_yaml_if_exists(claude_dir / PROJECT_CONTEXT_LOCAL_FILE) or {}
-    return merge_context(project, local)
+    merged = merge_context(project, local)
+    if merged:
+        merged = migrate_to_current(merged)
+    return merged
 
 
 def write_project_context(

--- a/skills/aida/scripts/validate.py
+++ b/skills/aida/scripts/validate.py
@@ -48,7 +48,11 @@ import yaml  # noqa: E402
 # that they're present and well-shaped; specific value enums get
 # checked in the value-shape section.
 EXPECTED_TOP_LEVEL_KEYS = {
-    "version",
+    # `schema_version` (post-#39) is the project-context schema
+    # version, distinct from the AIDA app version. Legacy configs
+    # with `version` are migrated in-memory so this key is always
+    # present after `load_project_context()`.
+    "schema_version",
     "project_name",
     "vcs",
     "files",

--- a/tests/unit/test_project_context_split.py
+++ b/tests/unit/test_project_context_split.py
@@ -143,8 +143,13 @@ class TestLoadProjectContext(unittest.TestCase):
             self.assertEqual(merged["vcs"]["type"], "git")
             self.assertEqual(merged["vcs"]["remote_url"], "u")
 
-    def test_legacy_single_file_returns_as_is(self):
-        """Existing projects with everything in .yml still work."""
+    def test_legacy_single_file_stamps_schema_version(self):
+        """Existing projects with everything in .yml still work.
+
+        After #39, the loader stamps `schema_version` on read so
+        callers always see a current-version dict. Original keys
+        (including the legacy `version` field) are preserved.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             claude = root / ".claude"
@@ -154,7 +159,17 @@ class TestLoadProjectContext(unittest.TestCase):
                 yaml.dump(legacy), encoding="utf-8"
             )
             merged = load_project_context(root)
-            self.assertEqual(merged, legacy)
+            # Every original key is preserved.
+            for k, v in legacy.items():
+                self.assertEqual(merged[k], v)
+            # Plus schema_version stamped to current.
+            from utils.project_context import (
+                PROJECT_CONTEXT_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                merged["schema_version"],
+                PROJECT_CONTEXT_SCHEMA_VERSION,
+            )
 
     def test_no_files_returns_empty_dict(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -201,7 +216,18 @@ class TestWriteProjectContext(unittest.TestCase):
             original = _sample_merged()
             write_project_context(root, original)
             reloaded = load_project_context(root)
-            self.assertEqual(reloaded, original)
+            # All original keys round-trip; the loader additionally
+            # stamps schema_version (#39) so we compare keys-wise
+            # rather than requiring exact equality.
+            for k, v in original.items():
+                self.assertEqual(reloaded[k], v)
+            from utils.project_context import (
+                PROJECT_CONTEXT_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                reloaded["schema_version"],
+                PROJECT_CONTEXT_SCHEMA_VERSION,
+            )
 
     def test_legacy_to_split_migration_on_write(self):
         """A single-file legacy project is split on next write."""
@@ -264,6 +290,118 @@ class TestEnsureGitignoreEntry(unittest.TestCase):
             content = (root / ".gitignore").read_text()
             self.assertTrue(content.startswith("*.pyc\n"))
             self.assertIn(".claude/aida-project-context.local.yml", content)
+
+
+class TestSchemaVersioning(unittest.TestCase):
+    """Test the schema versioning + migration framework (#39)."""
+
+    def test_current_version_is_a_string(self):
+        from utils.project_context import (
+            PROJECT_CONTEXT_SCHEMA_VERSION,
+        )
+        self.assertIsInstance(PROJECT_CONTEXT_SCHEMA_VERSION, str)
+        # Loose semver shape so callers can string-compare.
+        parts = PROJECT_CONTEXT_SCHEMA_VERSION.split(".")
+        self.assertEqual(len(parts), 3)
+        for p in parts:
+            int(p)  # must parse as integer
+
+    def test_migrate_stamps_current_on_empty_legacy_dict(self):
+        """A config with no schema_version gets stamped to current."""
+        from utils.project_context import (
+            PROJECT_CONTEXT_SCHEMA_VERSION,
+            migrate_to_current,
+        )
+        out = migrate_to_current({"project_name": "demo"})
+        self.assertEqual(
+            out["schema_version"], PROJECT_CONTEXT_SCHEMA_VERSION
+        )
+        self.assertEqual(out["project_name"], "demo")
+
+    def test_migrate_preserves_existing_schema_version(self):
+        """A config already at the current version is unchanged."""
+        from utils.project_context import (
+            PROJECT_CONTEXT_SCHEMA_VERSION,
+            migrate_to_current,
+        )
+        data = {
+            "schema_version": PROJECT_CONTEXT_SCHEMA_VERSION,
+            "project_name": "x",
+        }
+        out = migrate_to_current(data)
+        self.assertEqual(out, data)
+
+    def test_migrate_warns_on_newer_schema(self):
+        """Reading a config from a future AIDA version logs a
+        warning but returns the dict as-is (best-effort
+        forward-compat)."""
+        import logging
+        from utils.project_context import migrate_to_current
+
+        future = {
+            "schema_version": "99.0.0",
+            "project_name": "x",
+            "future_only_field": "stuff",
+        }
+        with self.assertLogs(
+            "utils.project_context", level=logging.WARNING
+        ) as cm:
+            out = migrate_to_current(future)
+        # Original fields preserved
+        self.assertEqual(out["project_name"], "x")
+        self.assertEqual(out["future_only_field"], "stuff")
+        # Warning logged
+        self.assertTrue(
+            any("newer than" in m for m in cm.output)
+        )
+
+    def test_migrate_empty_dict_returns_empty(self):
+        """Empty config (no .yml files) skips migration cleanly."""
+        from utils.project_context import migrate_to_current
+        self.assertEqual(migrate_to_current({}), {})
+
+    def test_legacy_version_field_treated_as_one_dot_zero(self):
+        """Pre-#39 files stamped `version: <app-version>` are
+        treated as schema 1.0.0 (the shape is identical)."""
+        from utils.project_context import (
+            PROJECT_CONTEXT_SCHEMA_VERSION,
+            migrate_to_current,
+        )
+        legacy = {
+            "version": "0.7.0",  # was app version, not schema
+            "project_name": "demo",
+        }
+        out = migrate_to_current(legacy)
+        # schema_version stamped to current
+        self.assertEqual(
+            out["schema_version"], PROJECT_CONTEXT_SCHEMA_VERSION
+        )
+        # Original `version` field preserved (it's a legacy app
+        # version stamp, harmless to keep around)
+        self.assertEqual(out["version"], "0.7.0")
+        self.assertEqual(out["project_name"], "demo")
+
+    def test_write_reads_back_with_schema_version(self):
+        """end-to-end: write a config, read it back, schema_version
+        is present even if the source dict didn't have it."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".claude").mkdir()
+            # Source dict has NO schema_version (typical for a
+            # caller that just built a fresh context)
+            source = {
+                "project_name": "demo",
+                "vcs": {"type": "git"},
+            }
+            write_project_context(root, source)
+            reloaded = load_project_context(root)
+            from utils.project_context import (
+                PROJECT_CONTEXT_SCHEMA_VERSION,
+            )
+            self.assertEqual(
+                reloaded["schema_version"],
+                PROJECT_CONTEXT_SCHEMA_VERSION,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes the last issue in **Config & Schema Quality** (6/6).

The project-context YAML now carries a \`schema_version\` field (currently \`1.0.0\`), separate from the AIDA app version. Addresses #39's core bug: the previous \`version: AIDA_VERSION\` stamp conflated app version with schema version — docs said one thing, code stamped another.

## What's new

**1. Schema versioning constants** in \`utils/project_context.py\`:

- \`PROJECT_CONTEXT_SCHEMA_VERSION = \"1.0.0\"\` — independent of \`AIDA_VERSION\`. Bump major for breaking changes, minor for additive, patch for clarifications.
- \`_MIGRATIONS\` registry: \`Dict[from_version, Callable]\`. Empty today (we just defined 1.0.0), but the framework is in place so future schema bumps can register migrators and the loader walks them in order.

**2. \`migrate_to_current(data)\`** — public entry point with four behaviors:

| Input version | Behavior |
| --- | --- |
| Current | Stamps \`schema_version\` (covers legacy files with no field) |
| Older | Walks \`_MIGRATIONS\` forward to current |
| Newer | Logs a warning, returns as-is (best-effort forward compat) |
| Missing migration in chain | Warns and stops rather than crashing |

**3. \`load_project_context()\`** now calls \`migrate_to_current()\` automatically. Consumers always see a current-version dict. The next \`write_project_context()\` persists the upgrade.

## Changed

- \`configure.py\`'s \`detect_project_info\` stamps \`schema_version: \"1.0.0\"\` instead of \`version: AIDA_VERSION\`. The conflation is the #39 bug.
- \`validate.py\`'s expected top-level keys now require \`schema_version\` (not \`version\`). Since \`load_project_context()\` stamps \`schema_version\` on read, this passes for every existing config after one round-trip.
- Legacy files preserve their \`version\` field for backward compat — \`migrate_to_current\` doesn't remove unknown fields. The loader just stamps \`schema_version\` alongside.

## Test plan

- [x] \`pytest tests/unit/test_project_context_split.py::TestSchemaVersioning\` — 7 pass (new)
- [x] \`pytest\` full suite — 991 pass (was 984, +7)
- [x] \`ruff check\` clean
- [x] \`reuse lint\` — 325/325 files clean
- [x] Version bump 1.5.18 → 1.5.19 + CHANGELOG entry

Two existing tests updated to assert the new schema-stamping contract:

- \`test_legacy_single_file_returns_as_is\` → \`test_legacy_single_file_stamps_schema_version\` (renamed + asserts \`schema_version: \"1.0.0\"\` stamped + original keys preserved)
- \`test_round_trip_via_disk\` (write → read no longer requires strict equality; preserves all originals + stamps \`schema_version\`)

## Notes

- This is foundational work — **no immediate user-facing behavior change**. Sets up safe future schema evolution.
- Empty \`_MIGRATIONS\` is intentional: there's nothing to migrate yet. The first real migration will be added when the schema actually changes; this PR provides the framework so that change is a small, well-tested diff rather than a big architectural one.
- Part of milestone **Config & Schema Quality** (6/6 closed after merge)

Closes #39