### PR TITLE
chore: MAINTAINERS.md + dependabot.yml (#90, 1.5.20)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.19",
+  "version": "1.5.20",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+---
+# Dependabot configuration (#90, ADR-0017).
+# Keeps Python deps + GitHub Actions versions current with weekly PRs.
+version: 2
+
+updates:
+  # Python deps live in requirements*.txt at the repo root.
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - python
+    commit-message:
+      prefix: chore
+      include: scope
+
+  # GitHub Actions versions in .github/workflows/*.yml.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: chore
+      include: scope

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,32 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.20] - 2026-05-23
+
+### Added
+
+- **`MAINTAINERS.md`** at the repo root (ADR-0015, #90). Lists
+  the current active maintainer roster, distinct from the broader
+  contributor list in `AUTHORS`. Includes a "how to reach us"
+  section and a brief note on becoming a maintainer.
+- **`.github/dependabot.yml`** (ADR-0017, #90). Weekly updates
+  for both Python (`pip`) and `github-actions`, anchored to
+  Monday 09:00 America/New_York with a 5-PR-at-once cap and
+  `dependencies` / `python` / `github-actions` labels for easy
+  triage.
+
+### Notes
+
+- Closes the Splash marketplace compliance audit (ADR-0015 +
+  ADR-0017) — once this lands, the plugin can be removed from
+  the grandfather lists in `splash-ai-marketplace`'s validator
+- Pure repo-hygiene addition; no runtime behavior changes
+- Pairs naturally with #53 if/when that broader hardening
+  checklist gets picked up (`SECURITY.md`, `CONTRIBUTING.md`,
+  pre-commit, etc.)
+
+---
+
 ## [1.5.19] - 2026-05-23
 
 ### Added

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,39 @@
+---
+type: documentation
+title: "AIDA Core Plugin Maintainers"
+description: "Current maintainers responsible for triaging issues, reviewing PRs, and shipping releases."
+---
+
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# Maintainers
+
+This file lists the **current maintainers** of aida-core-plugin — the
+people who triage issues, review PRs, and ship releases.
+
+For the full historical roster of substantive contributors, see
+[`AUTHORS`](AUTHORS).
+
+## Current maintainers
+
+- **Rob Johnson** [@oakensoul](https://github.com/oakensoul) —
+  `github@oakensoul.com`
+
+## How to reach us
+
+- **Bugs / features:** open an issue at
+  <https://github.com/aida-core/aida-core-plugin/issues>
+- **Security disclosures:** email `github@oakensoul.com` (until a
+  formal `SECURITY.md` lands as part of #53)
+- **Marketplace / packaging questions:** the
+  [Splash AI Marketplace](https://github.com/Splash-AI/splash-ai-marketplace)
+  validator consumes this file (per ADR-0015)
+
+## Becoming a maintainer
+
+Active contributors with sustained, high-quality engagement may be
+invited to join the maintainer roster. The process is informal —
+open an issue or DM a current maintainer if you're interested.
+Maintainer additions are reflected in this file and announced in the
+relevant release notes.


### PR DESCRIPTION
## Summary

Closes the Splash marketplace compliance audit by addressing the two concrete TODOs from #90:

- **ADR-0015**: \`MAINTAINERS.md\` at the repo root listing the current active maintainer (Rob Johnson / @oakensoul). Distinct from \`AUTHORS\` (the historical contributor roster — kept).
- **ADR-0017**: \`.github/dependabot.yml\` covering both \`pip\` and \`github-actions\` ecosystems with weekly Monday 09:00 (ET) cadence, a 5-PR-at-once cap, and \`dependencies\` / \`python\` / \`github-actions\` labels for easy triage.

Once this lands, the plugin can be removed from the grandfather lists in [splash-ai-marketplace](https://github.com/Splash-AI/splash-ai-marketplace)'s validator (per the request in the issue body).

## Test plan

- [x] \`yamllint -c .yamllint.yml .github/dependabot.yml\` clean
- [x] \`pytest\` full suite — 991 pass (no test changes — pure repo hygiene)
- [x] \`reuse lint\` — 327/327 files clean (was 325 + the 2 new files)
- [x] Version bump 1.5.19 → 1.5.20 + CHANGELOG entry

## Notes

- Pure repo-hygiene addition; no runtime behavior changes
- Pairs with #53 if/when the broader hardening checklist (\`SECURITY.md\`, \`CONTRIBUTING.md\`, \`CODE_OF_CONDUCT.md\`, pre-commit, pip-audit, etc.) gets picked up
- 21 unreleased version bumps now sitting on main (1.5.2 → 1.5.20); a release cut is the logical next milestone

Closes #90