### PR TITLE
chore: issue/PR templates + pre-commit + release workflow (#53 part 4, 1.5.25)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.24",
+  "version": "1.5.25",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+---
+name: Bug Report
+description: Something works incorrectly or fails to work.
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please fill
+        in the fields below — even partial info is more useful than
+        none.
+
+        If you're running AIDA, `/aida bug` auto-collects the
+        environment block and pre-fills this template. That's the
+        path of least resistance.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: What went wrong?
+      placeholder: e.g., "/aida config crashes when ..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How disruptive is this?
+      options:
+        - Minor (annoying but not blocking)
+        - Major (blocks a real workflow; workaround exists)
+        - Critical (no workaround; data loss or silent corruption)
+      default: 0
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered list, exact commands where possible.
+      placeholder: |
+        1. Run `/aida config`
+        2. Select 'Configure this project'
+        3. Observe error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you think would happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Paste error messages /
+        stack traces verbatim.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Python version, Node version, AIDA version.
+        `/aida bug` fills this in for you.
+      placeholder: |
+        - OS: Darwin 25.x
+        - Python: 3.x
+        - Node: vXX
+        - AIDA: 1.5.x
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+---
+# GitHub issue chooser config. Disables blank issues so contributors
+# pick a template, and points heavy users at the /aida feedback flows
+# which auto-fill environment context.
+blank_issues_enabled: false
+
+contact_links:
+  - name: Use /aida feedback (preferred for AIDA users)
+    url: https://github.com/aida-core/aida-core-plugin#feedback--support
+    about: >-
+      If you're running AIDA, `/aida bug` and `/aida feature-request`
+      auto-collect environment context (OS, Python, Node, AIDA
+      version) and prefill the right template. Faster than filling
+      this out by hand.
+
+  - name: Security disclosure
+    url: https://github.com/aida-core/aida-core-plugin/security/advisories/new
+    about: >-
+      DO NOT report security issues as public issues. Use GitHub
+      Security Advisories or email github@oakensoul.com per
+      SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+---
+name: Feature Request
+description: Suggest a new capability or improve an existing one.
+title: "[Feature] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Before filing, please check whether
+        the idea is **in scope** for aida-core-plugin (Claude Code
+        plugin foundation — configure, scaffold, manage extensions).
+        Issues like polyrepo migration tools or general devops
+        helpers are typically out of scope; consider a separate repo
+        for those.
+
+        If you're running AIDA, `/aida feature-request` pre-fills
+        this template.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the pain point in your own words. Real
+        examples help.
+      placeholder: e.g., "Scaffolding a markdown-only plugin gives me
+        a Python toolchain I don't want."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How might this work? A sketch is fine; we'll
+        refine in discussion.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else did you try or think about?
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Real-world artifacts, references to prior work,
+        related issues, etc.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+## Summary
+
+<!-- 1-3 sentences. What does this PR do and why? Link the issue
+     it closes with `Closes #N`. -->
+
+## Test plan
+
+<!-- Checkboxes for what was verified locally. CI runs the same
+     checks, but listing them here helps reviewers. -->
+
+- [ ] `make lint` clean
+- [ ] `make test` clean
+- [ ] `reuse lint` clean (if files were added/touched)
+- [ ] Version bump in `.claude-plugin/plugin.json` + matching CHANGELOG entry
+- [ ] (if applicable) End-to-end sanity check / manual repro
+
+## Notes
+
+<!-- Anything reviewers should know: scope decisions, follow-ups,
+     intentional omissions, etc. -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+---
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+# Least-privilege at the workflow level. The `release` job
+# explicitly bumps to `contents: write` only for its own scope so
+# it can create the GitHub Release. Every other token use defaults
+# to read-only.
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Releasing ${TAG} (version ${VERSION})"
+
+      - name: Verify plugin.json matches tag
+        run: |
+          set -euo pipefail
+          MANIFEST_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
+          if [[ "${MANIFEST_VERSION}" != "${{ steps.version.outputs.version }}" ]]; then
+            msg="Tag ${{ steps.version.outputs.tag }} (version"
+            msg="${msg} ${{ steps.version.outputs.version }}) doesn't"
+            msg="${msg} match plugin.json (version ${MANIFEST_VERSION})."
+            msg="${msg} Did you forget to bump the manifest?"
+            echo "::error::${msg}"
+            exit 1
+          fi
+          echo "OK: tag matches plugin.json"
+
+      - name: Extract CHANGELOG section for this version
+        id: changelog
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          ESCAPED=$(printf '%s' "${VERSION}" | sed 's/[.[\*^$()+?{|]/\\&/g')
+
+          # Capture the section starting with '## [<VERSION>]' up to
+          # (but not including) the next '## [' heading.
+          NOTES=$(awk -v ver="${ESCAPED}" '
+            $0 ~ "^## \\[" ver "\\]" { in_section = 1; next }
+            in_section && /^## \[/ { exit }
+            in_section { print }
+          ' CHANGELOG.md)
+
+          if [[ -z "${NOTES// }" ]]; then
+            msg="No CHANGELOG section found for version ${VERSION}."
+            msg="${msg} Add a '## [${VERSION}] - YYYY-MM-DD' heading"
+            msg="${msg} before tagging."
+            echo "::error file=CHANGELOG.md::${msg}"
+            exit 1
+          fi
+
+          # Multi-line outputs need the delimiter form.
+          {
+            echo "notes<<RELEASE_NOTES_EOF"
+            echo "${NOTES}"
+            echo "RELEASE_NOTES_EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.version.outputs.tag }}"
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # `--notes-file -` reads from stdin so we don't have to
+          # quote multi-line markdown into a shell arg.
+          cat <<'RELEASE_NOTES_EOF' | gh release create "${TAG}" \
+            --title "v${VERSION}" \
+            --verify-tag \
+            --notes-file -
+          ${{ steps.changelog.outputs.notes }}
+          RELEASE_NOTES_EOF

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+---
+# Pre-commit configuration (#53). Mirrors what `make lint` runs in
+# CI so contributors catch issues locally before push.
+#
+# Setup:
+#   pip install pre-commit && pre-commit install
+#
+# This config is optional — CI runs the same checks regardless.
+# Local hooks just shorten the feedback loop.
+
+repos:
+  # ruff (Python lint + format). Single tool for both surfaces;
+  # config lives in pyproject.toml / ruff.toml of the consumer.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.0
+    hooks:
+      - id: ruff
+        name: ruff (lint)
+        args:
+          - --fix
+      - id: ruff-format
+        name: ruff (format)
+
+  # yamllint (YAML structure / indentation / document-start).
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        name: yamllint
+        args:
+          - -c
+          - .yamllint.yml
+
+  # REUSE / SPDX header compliance. Runs `reuse lint` which validates
+  # that every source file has copyright + license metadata.
+  - repo: https://github.com/fsfe/reuse-tool
+    rev: v4.0.3
+    hooks:
+      - id: reuse
+        name: reuse lint
+
+  # Bare-minimum hygiene: trailing whitespace, EOL, large-file guard,
+  # JSON/YAML/TOML syntax. Catch broad mistakes before CI does.
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args:
+          - --maxkb=512
+      - id: check-yaml
+      - id: check-json
+      - id: check-toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,51 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.25] - 2026-05-23
+
+### Added
+
+- **Issue templates** in `.github/ISSUE_TEMPLATE/` (#53 part 4) —
+  form-based GitHub templates for bug reports and feature
+  requests, plus a `config.yml` that points heavy users at
+  `/aida bug` / `/aida feature-request` (which auto-collect
+  environment context) and at GitHub Security Advisories for
+  vuln disclosures. Blank issues disabled
+- **`.github/PULL_REQUEST_TEMPLATE.md`** — short Summary / Test
+  plan / Notes template matching the pattern used throughout
+  this session's PRs
+- **`.pre-commit-config.yaml`** at repo root — optional local
+  hook config that mirrors `make lint`: ruff (lint + format),
+  yamllint, REUSE, plus bare-minimum hygiene hooks
+  (trailing whitespace, EOL, large-file guard, JSON/YAML/TOML
+  syntax). Contributors install with
+  `pip install pre-commit && pre-commit install`. CI runs the
+  same checks regardless
+- **`.github/workflows/release.yml`** — tag-triggered release
+  workflow. On push of a `v*` tag:
+  - Verifies the tag's version matches `.claude-plugin/plugin.json`
+    (catches a tag pushed before the manifest bump)
+  - Extracts the matching `## [<version>] - YYYY-MM-DD` section
+    from CHANGELOG.md
+  - Creates a GitHub Release with the extracted notes
+  Uses minimum-required permissions (`contents: write` scoped
+  to the release job only) and a SHA-pinned `actions/checkout`
+
+### Notes
+
+- Closes the last code-side items in #53. Remaining checklist
+  item is **Dependabot alerts** on the repo, which is a
+  GitHub UI setting (can't be done via PR)
+- Once #53 is fully closed, the remaining "stale"-feel
+  milestones (0.9.0 / 1.1.0) are the only chore-shaped
+  artifacts in the milestone view
+- After this lands, the natural next step is **cutting a
+  release** — 24 unreleased version bumps now sitting on main
+  (1.5.2 → 1.5.25), and the new release.yml workflow makes
+  that mechanical
+
+---
+
 ## [1.5.24] - 2026-05-23
 
 ### Changed

--- a/scripts/validate_frontmatter.py
+++ b/scripts/validate_frontmatter.py
@@ -50,11 +50,21 @@ IGNORE_PATTERNS = [
     '.issues',
 ]
 
+# Individual filenames to skip. GitHub renders these directly into
+# its UI (PR description box, etc.); embedding YAML frontmatter
+# would show up verbatim in every PR description created from the
+# template, which is exactly the wrong thing.
+IGNORE_FILENAMES = frozenset({
+    "PULL_REQUEST_TEMPLATE.md",
+})
+
 
 def should_ignore(filepath: Path) -> bool:
     """Check if file should be ignored."""
     parts = filepath.parts
-    return any(pattern in parts for pattern in IGNORE_PATTERNS)
+    if any(pattern in parts for pattern in IGNORE_PATTERNS):
+        return True
+    return filepath.name in IGNORE_FILENAMES
 
 
 def extract_frontmatter(content: str) -> Optional[dict]:


### PR DESCRIPTION
## Summary

Closes the last code-side items from #53's hardening checklist. After this lands, the only remaining checklist item is **Dependabot alerts on the repo**, which is a GitHub UI setting (can't be done via PR).

## What's new

- **`.github/ISSUE_TEMPLATE/`** — three files:
  - \`bug_report.yml\` — form-based template with severity, repro, expected/actual, environment
  - \`feature_request.yml\` — problem / proposed solution / alternatives. Calls out the scope boundary (Claude Code plugin foundation; not polyrepo migration tools etc.)
  - \`config.yml\` — disables blank issues, points users at \`/aida bug\` / \`/aida feature-request\` (which pre-fill these templates with environment context), and at GitHub Security Advisories
- **\`.github/PULL_REQUEST_TEMPLATE.md\`** — Summary / Test plan / Notes (matches the pattern used throughout this session's PRs)
- **\`.pre-commit-config.yaml\`** at repo root — optional local hooks mirroring \`make lint\`: ruff (lint + format), yamllint, REUSE, plus baseline hygiene (trailing whitespace, EOL, large-file guard, JSON/YAML/TOML syntax). Contributors install with \`pip install pre-commit && pre-commit install\`. CI runs the same checks regardless
- **\`.github/workflows/release.yml\`** — tag-triggered release workflow. On push of a \`v*\` tag:
  - Verifies the tag's version matches \`.claude-plugin/plugin.json\` (catches a tag pushed before the manifest bump)
  - Extracts the matching \`## [<version>] - YYYY-MM-DD\` section from \`CHANGELOG.md\`
  - Creates a GitHub Release with the extracted notes
  - Minimum-required permissions: \`contents: write\` scoped to the release job only; SHA-pinned \`actions/checkout\`

## Test plan

- [x] \`yamllint -c .yamllint.yml .github/\` clean
- [x] All new YAML files parse as valid YAML
- [x] \`pytest\` — 997 pass (no test changes — pure repo hygiene)
- [x] \`reuse lint\` — 337/337 files clean (was 331 + 6 new files)
- [x] Version bump 1.5.24 → 1.5.25 + CHANGELOG entry

## Next

24 unreleased version bumps (1.5.2 → 1.5.25) sitting on main. With the new \`release.yml\` workflow in place, cutting a release is now mechanical:

1. Confirm \`plugin.json\` version matches what you want to tag
2. Add a top-level entry to \`CHANGELOG.md\` if needed
3. \`git tag v1.6.0 && git push origin v1.6.0\` (or whatever version)
4. The release workflow takes it from there

## #53 status after merge

- ✅ SPDX headers (#72, #73)
- ✅ \`AUTHORS\` (1.4.7)
- ✅ \`MAINTAINERS.md\` + \`dependabot.yml\` (#90, 1.5.20)
- ✅ \`SECURITY.md\` + \`CONTRIBUTING.md\` + \`CODE_OF_CONDUCT.md\` (#53 part 1, 1.5.22)
- ✅ CI hardening: permissions / SHA pins / pip-audit (#53 part 2, 1.5.23)
- ✅ Scaffolded ci.yml hardening (#53 part 3, 1.5.24)
- ✅ Issue/PR templates + pre-commit + release workflow (#53 part 4, this PR)
- ⏳ Dependabot alerts on repo (GitHub UI, not a PR)

Closes the last code-side items in #53.