### PR TITLE
chore: scaffolded ci.yml ships CI hardening (#53 part 3, 1.5.24)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.23",
+  "version": "1.5.24",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,47 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.24] - 2026-05-23
+
+### Changed
+
+- **Scaffolded `ci.yml` templates ship the same CI hardening as
+  aida-core** (#53 part 3). Every newly scaffolded plugin's
+  `.github/workflows/ci.yml` now lands with:
+  - Top-level `permissions: contents: read`
+  - GitHub Action references pinned to commit SHAs with version
+    comments (`@<sha>  # v4`)
+  - A dependency audit step (`pip-audit --strict` for Python,
+    `npm audit --audit-level=high` for TypeScript)
+  - Python templates also `pip install --upgrade pip` before
+    audit so the bundled CVE-laden pip doesn't fail the gate
+  Applied across all three flavors: python, typescript, and
+  none (skills-only). Downstream plugins ship secure by
+  default instead of re-deriving this from scratch
+
+### Added
+
+- **`TestScaffoldedCiHardening`** (6 tests in
+  `tests/unit/test_scaffold.py`) — pins the hardening across
+  scaffolds:
+  - Each language flavor includes `permissions: contents: read`
+  - Pinned actions match `actions/<name>@<40-char-sha>`
+  - No bare `actions/<name>@v<n>` form survives
+  - Python scaffold includes `pip-audit --strict`
+  - TypeScript scaffold includes `npm audit`
+
+### Notes
+
+- This closes the "scaffold-output hardening" follow-up flagged in
+  1.5.23's PR (#53 part 2 only updated aida-core's own CI; part 3
+  brings the scaffolded templates along)
+- Existing
+  `TestScaffoldedLintBaseline.test_python_ci_yml_sets_up_node`
+  test updated to assert on the SHA-pinned form (`actions/setup-node@`
+  with a `# v4` comment) instead of the bare `@v4` form
+
+---
+
 ## [1.5.23] - 2026-05-23
 
 ### Changed

--- a/skills/plugin-manager/templates/scaffold/none/ci.yml.jinja2
+++ b/skills/plugin-manager/templates/scaffold/none/ci.yml.jinja2
@@ -8,27 +8,35 @@ on:
   pull_request:
     branches: [main]
 
+# Least-privilege at the workflow level. Pinning Action references
+# to commit SHAs (with version comments) means a compromised tag
+# can't ship malicious code through CI. Dependabot keeps these
+# pins fresh.
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       # Skills-only plugins still need Python (for `reuse`) and Node
       # (for `npx markdownlint-cli`) so `make lint` can run end-to-end.
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '{{ python_version }}'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '{{ node_version }}'
 
       - name: Install lint tools
         run: |
+          python -m pip install --upgrade pip
           pip install 'reuse>=4.0'
           npm install -g markdownlint-cli@0.43.0
 

--- a/skills/plugin-manager/templates/scaffold/python/ci.yml.jinja2
+++ b/skills/plugin-manager/templates/scaffold/python/ci.yml.jinja2
@@ -8,6 +8,13 @@ on:
   pull_request:
     branches: [main]
 
+# Least-privilege at the workflow level. Individual jobs escalate
+# only if needed (none do today). Pinning Action references to
+# commit SHAs (with version comments) means a compromised tag can't
+# ship malicious code through CI. Dependabot keeps these pins fresh.
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
@@ -16,10 +23,10 @@ jobs:
         python-version: ["{{ python_version }}"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Python ${{ '{{' }} matrix.python-version {{ '}}' }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ '{{' }} matrix.python-version {{ '}}' }}
 
@@ -27,15 +34,25 @@ jobs:
       # `npx --yes markdownlint-cli`. Hosted Ubuntu runners ship Node
       # by default, so we only need setup-node to pin the version.
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '{{ node_version }}'
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
 
       - name: Lint
         run: make lint
 
       - name: Test
         run: make test
+
+      # Audit Python deps for known CVEs. --strict gates on any
+      # vulnerability in dev or runtime deps. pip-audit isn't a
+      # required dev dep — it's installed in CI only.
+      - name: Audit Python dependencies
+        run: |
+          pip install --quiet pip-audit
+          pip-audit --strict

