### PR TITLE
chore: CI hardening — permissions, SHA pins, pip-audit (#53 part 2, 1.5.23)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.22",
+  "version": "1.5.23",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,14 @@ on:
   pull_request:
     branches: [main]
 
+# Least-privilege at the workflow level (#53). Individual jobs
+# escalate explicitly if they need more (none do today). Dependabot
+# keeps the action SHAs below up-to-date — when a pinned action
+# releases a new version, dependabot opens a PR with the new SHA +
+# version comment.
+permissions:
+  contents: read
+
 jobs:
   unit-test:
     runs-on: ubuntu-latest
@@ -17,10 +25,10 @@ jobs:
       matrix:
         python-version: ['3.9', '3.11', '3.12']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -41,10 +49,10 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.11'
 
@@ -59,15 +67,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.11'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'
 
@@ -80,13 +88,22 @@ jobs:
       - name: Run all linters
         run: make lint
 
+      # pip-audit gates on known CVEs in our Python deps (#53).
+      # --strict fails on any vulnerability, including dev-only deps.
+      # Runs after install so it audits the actual pinned tree, not
+      # the requirements files in isolation.
+      - name: Audit Python dependencies for known CVEs
+        run: |
+          ~/.aida/venv/bin/pip install --quiet pip-audit
+          ~/.aida/venv/bin/pip-audit --strict
+
   check-attribution:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,14 @@ jobs:
       # --strict fails on any vulnerability, including dev-only deps.
       # Runs after install so it audits the actual pinned tree, not
       # the requirements files in isolation.
+      #
+      # The venv's bundled pip is upgraded first because pip itself
+      # is in the audited dependency tree — CI runners ship pip 24.0
+      # which has known CVEs that newer versions resolve. Upgrading
+      # pip is a no-op for our runtime/dev deps; we don't pin it.
       - name: Audit Python dependencies for known CVEs
         run: |
+          ~/.aida/venv/bin/pip install --quiet --upgrade pip
           ~/.aida/venv/bin/pip install --quiet pip-audit
           ~/.aida/venv/bin/pip-audit --strict
 

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -8,11 +8,14 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   version-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Verify version bump and matching CHANGELOG entry
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,46 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.23] - 2026-05-23
+
+### Changed
+
+- **CI security hardening** (#53 part 2):
+  - Both workflows (`ci.yml`, `version-check.yml`) now declare
+    top-level `permissions: contents: read` for least-privilege.
+    Individual jobs escalate explicitly if they need more (none
+    do today)
+  - GitHub Action references **pinned to commit SHAs** with
+    version comments (`@<sha>  # v4`). A compromised tag can't
+    ship malicious code through us. Dependabot's
+    `github-actions` ecosystem entry (added in 1.5.20) keeps the
+    pins fresh — when an action releases a new version,
+    dependabot opens a PR with the new SHA and updated comment
+  - Pinned actions: `actions/checkout@v4`,
+    `actions/setup-python@v5`, `actions/setup-node@v4`
+
+### Added
+
+- **`pip-audit` step in the `lint` job** (#53 part 2). Runs after
+  `make install` so it audits the actual pinned dependency tree
+  (not just `requirements*.txt` in isolation), gates on `--strict`
+  so any known CVE in our dev or runtime deps fails CI. Auditing
+  in the lint job rather than a separate one avoids re-installing
+  deps for a security-only job
+
+### Notes
+
+- Closes 3 more items from #53's hardening checklist:
+  `permissions: contents: read`, pin actions to SHA, add pip-audit
+- The **scaffolded** `ci.yml` templates (for new plugins) are not
+  updated in this PR — they're a separate template surface and
+  warrant their own follow-up (scaffold output should hold the
+  same hardening pattern so downstream plugins ship secure by
+  default)
+- No code change beyond CI; no test changes needed
+
+---
+
 ## [1.5.22] - 2026-05-23
 
 ### Added


### PR DESCRIPTION
## Summary

Three CI security hardening items from #53's checklist, applied to **aida-core's own workflows** (not the scaffolded templates — that's a separate surface, intentional follow-up).

### What changed

**1. Least-privilege permissions**

Both workflows now declare \`permissions: contents: read\` at the top level. Individual jobs escalate explicitly if they need more (none do today). This caps the GITHUB_TOKEN scope so a compromised step can't push to the repo, modify issues, etc.

**2. GitHub Actions pinned to commit SHAs**

Action references now pin to commit SHAs with version comments:

| Action | Pin | Version |
| --- | --- | --- |
| \`actions/checkout\` | \`@34e114876b0b11c390a56381ad16ebd13914f8d5\` | v4 |
| \`actions/setup-python\` | \`@a26af69be951a213d495a4c3e4e4022e16d87065\` | v5 |
| \`actions/setup-node\` | \`@49933ea5288caeca8642d1e84afbd3f7d6820020\` | v4 |

A compromised tag (rare but real — see the tj-actions/changed-files incident from 2025) can't ship malicious code through us. Dependabot's \`github-actions\` ecosystem entry (added in 1.5.20) keeps these pins fresh — when an action releases a new version, dependabot opens a PR with the new SHA + updated comment.

**3. \`pip-audit\` step in the \`lint\` job**

Runs after \`make install\` so it audits the actual pinned dependency tree (not just \`requirements*.txt\` in isolation). \`--strict\` gates on any known CVE in our dev or runtime deps. Putting it in the lint job rather than a standalone job avoids re-installing dependencies for a security-only run.

## Test plan

- [x] Both workflow files parse as YAML
- [x] \`yamllint -c .yamllint.yml .github/workflows/\` clean
- [x] Version bump 1.5.22 → 1.5.23 + CHANGELOG entry
- [x] CI on this PR will exercise the new hardened workflow (including the pip-audit step)

## What's still left in #53

- [ ] \`.pre-commit-config.yaml\`
- [ ] Issue/PR templates
- [ ] Add release workflow (tag-triggered)
- [ ] Enable Dependabot alerts on repo (GitHub UI; can't be done via PR)
- [ ] Scaffolded ci.yml templates should mirror these defaults — separate follow-up so downstream plugins ship secure by default

Already done:

- ✅ SPDX headers everywhere (#72, #73)
- ✅ \`dependabot.yml\` (#90, 1.5.20)
- ✅ Governance docs: SECURITY/CONTRIBUTING/CODE_OF_CONDUCT (#53 part 1, 1.5.22)

Closes part 2 of the #53 checklist.