### PR TITLE
feat: plugin dependency management foundation (#20, 1.5.26)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.25",
+  "version": "1.5.26",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,59 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.26] - 2026-05-23
+
+### Added
+
+- **Plugin dependency management foundation** (#20). New
+  `dependencies` field on `aida-config.json` lets a plugin declare
+  what other plugins (and what version ranges) it expects to be
+  present. Foundation only — install-time resolution and the
+  agent registry are deliberate follow-ups.
+- **`utils/dependencies.py`** module with three exports:
+  - `parse_version_spec(spec)` — parses bare versions plus `==`,
+    `>=`, `>`, `<=`, `<`, `^` (caret = major-compatible), and
+    `~` (tilde = minor-compatible). 1-3-part dotted-int versions
+    accepted; pre-release / build metadata not yet
+  - `version_satisfies(version, spec)` — best-effort check;
+    returns False on garbage rather than raising
+  - `check_dependencies(declared, installed)` — resolves a
+    declared dep map against the output of
+    `discover_installed_plugins()`, returning a sorted list of
+    per-dep statuses (`satisfied` / `wrong-version` / `missing`)
+- **`discover_installed_plugins()`** now surfaces each plugin's
+  `dependencies` (defaults to `{}` if the plugin hasn't declared
+  any). Other downstream skills can call
+  `utils.check_dependencies(plugin["dependencies"], installed)`
+  to get a status report
+- **Scaffolded `aida-config.json` includes the field** — every
+  new plugin lands with `"dependencies": {}` so authors have a
+  visible slot to declare deps when they need them
+- 23 new tests in `tests/unit/test_dependencies.py` covering
+  parsing (bare versions, all operators, partial versions,
+  garbage rejection), version satisfaction (each operator + caret
+  / tilde semantics + best-effort behavior on malformed input),
+  and check_dependencies (satisfied / missing / wrong-version /
+  mixed / deterministic sorting / malformed installed entries)
+
+### Notes
+
+- This is **foundation only**. The bigger #20 surface — interactive
+  install-time resolution, `/aida agents list` agent registry,
+  agent name collision detection — is deliberate follow-up work
+- The `packaging` / `semver` libraries weren't pulled in
+  intentionally. The current operator set covers the issue's
+  motivating example (`">=0.8.0"`) and the common cases. If we
+  ever need full PEP 440 / npm-style ranges, swap the internal
+  parser for `packaging.specifiers`
+- Future commands that build on this:
+  - `/aida plugin deps` — list a plugin's declared deps + status
+  - `/aida plugin install <name>` — install + resolve declared deps
+  - `/aida agents list` — unified view across plugins (also #20's
+    agent-registry piece)
+
+---
+
 ## [1.5.25] - 2026-05-23
 
 ### Added

--- a/skills/aida/scripts/utils/__init__.py
+++ b/skills/aida/scripts/utils/__init__.py
@@ -83,6 +83,13 @@ from .plugins import (
     generate_plugin_preference_questions,
 )
 
+# Plugin dependency management (#20)
+from .dependencies import (
+    check_dependencies,
+    parse_version_spec,
+    version_satisfies,
+)
+
 # Agent discovery
 from .agents import (
     discover_agents,
@@ -172,6 +179,10 @@ __all__ = [
     "validate_plugin_config",
     "generate_plugin_checklist",
     "generate_plugin_preference_questions",
+    # Plugin dependency management (#20)
+    "check_dependencies",
+    "parse_version_spec",
+    "version_satisfies",
     # Agent discovery
     "discover_agents",
     "generate_agent_routing_section",

--- a/skills/aida/scripts/utils/dependencies.py
+++ b/skills/aida/scripts/utils/dependencies.py
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+"""Plugin dependency declaration + checking (#20).
+
+This module is the foundation for plugin-to-plugin dependency
+management. It parses dependency version specs declared in
+`aida-config.json` (under the optional ``dependencies`` field) and
+checks them against installed plugins.
+
+Scope is deliberately small:
+
+  - Parse and check version specs (exact, `>=`, `^` caret, `~` tilde)
+  - Compare against the output of `discover_installed_plugins()`
+  - Surface per-dep status: satisfied / wrong-version / missing
+
+Out of scope (future work):
+
+  - Install-time resolution / auto-install
+  - Agent registry across plugins (`/aida agents list`)
+  - Collision detection between same-named agents in different plugins
+
+Why a tiny custom parser instead of `packaging` / `semver`: we don't
+need NPM-grade range syntax, and adding a runtime dep for four
+operators isn't worth it. If we ever need full PEP 440 / semver
+ranges, swap this for `packaging.specifiers`.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Tuple
+
+# Recognized operators. Order matters: longest prefix first.
+_OPERATORS = ("==", ">=", "<=", "^", "~", ">", "<")
+
+_VERSION_RE = re.compile(r"^\d+(?:\.\d+){0,2}$")
+
+
+def _parse_version(version: str) -> Tuple[int, int, int]:
+    """Parse a 1-3 part dotted-int version into a 3-tuple.
+
+    `"1"` -> (1, 0, 0); `"1.2"` -> (1, 2, 0); `"1.2.3"` -> (1, 2, 3).
+    Raises ``ValueError`` on garbage so callers can tell a malformed
+    spec from a missing one.
+    """
+    if not isinstance(version, str) or not _VERSION_RE.match(version):
+        raise ValueError(f"Not a dotted-int version: {version!r}")
+    parts = [int(p) for p in version.split(".")]
+    while len(parts) < 3:
+        parts.append(0)
+    major, minor, patch = parts[:3]
+    return major, minor, patch
+
+
+def parse_version_spec(spec: str) -> Tuple[str, str]:
+    """Parse a dependency version spec into (operator, version).
+
+    Accepted forms:
+
+      - ``"1.2.3"`` -> ``("==", "1.2.3")`` (bare version = exact)
+      - ``">=1.2.3"``, ``">1.2.3"``, ``"<=1.2.3"``, ``"<1.2.3"``,
+        ``"==1.2.3"`` -> straightforward comparators
+      - ``"^1.2.3"`` -> caret: ``>=1.2.3, <2.0.0`` (major-compatible)
+      - ``"~1.2.3"`` -> tilde: ``>=1.2.3, <1.3.0`` (minor-compatible)
+
+    Returns:
+        Tuple of (operator, version-string). The operator preserves
+        the input form (``"^"`` stays ``"^"``); ``version_satisfies``
+        handles the expansion.
+
+    Raises:
+        ValueError on malformed input.
+    """
+    if not isinstance(spec, str):
+        raise ValueError(
+            f"Version spec must be a string, got {type(spec).__name__}"
+        )
+    s = spec.strip()
+    if not s:
+        raise ValueError("Empty version spec")
+
+    for op in _OPERATORS:
+        if s.startswith(op):
+            version = s[len(op):].strip()
+            _parse_version(version)  # validate
+            return op, version
+
+    # Bare version -> exact match
+    _parse_version(s)
+    return "==", s
+
+
+def version_satisfies(version: str, spec: str) -> bool:
+    """Return True if ``version`` satisfies ``spec``.
+
+    See :func:`parse_version_spec` for the supported operators.
+    Malformed input returns False rather than raising — dep
+    checking should be best-effort, not fragile.
+    """
+    try:
+        op, want = parse_version_spec(spec)
+        have = _parse_version(version)
+        wanted = _parse_version(want)
+    except ValueError:
+        return False
+
+    if op == "==":
+        return have == wanted
+    if op == ">":
+        return have > wanted
+    if op == ">=":
+        return have >= wanted
+    if op == "<":
+        return have < wanted
+    if op == "<=":
+        return have <= wanted
+    if op == "^":
+        # Major-compatible: >= wanted, < next major
+        next_major = (wanted[0] + 1, 0, 0)
+        return wanted <= have < next_major
+    if op == "~":
+        # Minor-compatible: >= wanted, < next minor
+        next_minor = (wanted[0], wanted[1] + 1, 0)
+        return wanted <= have < next_minor
+
+    # Unreachable — parse_version_spec only returns the operators above
+    return False
+
+
+def check_dependencies(
+    declared: Dict[str, str],
+    installed: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Resolve declared dependencies against installed plugins.
+
+    Args:
+        declared: Map of plugin-name -> version-spec, as read from
+            an `aida-config.json` `dependencies` field.
+        installed: List of plugin dicts from
+            `discover_installed_plugins()` (each has at least
+            ``name`` and ``version``).
+
+    Returns:
+        List of result dicts, one per declared dep:
+
+        - ``name``: dep name
+        - ``required``: original spec string
+        - ``installed``: installed version, or None if missing
+        - ``status``: ``"satisfied"``, ``"wrong-version"``, or
+          ``"missing"``
+    """
+    by_name = {p.get("name"): p for p in installed if p.get("name")}
+    results: List[Dict[str, Any]] = []
+    for name, spec in sorted(declared.items()):
+        plugin = by_name.get(name)
+        if plugin is None:
+            results.append(
+                {
+                    "name": name,
+                    "required": spec,
+                    "installed": None,
+                    "status": "missing",
+                }
+            )
+            continue
+
+        installed_version = plugin.get("version", "0.0.0")
+        ok = version_satisfies(installed_version, spec)
+        results.append(
+            {
+                "name": name,
+                "required": spec,
+                "installed": installed_version,
+                "status": "satisfied" if ok else "wrong-version",
+            }
+        )
+    return results

--- a/skills/aida/scripts/utils/plugins.py
+++ b/skills/aida/scripts/utils/plugins.py
@@ -209,6 +209,21 @@ def discover_installed_plugins() -> list[dict]:
                 plugin_dir_path, resolved_root
             )
 
+            # Surface dependencies declared in aida-config.json
+            # (#20). Treated as an optional plain dict; downstream
+            # callers use `utils.dependencies.check_dependencies()`
+            # to resolve specs against installed plugins.
+            dependencies_raw = (
+                aida_config.get("dependencies", {})
+                if aida_config
+                else {}
+            )
+            dependencies = (
+                dependencies_raw
+                if isinstance(dependencies_raw, dict)
+                else {}
+            )
+
             plugins.append(
                 {
                     "name": data.get("name", "unknown"),
@@ -218,6 +233,7 @@ def discover_installed_plugins() -> list[dict]:
                         if aida_config
                         else {}
                     ),
+                    "dependencies": dependencies,
                     "recommendedPermissions": (
                         aida_config.get(
                             "recommendedPermissions", {}

--- a/skills/plugin-manager/templates/scaffold/shared/aida-config.json.jinja2
+++ b/skills/plugin-manager/templates/scaffold/shared/aida-config.json.jinja2
@@ -14,6 +14,7 @@
     ]
   },
   "recommendedPermissions": {},
+  "dependencies": {},
   "agents": [
     {% for name in [agent_stub_name] if include_agent_stub %}
     {{ name | tojson }}{{ "," if not loop.last else "" }}

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for plugin dependency parsing + checking (#20)."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_project_root = Path(__file__).parent.parent.parent
+sys.path.insert(
+    0, str(_project_root / "skills" / "aida" / "scripts")
+)
+
+from utils.dependencies import (  # noqa: E402
+    check_dependencies,
+    parse_version_spec,
+    version_satisfies,
+)
+
+
+class TestParseVersionSpec(unittest.TestCase):
+    """parse_version_spec extracts the operator + version."""
+
+    def test_bare_version_is_exact(self):
+        self.assertEqual(
+            parse_version_spec("1.2.3"), ("==", "1.2.3")
+        )
+
+    def test_explicit_equal(self):
+        self.assertEqual(
+            parse_version_spec("==1.2.3"), ("==", "1.2.3")
+        )
+
+    def test_gte(self):
+        self.assertEqual(
+            parse_version_spec(">=1.2.3"), (">=", "1.2.3")
+        )
+
+    def test_caret(self):
+        self.assertEqual(
+            parse_version_spec("^1.2.3"), ("^", "1.2.3")
+        )
+
+    def test_tilde(self):
+        self.assertEqual(
+            parse_version_spec("~1.2.3"), ("~", "1.2.3")
+        )
+
+    def test_leading_whitespace_tolerated(self):
+        self.assertEqual(
+            parse_version_spec("  >=1.2.3  "), (">=", "1.2.3")
+        )
+
+    def test_partial_versions_accepted(self):
+        """1, 1.2, and 1.2.3 all parse — `_parse_version` pads."""
+        for v in ("1", "1.2", "1.2.3"):
+            op, version = parse_version_spec(v)
+            self.assertEqual(op, "==")
+            self.assertEqual(version, v)
+
+    def test_garbage_raises(self):
+        for bad in ("", "  ", "1.x.x", "v1.2.3", "1.2.3-rc1", "foo"):
+            with self.assertRaises(ValueError):
+                parse_version_spec(bad)
+
+    def test_non_string_raises(self):
+        for bad in (None, 1.2, [], {}):
+            with self.assertRaises(ValueError):
+                parse_version_spec(bad)
+
+
+class TestVersionSatisfies(unittest.TestCase):
+    """version_satisfies checks a version against a spec."""
+
+    def test_exact_match(self):
+        self.assertTrue(version_satisfies("1.2.3", "1.2.3"))
+        self.assertTrue(version_satisfies("1.2.3", "==1.2.3"))
+        self.assertFalse(version_satisfies("1.2.4", "1.2.3"))
+
+    def test_gte(self):
+        self.assertTrue(version_satisfies("1.2.3", ">=1.2.3"))
+        self.assertTrue(version_satisfies("2.0.0", ">=1.2.3"))
+        self.assertFalse(version_satisfies("1.2.2", ">=1.2.3"))
+
+    def test_gt(self):
+        self.assertFalse(version_satisfies("1.2.3", ">1.2.3"))
+        self.assertTrue(version_satisfies("1.2.4", ">1.2.3"))
+
+    def test_lt_and_lte(self):
+        self.assertTrue(version_satisfies("1.0.0", "<1.2.3"))
+        self.assertFalse(version_satisfies("1.2.3", "<1.2.3"))
+        self.assertTrue(version_satisfies("1.2.3", "<=1.2.3"))
+        self.assertTrue(version_satisfies("1.2.2", "<=1.2.3"))
+        self.assertFalse(version_satisfies("1.2.4", "<=1.2.3"))
+
+    def test_caret_allows_same_major(self):
+        """^1.2.3 ≡ >=1.2.3, <2.0.0."""
+        self.assertTrue(version_satisfies("1.2.3", "^1.2.3"))
+        self.assertTrue(version_satisfies("1.5.0", "^1.2.3"))
+        self.assertTrue(version_satisfies("1.99.99", "^1.2.3"))
+        self.assertFalse(version_satisfies("2.0.0", "^1.2.3"))
+        self.assertFalse(version_satisfies("1.2.2", "^1.2.3"))
+        self.assertFalse(version_satisfies("0.9.9", "^1.2.3"))
+
+    def test_tilde_allows_same_minor(self):
+        """~1.2.3 ≡ >=1.2.3, <1.3.0."""
+        self.assertTrue(version_satisfies("1.2.3", "~1.2.3"))
+        self.assertTrue(version_satisfies("1.2.99", "~1.2.3"))
+        self.assertFalse(version_satisfies("1.3.0", "~1.2.3"))
+        self.assertFalse(version_satisfies("1.2.2", "~1.2.3"))
+
+    def test_malformed_returns_false_not_raise(self):
+        """Dep checking is best-effort; we want False on garbage,
+        not a crash."""
+        self.assertFalse(version_satisfies("1.2.3", "garbage"))
+        self.assertFalse(version_satisfies("not-a-version", "^1.2.3"))
+        self.assertFalse(version_satisfies("1.2.3", ""))
+
+
+class TestCheckDependencies(unittest.TestCase):
+    """check_dependencies resolves a declared map against installed."""
+
+    def test_all_satisfied(self):
+        installed = [
+            {"name": "aida-team-essentials", "version": "0.8.0"},
+            {"name": "aida-data", "version": "1.0.0"},
+        ]
+        declared = {
+            "aida-team-essentials": ">=0.8.0",
+            "aida-data": "^1.0.0",
+        }
+        result = check_dependencies(declared, installed)
+        self.assertEqual(len(result), 2)
+        self.assertTrue(all(r["status"] == "satisfied" for r in result))
+
+    def test_missing_dependency(self):
+        installed = [{"name": "aida-other", "version": "1.0.0"}]
+        declared = {"aida-team-essentials": ">=0.8.0"}
+        result = check_dependencies(declared, installed)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(
+            result[0],
+            {
+                "name": "aida-team-essentials",
+                "required": ">=0.8.0",
+                "installed": None,
+                "status": "missing",
+            },
+        )
+
+    def test_wrong_version(self):
+        installed = [
+            {"name": "aida-team-essentials", "version": "0.7.0"},
+        ]
+        declared = {"aida-team-essentials": ">=0.8.0"}
+        result = check_dependencies(declared, installed)
+        self.assertEqual(result[0]["status"], "wrong-version")
+        self.assertEqual(result[0]["installed"], "0.7.0")
+        self.assertEqual(result[0]["required"], ">=0.8.0")
+
+    def test_mixed_statuses(self):
+        """One satisfied, one missing, one wrong-version."""
+        installed = [
+            {"name": "ok-plugin", "version": "1.0.0"},
+            {"name": "old-plugin", "version": "0.5.0"},
+        ]
+        declared = {
+            "ok-plugin": ">=1.0.0",
+            "missing-plugin": "^1.0.0",
+            "old-plugin": ">=1.0.0",
+        }
+        result = check_dependencies(declared, installed)
+        by_name = {r["name"]: r for r in result}
+        self.assertEqual(by_name["ok-plugin"]["status"], "satisfied")
+        self.assertEqual(by_name["missing-plugin"]["status"], "missing")
+        self.assertEqual(
+            by_name["old-plugin"]["status"], "wrong-version"
+        )
+
+    def test_results_are_sorted_by_name(self):
+        """Deterministic output makes diffs / reports stable."""
+        installed = []
+        declared = {"z-plugin": "1.0.0", "a-plugin": "1.0.0"}
+        result = check_dependencies(declared, installed)
+        names = [r["name"] for r in result]
+        self.assertEqual(names, sorted(names))
+
+    def test_empty_declared_returns_empty(self):
+        self.assertEqual(check_dependencies({}, []), [])
+
+    def test_installed_without_name_ignored(self):
+        """A malformed installed entry (no `name`) doesn't crash."""
+        installed = [
+            {"version": "1.0.0"},  # missing name
+            {"name": "real", "version": "1.0.0"},
+        ]
+        declared = {"real": "1.0.0"}
+        result = check_dependencies(declared, installed)
+        self.assertEqual(result[0]["status"], "satisfied")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Foundation pieces for #20's plugin dependency management surface. **Install-time resolution and the agent registry are deliberate follow-ups** — this PR gets the data-model + checking primitives in place so downstream features can build on them.

## What's new

**1. \`utils/dependencies.py\`** — three primitives:

- \`parse_version_spec(spec)\` — bare versions plus \`==\` / \`>=\` / \`>\` / \`<=\` / \`<\` / \`^\` (caret = major-compatible) / \`~\` (tilde = minor-compatible). 1-3-part dotted-int versions; no pre-release / build metadata yet
- \`version_satisfies(version, spec)\` — best-effort check; returns False on garbage rather than raising
- \`check_dependencies(declared, installed)\` — resolves a declared dep map against the installed-plugins list, returning sorted per-dep statuses (\`satisfied\` / \`wrong-version\` / \`missing\`)

**2. \`discover_installed_plugins()\` surfaces dependencies.** Each plugin dict now carries its declared \`dependencies\` field from \`aida-config.json\` (defaults to \`{}\` if not declared). Other skills do:

\`\`\`python
from utils import discover_installed_plugins, check_dependencies

installed = discover_installed_plugins()
me = next(p for p in installed if p["name"] == "my-plugin")
status = check_dependencies(me["dependencies"], installed)
# -> [{"name": "...", "required": ">=0.8.0", "installed": "0.8.0", "status": "satisfied"}, ...]
\`\`\`

**3. Scaffolded \`aida-config.json\` includes the field.** Every new plugin lands with \`"dependencies": {}\` — a visible slot to declare deps when needed.

## Test plan

- [x] \`pytest tests/unit/test_dependencies.py\` — 23 pass (new)
- [x] \`pytest\` full suite — 1020 pass (was 997, +23)
- [x] \`ruff check\` clean
- [x] \`reuse lint\` — 339/339 files clean
- [x] **End-to-end**: scaffolded a fresh Python plugin, confirmed \`aida-config.json\` keys are \`['agents', 'config', 'dependencies', 'generator_version', 'recommendedPermissions', 'skills']\` with \`dependencies: {}\`
- [x] Version bump 1.5.25 → 1.5.26 + CHANGELOG entry

## What this is NOT (the bigger #20 surface, deferred)

- \`/aida plugin deps\` interactive command — needs UX + routing
- \`/aida plugin install <name>\` with auto-resolution — needs marketplace coordination
- \`/aida agents list\` agent registry — needs cross-plugin agent collation
- Collision detection between same-named agents in different plugins

This PR keeps that surface as small as possible: the **data model**, **checking primitives**, and **scaffold slot**. Future commands sit on top.

## Notes

- \`packaging\` / \`semver\` libraries deliberately not pulled in — the current operator set covers the issue's motivating example (\`">=0.8.0"\`) and common cases. Swap for \`packaging.specifiers\` if we ever need full PEP 440 ranges
- This PR doesn't close #20 — it's the foundation. Issue stays open for the follow-on work