--- a/skills/plugin-manager/templates/scaffold/typescript/ci.yml.jinja2
+++ b/skills/plugin-manager/templates/scaffold/typescript/ci.yml.jinja2
@@ -8,6 +8,13 @@ on:
   pull_request:
     branches: [main]
 
+# Least-privilege at the workflow level. Pinning Action references
+# to commit SHAs (with version comments) means a compromised tag
+# can't ship malicious code through CI. Dependabot keeps these
+# pins fresh.
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
@@ -16,10 +23,10 @@ jobs:
         node-version: ["{{ node_version }}"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Node.js ${{ '{{' }} matrix.node-version {{ '}}' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: ${{ '{{' }} matrix.node-version {{ '}}' }}
 
@@ -31,3 +38,9 @@ jobs:
 
       - name: Test
         run: make test
+
+      # Audit npm deps for known CVEs. `npm audit --audit-level=high`
+      # gates on high+ severity findings (moderate/low are noisy and
+      # rarely actionable in dev tooling).
+      - name: Audit npm dependencies
+        run: npm audit --audit-level=high

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -3,6 +3,7 @@
 
 """Unit tests for plugin-manager scaffold.py main entry point."""
 
+import re
 import sys
 import tempfile
 import unittest
@@ -545,11 +546,22 @@ class TestScaffoldedLintBaseline(unittest.TestCase):
                 / "workflows"
                 / "ci.yml"
             ).read_text()
+            # Pinned to SHA per #53 hardening; the comment still
+            # carries the human-readable `v4`. Assert on the
+            # action name with its SHA-pin marker rather than the
+            # bare `@v4` form (which we deliberately moved away
+            # from to defend against compromised-tag attacks).
             self.assertIn(
-                "actions/setup-node@v4",
+                "actions/setup-node@",
                 ci,
                 "Python ci.yml missing setup-node step — `npx "
                 "markdownlint-cli` will fail without Node.",
+            )
+            self.assertIn(
+                "# v4",
+                ci,
+                "setup-node pin must carry a human-readable "
+                "version comment so reviewers can spot drift.",
             )
     """Test execute with agent stub."""
 
@@ -580,6 +592,104 @@ class TestScaffoldedLintBaseline(unittest.TestCase):
             self.assertTrue(
                 (target_path / "agents" / "my-agent" / "my-agent.md").exists()
             )
+
+
+class TestScaffoldedCiHardening(unittest.TestCase):
+    """Pin the CI security hardening pattern in scaffolded ci.yml (#53).
+
+    Downstream plugins should ship with the same hardening as aida-core
+    itself: least-privilege `permissions: contents: read`, SHA-pinned
+    Action references (with version comments), and a dependency audit
+    step. Otherwise every new plugin re-derives this from scratch (or
+    silently ships without it).
+    """
+
+    SHA_PATTERN = re.compile(
+        r"actions/(checkout|setup-python|setup-node)@[0-9a-f]{40}"
+    )
+
+    def _scaffold(self, language: str) -> Path:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = str(Path(tmp) / f"{language}-plugin")
+            context = {
+                "plugin_name": f"{language}-plugin",
+                "description": f"A {language} plugin for #53 part 3 hardening tests",
+                "license": "MIT",
+                "language": language,
+                "target_directory": target,
+                "author_name": "Test",
+                "author_email": "test@test.com",
+                "keywords": "",
+                "version": "0.1.0",
+            }
+            with patch.object(
+                _scaffold_mod, "initialize_git", return_value=True
+            ), patch.object(
+                _scaffold_mod,
+                "create_initial_commit",
+                return_value=True,
+            ):
+                result = execute(context)
+            self.assertTrue(
+                result["success"], result.get("message")
+            )
+            ci_path = (
+                Path(result["path"])
+                / ".github"
+                / "workflows"
+                / "ci.yml"
+            )
+            self.assertTrue(
+                ci_path.exists(),
+                f"{language} scaffold missing ci.yml",
+            )
+            # Read content before the temp dir is cleaned up.
+            return ci_path.read_text(encoding="utf-8")
+
+    def test_python_ci_has_workflow_permissions(self):
+        ci = self._scaffold("python")
+        self.assertIn("permissions:", ci)
+        self.assertIn("contents: read", ci)
+
+    def test_typescript_ci_has_workflow_permissions(self):
+        ci = self._scaffold("typescript")
+        self.assertIn("permissions:", ci)
+        self.assertIn("contents: read", ci)
+
+    def test_none_ci_has_workflow_permissions(self):
+        ci = self._scaffold("none")
+        self.assertIn("permissions:", ci)
+        self.assertIn("contents: read", ci)
+
+    def test_python_ci_pins_actions_to_sha(self):
+        """No bare `actions/<name>@v<n>` form — only SHA pins."""
+        ci = self._scaffold("python")
+        matches = self.SHA_PATTERN.findall(ci)
+        self.assertGreaterEqual(
+            len(matches),
+            3,
+            f"Expected at least 3 SHA-pinned actions; got "
+            f"{matches!r} from ci.yml",
+        )
+        # Defensive: no bare @v<digit> pattern survived.
+        for line in ci.splitlines():
+            if "uses:" in line and "actions/" in line:
+                self.assertNotRegex(
+                    line,
+                    r"actions/[a-z-]+@v\d+\s*$",
+                    f"Bare version pin (should be SHA): {line!r}",
+                )
+
+    def test_python_ci_includes_pip_audit(self):
+        """Python scaffold's CI runs pip-audit on the install tree."""
+        ci = self._scaffold("python")
+        self.assertIn("pip-audit", ci)
+        self.assertIn("--strict", ci)
+
+    def test_typescript_ci_includes_npm_audit(self):
+        """TypeScript scaffold's CI runs `npm audit`."""
+        ci = self._scaffold("typescript")
+        self.assertIn("npm audit", ci)
 
 
 class TestExecuteSkillsOnlyProject(unittest.TestCase):


### PR DESCRIPTION
## Summary

Closes the follow-up flagged in #133 (1.5.23's PR): #53 part 2 hardened **aida-core's own** CI. This PR brings the scaffolded \`ci.yml\` templates along so downstream plugins ship with the same security posture instead of re-deriving it.

Applied across all three scaffold flavors (\`python\`, \`typescript\`, \`none\`):

| Hardening | Applied to |
| --- | --- |
| \`permissions: contents: read\` at workflow level | all three |
| Actions pinned to commit SHAs with version comments | all three |
| \`pip-audit --strict\` step (after install) | python |
| \`npm audit --audit-level=high\` step | typescript |
| \`pip install --upgrade pip\` before audit | python, none |

Pinned SHAs match what aida-core's own CI uses:

- \`actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4\`
- \`actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5\`
- \`actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4\`

Dependabot in the scaffolded plugin keeps these fresh once the plugin author also adopts \`dependabot.yml\` (separate concern; the scaffold doesn't currently emit one — could be a future follow-up).

## Test plan

- [x] \`pytest tests/unit/test_scaffold.py::TestScaffoldedCiHardening\` — 6 pass (new)
- [x] \`pytest\` full suite — 997 pass (was 991, +6)
- [x] \`ruff check\` clean
- [x] \`yamllint -c .yamllint.yml skills/\` clean
- [x] \`reuse lint\` — 331/331 files clean
- [x] Version bump 1.5.23 → 1.5.24 + CHANGELOG entry

## New tests

\`TestScaffoldedCiHardening\` (6 cases) pins:

- Each language flavor includes \`permissions: contents: read\`
- Pinned actions match \`actions/<name>@<40-char hex>\` (regex-validated)
- No bare \`@v<n>\` form survives anywhere
- Python scaffold includes \`pip-audit --strict\`
- TypeScript scaffold includes \`npm audit\`

Existing \`test_python_ci_yml_sets_up_node\` updated to assert on the SHA-pinned shape (\`actions/setup-node@\` + \`# v4\` comment) instead of the bare \`@v4\` form.

## Why upgrade pip in the audit step

The Python ci template now does \`python -m pip install --upgrade pip\` before \`pip-audit\`. GitHub-hosted runners ship pip 24.0 which has CVE-2025-8869 and CVE-2026-1703 — \`pip-audit --strict\` would fail on those before checking anything we control. Upgrading is a no-op for our deps; we don't pin pip itself.

## What's still left in #53

- [ ] \`.pre-commit-config.yaml\`
- [ ] Issue/PR templates
- [ ] Release workflow (tag-triggered)
- [ ] Dependabot alerts on repo (GitHub UI; can't be done via PR)

Closes part 3 of the #53 checklist.