### PR TITLE
feat: /aida plugin agents — cross-plugin registry (#20 part 3, 1.5.28)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.27",
+  "version": "1.5.28",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,48 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.28] - 2026-05-23
+
+### Added
+
+- **`/aida plugin agents` command** (#20 part 3) — cross-plugin
+  agent registry with collision detection. Walks the project's
+  `agents/`, the user's `~/.claude/agents/`, and every installed
+  plugin under `~/.claude/plugins/cache/`. Returns a unified
+  roster (each entry tagged with its source + source_label) plus
+  a list of name collisions across sources. `success: False`
+  when any collision is detected, so the command is usable as a
+  CI gate ("verify our plugin doesn't introduce an agent-name
+  conflict with anything we have installed")
+- **`operations/agents.py`** in plugin-manager — distinct from
+  `utils.discover_agents` (which dedupes by name — first-found
+  wins). This view preserves duplicates so collisions can be
+  flagged. Lightweight by design — handles malformed frontmatter
+  gracefully (falls back to filename), skips `agents/<name>/knowledge/`
+  files, skips symlinked plugin dirs
+- **`/aida plugin agents` routing** in the aida dispatcher SKILL.md;
+  `agents` row added to plugin-manager's Operations table
+- 15 new tests in `tests/unit/test_plugin_agents.py` cover discovery
+  across all three sources, malformed-frontmatter fallback, knowledge-
+  file skipping, the collision detector (cross-source + sorted
+  output), the execute summary (`success`, `by_source` breakdown,
+  collision count), and the get_questions phase shape
+
+### Notes
+
+- **Closes the user-facing scope of #20**. Three slices shipped:
+  - Foundation: dep helpers + scaffold field (1.5.26)
+  - `/aida plugin deps`: declared deps + status (1.5.27)
+  - `/aida plugin agents`: cross-plugin agent registry (this PR)
+  The remaining piece — automatic install-time resolution
+  (`/aida plugin install <name>`) — needs marketplace coordination
+  and stays out of scope here
+- Distinct command surface from `/aida agent list` (agent-manager
+  CRUD on a single agent definition). `/aida plugin agents` is
+  the cross-plugin roster view
+
+---
+
 ## [1.5.27] - 2026-05-23
 
 ### Added

--- a/skills/aida/SKILL.md
+++ b/skills/aida/SKILL.md
@@ -171,7 +171,7 @@ For `plugin` commands (including `plugin scaffold`):
 - **Invoke the `plugin-manager` skill** to handle these operations
 - Pass the full command arguments to the skill
 - The skill handles create, validate, version, list, scaffold, update,
-  and deps operations
+  deps, and agents operations
 - Scaffold creates a NEW plugin project (not an extension inside an existing
   project)
 - Update scans an existing plugin and patches it to current standards
@@ -198,6 +198,8 @@ For `plugin` commands (including `plugin scaffold`):
 /aida plugin update "/path/to/plugin"   → plugin-manager skill
 /aida plugin deps                        → plugin-manager skill (cwd)
 /aida plugin deps "/path/to/plugin"     → plugin-manager skill
+/aida plugin agents                      → plugin-manager skill (cwd)
+/aida plugin agents "/path/to/project"  → plugin-manager skill
 ```
 
 ### Hook Management Commands

--- a/skills/plugin-manager/SKILL.md
+++ b/skills/plugin-manager/SKILL.md
@@ -50,6 +50,7 @@ This skill activates when:
 | `scaffold` | Scaffolding | Scaffold a full new plugin project         |
 | `update`   | Migration   | Scan and patch plugin to current standards |
 | `deps`     | Inspection  | Report a plugin's declared deps + status   |
+| `agents`   | Inspection  | Cross-plugin agent roster + collisions     |
 
 ## Path Resolution
 

--- a/skills/plugin-manager/scripts/manage.py
+++ b/skills/plugin-manager/scripts/manage.py
@@ -40,6 +40,7 @@ from typing import Any
 import _paths  # noqa: F401
 
 from shared.utils import safe_json_load  # noqa: E402
+from operations import agents as agents_op  # noqa: E402
 from operations import deps  # noqa: E402
 from operations import extensions  # noqa: E402
 from operations import scaffold  # noqa: E402
@@ -90,6 +91,18 @@ def is_deps_operation(context: dict[str, Any]) -> bool:
     return context.get("operation") == "deps"
 
 
+def is_agents_operation(context: dict[str, Any]) -> bool:
+    """Determine if this is an agents-registry operation (#20).
+
+    Args:
+        context: Operation context
+
+    Returns:
+        True if the operation is `agents`
+    """
+    return context.get("operation") == "agents"
+
+
 def get_questions(
     context: dict[str, Any],
 ) -> dict[str, Any]:
@@ -109,6 +122,9 @@ def get_questions(
 
     if is_deps_operation(context):
         return deps.get_questions(context)
+
+    if is_agents_operation(context):
+        return agents_op.get_questions(context)
 
     # Force type to plugin for extension operations
     context["type"] = "plugin"
@@ -139,6 +155,9 @@ def execute(
 
     if is_deps_operation(context):
         return deps.execute(context, responses)
+
+    if is_agents_operation(context):
+        return agents_op.execute(context, responses)
 
     # Force type to plugin for extension operations
     context["type"] = "plugin"

--- a/skills/plugin-manager/scripts/operations/agents.py
+++ b/skills/plugin-manager/scripts/operations/agents.py
@@ -1,0 +1,299 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+"""`/aida plugin agents` — cross-plugin agent registry (#20).
+
+Non-interactive, CI-friendly. Walks installed plugins and the
+project / user agent directories, returns a unified roster, and
+flags name collisions across plugins.
+
+Distinct from ``/aida agent list`` (agent-manager) which is per-skill
+CRUD. This view crosses plugin boundaries — useful for spotting
+"two installed plugins both ship a `code-reviewer` agent" before
+those collisions cause runtime confusion.
+
+Phase 1 (`get_questions`): no questions — single-read operation.
+The inferred dict carries the roster + collision summary.
+
+Phase 2 (`execute`): same data, plus a `success` flag that goes
+False when any collision is detected so this is usable as a CI
+gate ("verify our plugin doesn't clash with the installed set").
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+_FRONTMATTER_RE = re.compile(
+    r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL
+)
+
+
+def _resolve_project_root(context: Dict[str, Any]) -> Path:
+    """Pick the project root from context, defaulting to cwd.
+
+    Used to scan `<project>/.claude/agents/`. Defaulting to cwd
+    matches the pattern in `deps.py` so the operations feel
+    consistent.
+    """
+    path_str = context.get("project_root") or str(Path.cwd())
+    return Path(path_str).resolve()
+
+
+def _parse_agent_frontmatter(
+    md_path: Path,
+) -> Optional[Dict[str, Any]]:
+    """Parse YAML frontmatter from an agent markdown file.
+
+    Returns the parsed mapping, or None if there's no frontmatter
+    or it's malformed. Defensive on purpose — a broken agent file
+    shouldn't crash the registry scan.
+    """
+    try:
+        text = md_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        return None
+
+    # Use a lightweight YAML import — keep the operation dep-free
+    # apart from PyYAML (which is already in requirements).
+    try:
+        import yaml
+    except ImportError:
+        return None
+
+    try:
+        data = yaml.safe_load(match.group(1))
+    except yaml.YAMLError:
+        return None
+
+    return data if isinstance(data, dict) else None
+
+
+def _iter_agent_files(agents_dir: Path) -> List[Path]:
+    """Return agent markdown files under ``agents_dir``.
+
+    Convention: ``agents/<name>/<name>.md``. Top-level standalone
+    ``.md`` files are also picked up so existing project /
+    user-level agent layouts work.
+    """
+    if not agents_dir.is_dir():
+        return []
+    results: List[Path] = []
+    for md in sorted(agents_dir.rglob("*.md")):
+        # Skip knowledge files / supporting docs — agents are
+        # named files whose stem matches a parent directory name,
+        # or a top-level md inside agents/.
+        if md.parent.name == "knowledge":
+            continue
+        if (
+            md.parent.parent == agents_dir
+            and md.stem != md.parent.name
+        ):
+            continue
+        results.append(md)
+    return results
+
+
+def _build_agent_entry(
+    md_path: Path,
+    *,
+    source: str,
+    source_label: str,
+) -> Optional[Dict[str, Any]]:
+    """Build a flat agent registry entry from a markdown file.
+
+    Returns None on malformed input. Pulls `name` / `description`
+    / `version` / `tags` from frontmatter; falls back to the file
+    stem for `name` if frontmatter is missing one.
+    """
+    fm = _parse_agent_frontmatter(md_path) or {}
+    name = fm.get("name") or md_path.stem
+    if not isinstance(name, str):
+        return None
+    return {
+        "name": name,
+        "description": fm.get("description", ""),
+        "version": fm.get("version", ""),
+        "tags": fm.get("tags", []) or [],
+        "source": source,
+        "source_label": source_label,
+        "path": str(md_path),
+    }
+
+
+def _discover_all_agents(
+    project_root: Path,
+) -> List[Dict[str, Any]]:
+    """Walk every agent source, returning **every** agent found.
+
+    Distinct from `utils.discover_agents` (which dedupes by name —
+    first-found wins). This variant preserves duplicates so the
+    caller can detect cross-plugin collisions.
+    """
+    agents: List[Dict[str, Any]] = []
+
+    # 1. Project agents
+    for md in _iter_agent_files(
+        project_root / ".claude" / "agents"
+    ):
+        entry = _build_agent_entry(
+            md,
+            source="project",
+            source_label=f"project: {project_root.name}",
+        )
+        if entry is not None:
+            agents.append(entry)
+
+    # 2. User agents
+    user_agents = Path.home() / ".claude" / "agents"
+    for md in _iter_agent_files(user_agents):
+        entry = _build_agent_entry(
+            md, source="user", source_label="user"
+        )
+        if entry is not None:
+            agents.append(entry)
+
+    # 3. Plugin agents (every plugin in the cache)
+    cache_root = (
+        Path.home() / ".claude" / "plugins" / "cache"
+    )
+    if cache_root.is_dir():
+        pattern = str(
+            cache_root / "*" / "*" / ".claude-plugin" / "plugin.json"
+        )
+        for manifest_path in sorted(glob.glob(pattern)):
+            manifest = Path(manifest_path)
+            if manifest.parent.is_symlink():
+                continue
+            plugin_root = manifest.parent.parent
+            try:
+                manifest_data = json.loads(
+                    manifest.read_text(encoding="utf-8")
+                )
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(manifest_data, dict):
+                continue
+            plugin_name = manifest_data.get("name", plugin_root.name)
+            for md in _iter_agent_files(plugin_root / "agents"):
+                entry = _build_agent_entry(
+                    md,
+                    source="plugin",
+                    source_label=f"plugin: {plugin_name}",
+                )
+                if entry is not None:
+                    agents.append(entry)
+
+    return agents
+
+
+def _detect_collisions(
+    agents: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Return per-name collision groups.
+
+    A collision is two+ agents with the same `name` from different
+    sources. Same-source duplicates (two project agents with the
+    same name) shouldn't really happen but get folded in too —
+    the user wants to see them either way.
+
+    Returns a sorted list of {name, count, sources} dicts.
+    """
+    by_name: Dict[str, List[Dict[str, Any]]] = {}
+    for agent in agents:
+        by_name.setdefault(agent["name"], []).append(agent)
+
+    collisions = []
+    for name in sorted(by_name):
+        entries = by_name[name]
+        if len(entries) < 2:
+            continue
+        collisions.append(
+            {
+                "name": name,
+                "count": len(entries),
+                "sources": [e["source_label"] for e in entries],
+            }
+        )
+    return collisions
+
+
+def get_questions(
+    context: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Phase 1: no questions — registry up-front in inferred."""
+    project_root = _resolve_project_root(context)
+    agents = _discover_all_agents(project_root)
+    collisions = _detect_collisions(agents)
+    return {
+        "questions": [],
+        "inferred": {
+            "project_root": str(project_root),
+            "agent_count": len(agents),
+            "collision_count": len(collisions),
+            "agents": agents,
+            "collisions": collisions,
+        },
+        "phase": "get_questions",
+    }
+
+
+def execute(
+    context: Dict[str, Any],
+    responses: Dict[str, Any] | None = None,  # noqa: ARG001
+) -> Dict[str, Any]:
+    """Phase 2: registry + pass/fail summary.
+
+    Returns ``success: False`` when at least one collision is
+    detected so this is usable as a CI gate (e.g., "verify our
+    new plugin doesn't introduce an agent-name conflict with any
+    of our other installed plugins").
+    """
+    project_root = _resolve_project_root(context)
+    agents = _discover_all_agents(project_root)
+    collisions = _detect_collisions(agents)
+    success = not collisions
+
+    by_source = {}
+    for agent in agents:
+        by_source[agent["source"]] = (
+            by_source.get(agent["source"], 0) + 1
+        )
+
+    if not agents:
+        message = "No agents discovered."
+    elif success:
+        message = (
+            f"Discovered {len(agents)} agent(s); no collisions."
+        )
+    else:
+        message = (
+            f"Discovered {len(agents)} agent(s); "
+            f"{len(collisions)} name collision(s) across sources."
+        )
+
+    return {
+        "success": success,
+        "operation": "agents",
+        "message": message,
+        "project_root": str(project_root),
+        "summary": {
+            "total": len(agents),
+            "by_source": by_source,
+            "collisions": len(collisions),
+        },
+        "agents": agents,
+        "collisions": collisions,
+    }

--- a/tests/unit/test_plugin_agents.py
+++ b/tests/unit/test_plugin_agents.py
@@ -1,0 +1,320 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for the `/aida plugin agents` operation (#20)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(_project_root / "scripts"))
+sys.path.insert(
+    0, str(_project_root / "skills" / "plugin-manager" / "scripts")
+)
+
+# Cross-skill cache hygiene
+sys.modules.pop("_paths", None)
+for _name in list(sys.modules):
+    if _name == "operations" or _name.startswith("operations."):
+        del sys.modules[_name]
+
+from operations import agents as _agents  # noqa: E402
+
+_ops_snapshot = {
+    k: v for k, v in sys.modules.items()
+    if k == "operations" or k.startswith("operations.")
+}
+
+
+def _write_agent(
+    agents_dir: Path,
+    name: str,
+    *,
+    description: str = "Test agent",
+    version: str = "0.1.0",
+    tags: list | None = None,
+) -> Path:
+    """Write a minimal agent file at agents/<name>/<name>.md."""
+    agent_dir = agents_dir / name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    fm_lines = [
+        "---",
+        f"name: {name}",
+        f"description: {description}",
+        f"version: {version}",
+    ]
+    if tags is not None:
+        fm_lines.append("tags:")
+        for tag in tags:
+            fm_lines.append(f"  - {tag}")
+    fm_lines.append("---")
+    fm_lines.append("")
+    fm_lines.append(f"# {name}")
+    md = agent_dir / f"{name}.md"
+    md.write_text("\n".join(fm_lines) + "\n", encoding="utf-8")
+    return md
+
+
+def _write_plugin_with_agent(
+    cache_root: Path,
+    plugin_name: str,
+    agent_name: str,
+    *,
+    plugin_version: str = "0.1.0",
+) -> Path:
+    """Create a fake installed plugin with one agent."""
+    plugin_root = cache_root / "org" / plugin_name
+    cfg_dir = plugin_root / ".claude-plugin"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "plugin.json").write_text(
+        json.dumps(
+            {"name": plugin_name, "version": plugin_version}
+        ),
+        encoding="utf-8",
+    )
+    _write_agent(plugin_root / "agents", agent_name)
+    return plugin_root
+
+
+class TestDiscoverAllAgents(unittest.TestCase):
+    """_discover_all_agents walks project + user + plugin sources."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.project = Path(self.tmp) / "proj"
+        self.project.mkdir()
+        self.fake_home = Path(self.tmp) / "home"
+        self.fake_home.mkdir()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _discover(self):
+        with patch.object(Path, "home", return_value=self.fake_home):
+            return _agents._discover_all_agents(self.project)
+
+    def test_empty_returns_empty_list(self):
+        self.assertEqual(self._discover(), [])
+
+    def test_project_agents_discovered(self):
+        _write_agent(self.project / ".claude" / "agents", "scribe")
+        result = self._discover()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "scribe")
+        self.assertEqual(result[0]["source"], "project")
+
+    def test_user_agents_discovered(self):
+        _write_agent(
+            self.fake_home / ".claude" / "agents", "personal-ed"
+        )
+        result = self._discover()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "personal-ed")
+        self.assertEqual(result[0]["source"], "user")
+
+    def test_plugin_agents_discovered_with_plugin_name(self):
+        cache = self.fake_home / ".claude" / "plugins" / "cache"
+        _write_plugin_with_agent(
+            cache, "aida-team-essentials", "tech-lead"
+        )
+        result = self._discover()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "tech-lead")
+        self.assertEqual(result[0]["source"], "plugin")
+        self.assertIn(
+            "aida-team-essentials", result[0]["source_label"]
+        )
+
+    def test_all_sources_collected_no_dedup(self):
+        """Distinct from utils.discover_agents (which dedupes —
+        first-found wins). This view preserves duplicates so the
+        caller can flag collisions.
+        """
+        _write_agent(
+            self.project / ".claude" / "agents", "scribe"
+        )
+        _write_agent(
+            self.fake_home / ".claude" / "agents", "scribe"
+        )
+        cache = self.fake_home / ".claude" / "plugins" / "cache"
+        _write_plugin_with_agent(cache, "plug-a", "scribe")
+        _write_plugin_with_agent(cache, "plug-b", "scribe")
+
+        result = self._discover()
+        names = [a["name"] for a in result]
+        self.assertEqual(names.count("scribe"), 4)
+
+    def test_malformed_frontmatter_falls_back_to_filename(self):
+        agent_dir = (
+            self.project / ".claude" / "agents" / "broken"
+        )
+        agent_dir.mkdir(parents=True)
+        # Frontmatter delimiters but invalid YAML inside
+        (agent_dir / "broken.md").write_text(
+            "---\n[not valid yaml:\n---\n# body\n",
+            encoding="utf-8",
+        )
+        result = self._discover()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "broken")
+
+    def test_knowledge_dir_files_skipped(self):
+        """`agents/<name>/knowledge/*.md` files aren't agents."""
+        agents_dir = self.project / ".claude" / "agents"
+        _write_agent(agents_dir, "expert")
+        knowledge = agents_dir / "expert" / "knowledge"
+        knowledge.mkdir()
+        (knowledge / "intro.md").write_text(
+            "# knowledge intro\n", encoding="utf-8"
+        )
+        result = self._discover()
+        names = [a["name"] for a in result]
+        self.assertEqual(names, ["expert"])
+
+
+class TestDetectCollisions(unittest.TestCase):
+    """_detect_collisions groups duplicates by name."""
+
+    def test_no_duplicates(self):
+        agents = [
+            {"name": "a", "source": "project", "source_label": "x"},
+            {"name": "b", "source": "user", "source_label": "y"},
+        ]
+        self.assertEqual(_agents._detect_collisions(agents), [])
+
+    def test_cross_source_collision_flagged(self):
+        agents = [
+            {
+                "name": "code-reviewer",
+                "source": "plugin",
+                "source_label": "plugin: pkg-a",
+            },
+            {
+                "name": "code-reviewer",
+                "source": "plugin",
+                "source_label": "plugin: pkg-b",
+            },
+        ]
+        result = _agents._detect_collisions(agents)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "code-reviewer")
+        self.assertEqual(result[0]["count"], 2)
+        self.assertEqual(
+            sorted(result[0]["sources"]),
+            ["plugin: pkg-a", "plugin: pkg-b"],
+        )
+
+    def test_result_sorted_by_name(self):
+        agents = [
+            {"name": "z", "source_label": "a"},
+            {"name": "z", "source_label": "b"},
+            {"name": "a", "source_label": "c"},
+            {"name": "a", "source_label": "d"},
+        ]
+        result = _agents._detect_collisions(agents)
+        self.assertEqual([r["name"] for r in result], ["a", "z"])
+
+
+class TestExecuteAgentsOperation(unittest.TestCase):
+    """`agents.execute` returns a structured report + success flag."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.project = Path(self.tmp) / "proj"
+        self.project.mkdir()
+        self.fake_home = Path(self.tmp) / "home"
+        self.fake_home.mkdir()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _execute(self, **ctx_overrides):
+        ctx = {"project_root": str(self.project)}
+        ctx.update(ctx_overrides)
+        with patch.object(Path, "home", return_value=self.fake_home):
+            return _agents.execute(ctx)
+
+    def test_empty_succeeds(self):
+        result = self._execute()
+        self.assertTrue(result["success"])
+        self.assertEqual(result["summary"]["total"], 0)
+        self.assertIn("No agents discovered", result["message"])
+
+    def test_no_collisions_succeeds(self):
+        _write_agent(
+            self.project / ".claude" / "agents", "scribe"
+        )
+        cache = self.fake_home / ".claude" / "plugins" / "cache"
+        _write_plugin_with_agent(cache, "pkg-a", "tech-lead")
+        result = self._execute()
+        self.assertTrue(result["success"])
+        self.assertEqual(result["summary"]["total"], 2)
+        self.assertEqual(result["summary"]["collisions"], 0)
+        self.assertIn("no collisions", result["message"])
+
+    def test_collision_fails(self):
+        cache = self.fake_home / ".claude" / "plugins" / "cache"
+        _write_plugin_with_agent(cache, "pkg-a", "code-reviewer")
+        _write_plugin_with_agent(cache, "pkg-b", "code-reviewer")
+        result = self._execute()
+        self.assertFalse(result["success"])
+        self.assertEqual(result["summary"]["collisions"], 1)
+        self.assertEqual(len(result["collisions"]), 1)
+        self.assertEqual(
+            result["collisions"][0]["name"], "code-reviewer"
+        )
+        self.assertIn("name collision", result["message"])
+
+    def test_summary_breaks_down_by_source(self):
+        _write_agent(
+            self.project / ".claude" / "agents", "proj-a"
+        )
+        _write_agent(
+            self.fake_home / ".claude" / "agents", "user-a"
+        )
+        cache = self.fake_home / ".claude" / "plugins" / "cache"
+        _write_plugin_with_agent(cache, "pkg-a", "plug-a")
+        result = self._execute()
+        self.assertEqual(
+            result["summary"]["by_source"],
+            {"project": 1, "user": 1, "plugin": 1},
+        )
+
+
+class TestGetQuestions(unittest.TestCase):
+    """`agents.get_questions` returns the registry up-front."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.project = Path(self.tmp) / "proj"
+        self.project.mkdir()
+        self.fake_home = Path(self.tmp) / "home"
+        self.fake_home.mkdir()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_phase_marker_and_no_questions(self):
+        with patch.object(Path, "home", return_value=self.fake_home):
+            result = _agents.get_questions(
+                {"project_root": str(self.project)}
+            )
+        self.assertEqual(result["questions"], [])
+        self.assertEqual(result["phase"], "get_questions")
+        self.assertEqual(
+            result["inferred"]["agent_count"], 0
+        )
+        self.assertEqual(
+            result["inferred"]["collision_count"], 0
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Cross-plugin agent registry with collision detection — the **third and final user-facing slice of #20**. Walks every agent source (project / user / installed plugins), returns a unified roster, and flags name collisions across sources.

\`\`\`bash
\$ /aida plugin agents
\`\`\`

\`\`\`json
{
  \"success\": true,
  \"operation\": \"agents\",
  \"message\": \"Discovered 12 agent(s); no collisions.\",
  \"summary\": {
    \"total\": 12,
    \"by_source\": {\"project\": 2, \"user\": 1, \"plugin\": 9},
    \"collisions\": 0
  },
  \"agents\": [...],
  \"collisions\": []
}
\`\`\`

\`success: False\` on any collision so the command is usable as a CI gate (\"verify our plugin doesn't introduce an agent-name conflict with anything we have installed\").

## Why a new operation instead of extending utils.discover_agents

\`utils.discover_agents\` dedupes by name — first-found wins. That's the right behavior for runtime agent loading (the project agent shadows the user one shadows the plugin one). But it **hides collisions**, which is exactly what we want to surface here.

\`operations/agents.py\` preserves duplicates so the collision detector has full input. The two coexist.

## What's new

- **\`operations/agents.py\`** in plugin-manager:
  - Walks project agents → user agents → every installed plugin's \`agents/\` dir
  - Handles malformed frontmatter gracefully (falls back to filename)
  - Skips \`agents/<name>/knowledge/\` files (those are knowledge, not agents)
  - Skips symlinked plugin dirs (defense-in-depth)
- **\`manage.py\` dispatch** — \`is_agents_operation\` + routing alongside scaffold / update / deps
- **aida dispatcher SKILL.md** — \`/aida plugin agents\` routing with example invocations
- **plugin-manager SKILL.md** — \`agents\` row added to the Operations table

## Distinct from /aida agent list

\`/aida agent list\` (agent-manager) is CRUD on a single agent definition — per-scope, dedupes. \`/aida plugin agents\` is the **cross-plugin roster view** — preserves duplicates so collisions surface. Different question, different command.

## Test plan

- [x] \`pytest tests/unit/test_plugin_agents.py\` — 15 pass (new)
- [x] \`pytest\` full suite — 1046 pass (was 1031, +15)
- [x] \`ruff check\` clean
- [x] \`reuse lint\` — 344/344 files clean
- [x] Version bump 1.5.27 → 1.5.28 + CHANGELOG entry

## What's still deferred from #20

- Automatic install-time resolution (\`/aida plugin install <name>\`) — needs marketplace coordination
- Automatic dependency-install prompt during install — same

These two need cross-repo cooperation with marketplace tooling, not just code in this repo. Tracking separately if/when that work picks up. The data model + commands needed to support those future flows are now in place.

Closes #20 (user-facing scope complete).