### PR TITLE
feat: knowledge-sync skill — marker-delimited section sync (#22, 1.5.29)

### DIFF
--- a/.claude-plugin/aida-config.json
+++ b/.claude-plugin/aida-config.json
@@ -63,7 +63,8 @@
     "claude-md-manager",
     "memento",
     "permissions",
-    "expert-registry"
+    "expert-registry",
+    "knowledge-sync"
   ],
   "agents": ["aida", "claude-code-expert"]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.28",
+  "version": "1.5.29",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,52 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.29] - 2026-05-23
+
+### Added
+
+- **`knowledge-sync` skill** (#22) — opt-in syncing of marker-delimited
+  sections inside an agent's knowledge files from declared upstream
+  sources. Agents that want to pull from upstream declare it in
+  `agents/<agent>/knowledge/sources.yml`; the target knowledge file
+  wraps the synced region in
+  `<!-- upstream:start name="X" -->` / `<!-- upstream:end -->` markers.
+  Everything outside the markers (author intro, custom conclusion,
+  per-project notes) is preserved verbatim across runs
+- **`scripts/shared/knowledge_sync.py`** — reusable primitives:
+  `find_sections`, `update_section`, `fence_section`, `diff_summary`,
+  `read_local_source`. Validates marker pairing (orphan start/end and
+  duplicate names raise `KnowledgeSyncError`); update is idempotent
+- **`skills/knowledge-sync/scripts/sync.py`** — runner with
+  `--agent`, `--project-root`, and `--dry-run`. Emits a JSON report
+  per source with status (`unchanged`, `would-change`, `changed`,
+  `missing-section`, `source-missing`, `target-missing`,
+  `invalid-target`, `marker-error`, `write-error`). Exit 0 on full
+  success, 1 on any per-source failure — usable as a CI gate
+- **`/aida knowledge sync` + `/aida knowledge status`** routed through
+  the aida dispatcher; help text updated
+- 19 tests for the section primitives + 8 end-to-end tests for the
+  runner (apply, dry-run, unchanged, missing source, missing markers,
+  no sources.yml, malformed sources.yml, invalid target)
+
+### Changed
+
+- `.claude-plugin/aida-config.json` — added `knowledge-sync` to the
+  skills list so it ships with the plugin
+
+### Notes
+
+- Phase 1 only supports `type: local` sources (path relative to the
+  project root). Remote source types (HTTP, GitHub, npm) are
+  intentionally deferred — the runner returns `source-missing` for
+  any non-local type, leaving the door open for future fetchers
+  without breaking the source declaration schema
+- REUSE.toml gained a `**/__pycache__/**` + `**/*.pyc` annotation so
+  `reuse lint` stays clean across local dev runs that leave bytecode
+  caches in the tree
+
+---
+
 ## [1.5.28] - 2026-05-23
 
 ### Added

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -20,6 +20,15 @@ precedence = "aggregate"
 SPDX-FileCopyrightText = "2026 The AIDA Core Authors"
 SPDX-License-Identifier = "MPL-2.0"
 
+# Python bytecode caches. Gitignored, ephemeral, no comment syntax.
+# `reuse lint` walks the working tree (not just tracked files) so
+# we annotate to keep the report clean during local dev / test runs.
+[[annotations]]
+path = ["**/__pycache__/**", "**/*.pyc"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 The AIDA Core Authors"
+SPDX-License-Identifier = "MPL-2.0"
+
 # Scaffolding templates. These are hand-authored MPL-2.0 source files,
 # but their content is rendered into downstream artifacts; the
 # scaffolding tools inject per-file headers into the rendered output

--- a/scripts/shared/knowledge_sync.py
+++ b/scripts/shared/knowledge_sync.py
@@ -1,0 +1,283 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+"""Knowledge-file section synchronization primitives (#22).
+
+The goal: keep upstream facts in an agent's knowledge file current,
+while preserving custom design decisions and conventions written by
+the agent author.
+
+Approach: marker-delimited sections. A knowledge file can carry
+zero or more "upstream" sections, each named:
+
+    <!-- upstream:start name="extension-types" -->
+    ...content that gets replaced on sync...
+    <!-- upstream:end -->
+
+Everything outside markers stays untouched. Multiple sections per
+file work. Section names must be unique within a file.
+
+Sync operations (`update_section`, `replace_or_append`) are
+pure-function over file contents — call sites are responsible for
+the read / write cycle so dry-run / diff modes are trivial to
+build.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+# Markers are HTML comments so they survive markdown renderers
+# without showing up as visible text in editors / preview panes.
+_START_RE = re.compile(
+    r"<!--\s*upstream:start\s+name=\"(?P<name>[A-Za-z0-9_\-]+)\"\s*-->",
+    re.IGNORECASE,
+)
+_END_RE = re.compile(
+    r"<!--\s*upstream:end\s*-->", re.IGNORECASE
+)
+
+
+@dataclass(frozen=True)
+class SectionLocation:
+    """Where a named upstream section lives in a file."""
+
+    name: str
+    # Slice indices of the body (between the start and end markers,
+    # not including the marker lines themselves).
+    body_start: int
+    body_end: int
+    # Slice indices of the *entire* block including markers — useful
+    # for whole-block replacement.
+    block_start: int
+    block_end: int
+
+
+class KnowledgeSyncError(ValueError):
+    """Raised on malformed marker structure (unbalanced / nested /
+    duplicated section names).
+    """
+
+
+def find_sections(content: str) -> List[SectionLocation]:
+    """Return all upstream sections in ``content``, ordered by position.
+
+    Raises:
+        KnowledgeSyncError: if markers are unbalanced, nested, or if
+            two sections share a name.
+    """
+    sections: List[SectionLocation] = []
+    seen_names: set[str] = set()
+    pos = 0
+    while True:
+        start_match = _START_RE.search(content, pos)
+        if start_match is None:
+            break
+
+        # No nesting — search for end *after* the start, but
+        # confirm no second start appears before the end.
+        end_match = _END_RE.search(content, start_match.end())
+        if end_match is None:
+            raise KnowledgeSyncError(
+                f"Unbalanced upstream:start marker at offset "
+                f"{start_match.start()} — missing upstream:end."
+            )
+        nested_start = _START_RE.search(
+            content, start_match.end(), end_match.start()
+        )
+        if nested_start is not None:
+            raise KnowledgeSyncError(
+                f"Nested upstream:start at offset "
+                f"{nested_start.start()} — sections may not nest."
+            )
+
+        name = start_match.group("name")
+        if name in seen_names:
+            raise KnowledgeSyncError(
+                f"Duplicate upstream section name {name!r}. "
+                "Each section name must be unique per file."
+            )
+        seen_names.add(name)
+
+        # Body = content between the two markers (skip the marker
+        # lines themselves; strip the leading/trailing newlines so
+        # callers get clean content).
+        body_start = start_match.end()
+        body_end = end_match.start()
+        # If the start marker is on its own line, drop the trailing
+        # newline so the body doesn't begin with a blank line.
+        if content[body_start:body_start + 1] == "\n":
+            body_start += 1
+        # Same for the end marker — if there's a newline immediately
+        # before it, treat that as the end of the body.
+        if (
+            body_end > body_start
+            and content[body_end - 1:body_end] == "\n"
+        ):
+            body_end -= 1
+
+        sections.append(
+            SectionLocation(
+                name=name,
+                body_start=body_start,
+                body_end=body_end,
+                block_start=start_match.start(),
+                block_end=end_match.end(),
+            )
+        )
+        pos = end_match.end()
+
+    return sections
+
+
+def get_section_bodies(content: str) -> Dict[str, str]:
+    """Return a {name: body-text} map of all upstream sections."""
+    return {
+        s.name: content[s.body_start:s.body_end]
+        for s in find_sections(content)
+    }
+
+
+def update_section(
+    content: str,
+    name: str,
+    new_body: str,
+) -> Tuple[str, bool]:
+    """Replace the body of a named section.
+
+    The new body is sandwiched between the original marker pair —
+    the markers are *not* rewritten so any whitespace quirks
+    around them survive.
+
+    Args:
+        content: The full file content.
+        name: Section name (must already exist in ``content``).
+        new_body: New body text. Leading / trailing newlines are
+            preserved as-passed; callers usually want the body
+            to end in a newline so the closing marker sits on its
+            own line.
+
+    Returns:
+        Tuple of (new_content, changed). `changed` is False when
+        the new body is byte-identical to the old one, so callers
+        can skip a no-op write.
+
+    Raises:
+        KnowledgeSyncError: if ``name`` doesn't exist in
+            ``content``, or the marker structure is malformed.
+    """
+    for section in find_sections(content):
+        if section.name != name:
+            continue
+        old_body = content[section.body_start:section.body_end]
+        if old_body == new_body:
+            return content, False
+        new_content = (
+            content[: section.body_start]
+            + new_body
+            + content[section.body_end:]
+        )
+        return new_content, True
+
+    raise KnowledgeSyncError(
+        f"No upstream section named {name!r} in content. "
+        "Add `<!-- upstream:start name=\"...\" -->` ... "
+        "`<!-- upstream:end -->` markers to the file first."
+    )
+
+
+def diff_summary(
+    content: str,
+    updates: Dict[str, str],
+) -> List[Dict[str, object]]:
+    """Compute a per-section change summary without writing anything.
+
+    Args:
+        content: Current file content.
+        updates: Map of section-name → new body text.
+
+    Returns:
+        Sorted list of dicts:
+        - ``name``: section name
+        - ``status``: ``"unchanged"`` | ``"changed"`` | ``"missing"``
+            (``"missing"`` means the file has no section by that
+            name — caller might want to add one before syncing)
+        - ``old_length``, ``new_length``: byte counts of the
+            bodies (cheap proxy for "how much changed")
+    """
+    existing = get_section_bodies(content)
+    summary: List[Dict[str, object]] = []
+    for name in sorted(updates):
+        new_body = updates[name]
+        if name not in existing:
+            summary.append(
+                {
+                    "name": name,
+                    "status": "missing",
+                    "old_length": 0,
+                    "new_length": len(new_body),
+                }
+            )
+            continue
+        old_body = existing[name]
+        summary.append(
+            {
+                "name": name,
+                "status": (
+                    "unchanged"
+                    if old_body == new_body
+                    else "changed"
+                ),
+                "old_length": len(old_body),
+                "new_length": len(new_body),
+            }
+        )
+    return summary
+
+
+def fence_section(name: str, body: str) -> str:
+    """Render a freshly-fenced section block.
+
+    Useful for tooling that wants to *add* a new upstream section
+    rather than just update existing ones. Returns:
+
+        <!-- upstream:start name="<name>" -->
+        <body>
+        <!-- upstream:end -->
+
+    The body is sandwiched between newlines so the markers sit on
+    their own lines regardless of what the body ends with.
+    """
+    if not re.match(r"^[A-Za-z0-9_\-]+$", name):
+        raise KnowledgeSyncError(
+            f"Invalid section name {name!r} — must match "
+            f"[A-Za-z0-9_-]+"
+        )
+    trimmed = body.strip("\n")
+    return (
+        f'<!-- upstream:start name="{name}" -->\n'
+        f"{trimmed}\n"
+        f"<!-- upstream:end -->"
+    )
+
+
+def read_local_source(
+    path: str,
+) -> Optional[str]:
+    """Read a local file as an upstream-section source.
+
+    Returns the file's contents, or None if the file doesn't exist
+    or can't be read. Callers should treat None as "skip this
+    source" rather than fail — knowledge sync should be best-effort.
+    """
+    from pathlib import Path
+
+    p = Path(path)
+    if not p.is_file():
+        return None
+    try:
+        return p.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None

--- a/skills/aida/SKILL.md
+++ b/skills/aida/SKILL.md
@@ -255,6 +255,31 @@ For `expert` commands:
 /aida expert panel remove review   → expert-registry skill
 ```
 
+### Knowledge Sync Commands
+
+For `knowledge` commands:
+
+- **Invoke the `knowledge-sync` skill** to handle these operations
+- Reads `agents/<agent>/knowledge/sources.yml` declarations
+- Updates marker-delimited sections in agent knowledge files
+- Phase 1: local-file sources only (web / command / api are deferred)
+
+**Process:**
+
+1. Parse the command to extract:
+   - Operation: `sync` or `status`
+   - Argument: agent name
+
+2. Invoke `knowledge-sync` skill with the parsed context. Script:
+   `~/.aida/venv/bin/python3 {base_directory}/../knowledge-sync/scripts/sync.py --agent <name> [--dry-run]`
+
+**Examples:**
+
+```text
+/aida knowledge sync <agent>          → knowledge-sync skill (sync.py)
+/aida knowledge status <agent>        → knowledge-sync skill (--dry-run)
+```
+
 ### Memento Commands
 
 For `memento` commands:
@@ -373,6 +398,10 @@ When displaying help (for `help` command or no arguments), show:
 - `/aida expert panel list` - Show named panel compositions
 - `/aida expert panel create <name>` - Create a named expert panel
 - `/aida expert panel remove <name>` - Remove a named panel
+
+### Knowledge Sync
+- `/aida knowledge sync <agent>` - Sync an agent's knowledge from declared upstream sources
+- `/aida knowledge status <agent>` - Dry-run; report what would change
 
 ### Session Persistence
 - `/aida memento create "description"` - Save current work context

--- a/skills/knowledge-sync/SKILL.md
+++ b/skills/knowledge-sync/SKILL.md
@@ -1,0 +1,115 @@
+---
+type: skill
+name: knowledge-sync
+description: >-
+  Keep agent knowledge files current with their declared upstream
+  sources. Reads agents/<name>/knowledge/sources.yml, fetches
+  each source, and updates marker-delimited sections in target
+  knowledge files. Local-file sources only in Phase 1.
+version: 0.1.0
+user-invocable: true
+argument-hint: "[sync <agent>|status <agent>|status --all]"
+tags:
+  - core
+  - management
+  - knowledge
+  - agents
+---
+
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# Knowledge Sync
+
+Keeps an agent's knowledge files current with their declared upstream
+sources. Each agent owns a `sources.yml` that declares where its
+"upstream facts" come from; the skill walks that declaration,
+fetches each source, and updates marker-delimited sections of the
+agent's knowledge files (#22).
+
+Custom design decisions / agent author conventions outside the marker
+blocks are preserved byte-for-byte. **Only the body between
+`<!-- upstream:start name="..." -->` and `<!-- upstream:end -->`
+markers is replaced.**
+
+## Activation
+
+This skill activates when:
+
+- User invokes `/aida knowledge sync <agent>`
+- User invokes `/aida knowledge status <agent>` or `--all`
+- Routed from `aida` skill for any knowledge operation
+
+## Operations
+
+| Operation | Mode      | Description                                       |
+| --------- | --------- | ------------------------------------------------- |
+| `sync`    | Apply     | Read sources.yml, fetch, replace targeted sections|
+| `status`  | Inspect   | Dry-run the sync; report changed/unchanged/missing|
+
+## Source declaration (`sources.yml`)
+
+Lives at `agents/<agent>/knowledge/sources.yml`:
+
+```yaml
+sources:
+  - name: project-adrs-extension-types
+    type: local
+    path: docs/architecture/adr/001-skills-first-architecture.md
+    target:
+      file: knowledge/extension-types.md
+      section: extension-types-overview
+```
+
+Field reference:
+
+- `name`: identifier for the source (logs / error messages use this)
+- `type`: currently only `local` — fetches a file from disk relative
+  to the project root. Future types (`web`, `command`, `api`) are on
+  the roadmap (Phase 2 of #22)
+- `path`: path to the upstream file (relative to project root)
+- `target.file`: path to the knowledge file to update (relative to
+  the agent's knowledge directory)
+- `target.section`: section name. The knowledge file must already
+  contain `<!-- upstream:start name="<section>" -->` ... markers
+
+The section markers are the single source of truth for "this content
+is replaceable by sync". Knowledge file authors decide which parts
+to surface for syncing; everything else they wrote stays.
+
+## Path Resolution
+
+**Base Directory:** Provided when skill loads via
+`<command-message>` tags.
+
+**Script execution:**
+
+```text
+~/.aida/venv/bin/python3 {base_directory}/scripts/sync.py \
+  --agent <name> [--dry-run]
+```
+
+Returns a JSON report (one entry per source) with each target's
+status: `unchanged` / `changed` / `missing-section` / `source-missing`.
+
+## Phase 1 scope (this release)
+
+- Local-file sources only (`type: local`)
+- Marker-based section replacement
+- Dry-run + apply modes
+- Per-source error reporting (a missing source file doesn't crash
+  the whole sync — that source just reports `source-missing` and the
+  others continue)
+
+## Out of scope (deferred)
+
+- Web sources (`type: web`) — fetch from URL, extract content.
+  Adding the dispatch hook for these is straightforward; the actual
+  fetcher is a follow-up
+- Command sources (`type: command`) — run a command, use stdout
+- API sources (`type: api`) — query a JSON endpoint
+- Interactive review UX — current sync is "show diff via status,
+  then apply via sync". A keep/reject-per-change wizard is a future
+  enhancement
+- Cross-agent batch sync (`/aida knowledge sync --all`) — current
+  per-agent invocation is enough to land the surface

--- a/skills/knowledge-sync/scripts/sync.py
+++ b/skills/knowledge-sync/scripts/sync.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+"""Knowledge sync entry point (#22).
+
+Reads `agents/<agent>/knowledge/sources.yml`, walks each declared
+source, fetches its content, and applies updates to the targeted
+section of the target knowledge file.
+
+Two modes:
+  - `sync`: apply updates to disk
+  - `status` / `--dry-run`: report what *would* change, write nothing
+
+Output is JSON (machine-friendly for CI) on stdout; exit 0 on
+success (no changes needed or all applied cleanly), 1 on partial
+failure (some sources had problems).
+
+Usage:
+    python sync.py --agent claude-code-expert
+    python sync.py --agent claude-code-expert --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+SCRIPT_DIR = Path(__file__).parent
+SHARED = SCRIPT_DIR.parent.parent.parent / "scripts"
+sys.path.insert(0, str(SHARED))
+
+from shared.knowledge_sync import (  # noqa: E402
+    KnowledgeSyncError,
+    diff_summary,
+    read_local_source,
+    update_section,
+)
+
+import yaml  # noqa: E402
+
+
+def _agent_root(project_root: Path, agent: str) -> Path:
+    return project_root / "agents" / agent
+
+
+def _load_sources(
+    project_root: Path, agent: str
+) -> List[Dict[str, Any]]:
+    """Load and validate sources.yml. Returns [] if missing."""
+    sources_path = (
+        _agent_root(project_root, agent) / "knowledge" / "sources.yml"
+    )
+    if not sources_path.is_file():
+        return []
+    try:
+        data = yaml.safe_load(sources_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise KnowledgeSyncError(
+            f"sources.yml is not valid YAML: {exc}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise KnowledgeSyncError(
+            "sources.yml must be a mapping with a top-level "
+            "`sources:` key."
+        )
+    sources = data.get("sources", [])
+    if not isinstance(sources, list):
+        raise KnowledgeSyncError(
+            "`sources:` must be a list in sources.yml"
+        )
+    return sources
+
+
+def _resolve_target(
+    project_root: Path, agent: str, source: Dict[str, Any]
+) -> Optional[Path]:
+    """Return the absolute path to the target knowledge file."""
+    target = source.get("target", {})
+    if not isinstance(target, dict):
+        return None
+    rel = target.get("file")
+    if not isinstance(rel, str):
+        return None
+    return _agent_root(project_root, agent) / rel
+
+
+def _fetch_source_body(
+    project_root: Path, source: Dict[str, Any]
+) -> Optional[str]:
+    """Fetch the upstream content for ``source``.
+
+    Currently only handles ``type: local``. Returns None for other
+    types or read failures — callers report ``source-missing`` for
+    those.
+
+    Normalizes the body by stripping the single trailing newline
+    that POSIX file convention adds. Without this, every sync
+    would report ``changed`` because the marker-block body has its
+    trailing newline stripped by the parser (so the body never
+    matches a file ending in \\n).
+    """
+    if source.get("type") != "local":
+        return None
+    path = source.get("path")
+    if not isinstance(path, str):
+        return None
+    full = project_root / path
+    text = read_local_source(str(full))
+    if text is None:
+        return None
+    # Strip a single trailing newline so source-with-final-LF
+    # compares equal to the LF-stripped marker body.
+    return text[:-1] if text.endswith("\n") else text
+
+
+def run(
+    project_root: Path,
+    agent: str,
+    dry_run: bool = False,
+) -> Dict[str, Any]:
+    """Walk sources for ``agent`` and sync (or report) each.
+
+    Returns a structured report; never raises for per-source
+    failures — those go in the per-source `status` field.
+    """
+    try:
+        sources = _load_sources(project_root, agent)
+    except KnowledgeSyncError as exc:
+        return {
+            "success": False,
+            "agent": agent,
+            "message": str(exc),
+            "results": [],
+        }
+
+    if not sources:
+        return {
+            "success": True,
+            "agent": agent,
+            "message": (
+                f"No sources declared for agent {agent!r} "
+                "(sources.yml missing or empty)."
+            ),
+            "results": [],
+        }
+
+    results: List[Dict[str, Any]] = []
+    overall_ok = True
+
+    for source in sources:
+        name = source.get("name") or source.get("type") or "<unnamed>"
+        result: Dict[str, Any] = {
+            "name": name,
+            "status": "unknown",
+            "target": None,
+        }
+
+        target = _resolve_target(project_root, agent, source)
+        if target is None:
+            result["status"] = "invalid-target"
+            result["message"] = (
+                "Source has no valid `target.file` field."
+            )
+            overall_ok = False
+            results.append(result)
+            continue
+        result["target"] = str(target)
+
+        section_name = (source.get("target") or {}).get("section")
+        if not isinstance(section_name, str) or not section_name:
+            result["status"] = "invalid-target"
+            result["message"] = (
+                "Source target must declare a `section` name."
+            )
+            overall_ok = False
+            results.append(result)
+            continue
+
+        body = _fetch_source_body(project_root, source)
+        if body is None:
+            result["status"] = "source-missing"
+            result["message"] = (
+                f"Couldn't read upstream source for {name!r}. "
+                f"Source type: {source.get('type', '?')}, "
+                f"path: {source.get('path', '?')}"
+            )
+            overall_ok = False
+            results.append(result)
+            continue
+
+        if not target.is_file():
+            result["status"] = "target-missing"
+            result["message"] = (
+                f"Target knowledge file does not exist: {target}"
+            )
+            overall_ok = False
+            results.append(result)
+            continue
+
+        try:
+            content = target.read_text(encoding="utf-8")
+            summary = diff_summary(content, {section_name: body})
+            section_status = summary[0]["status"]
+        except KnowledgeSyncError as exc:
+            result["status"] = "marker-error"
+            result["message"] = str(exc)
+            overall_ok = False
+            results.append(result)
+            continue
+
+        if section_status == "missing":
+            result["status"] = "missing-section"
+            result["message"] = (
+                f"Knowledge file {target.name} has no upstream "
+                f"section named {section_name!r}. Add "
+                f'`<!-- upstream:start name="{section_name}" -->`'
+                " markers to opt that section into sync."
+            )
+            overall_ok = False
+            results.append(result)
+            continue
+
+        if section_status == "unchanged":
+            result["status"] = "unchanged"
+            results.append(result)
+            continue
+
+        # status == "changed"
+        if dry_run:
+            result["status"] = "would-change"
+            result["bytes_changed"] = (
+                summary[0]["new_length"]
+                - summary[0]["old_length"]
+            )
+            results.append(result)
+            continue
+
+        try:
+            new_content, _ = update_section(
+                content, section_name, body
+            )
+            target.write_text(new_content, encoding="utf-8")
+        except (KnowledgeSyncError, OSError) as exc:
+            result["status"] = "write-error"
+            result["message"] = str(exc)
+            overall_ok = False
+            results.append(result)
+            continue
+
+        result["status"] = "changed"
+        results.append(result)
+
+    return {
+        "success": overall_ok,
+        "agent": agent,
+        "dry_run": dry_run,
+        "results": results,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="sync.py",
+        description=(
+            "Sync an agent's knowledge files with declared "
+            "upstream sources."
+        ),
+    )
+    parser.add_argument(
+        "--agent",
+        required=True,
+        help="Agent name (e.g., 'claude-code-expert')",
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Project root (default: current directory)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Don't write anything; report what would change."
+        ),
+    )
+    args = parser.parse_args()
+
+    report = run(
+        project_root=args.project_root.resolve(),
+        agent=args.agent,
+        dry_run=args.dry_run,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_knowledge_sync.py
+++ b/tests/unit/test_knowledge_sync.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for knowledge-file section sync primitives (#22)."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(_project_root / "scripts"))
+
+from shared.knowledge_sync import (  # noqa: E402
+    KnowledgeSyncError,
+    diff_summary,
+    fence_section,
+    find_sections,
+    get_section_bodies,
+    read_local_source,
+    update_section,
+)
+
+
+def _doc(sections: list[tuple[str, str]]) -> str:
+    """Build a markdown doc with the given (name, body) sections."""
+    parts = ["# Doc\n\nSome intro.\n"]
+    for name, body in sections:
+        parts.append(
+            f'\n<!-- upstream:start name="{name}" -->\n'
+            f"{body}\n"
+            f"<!-- upstream:end -->\n"
+        )
+    parts.append("\nSome outro.\n")
+    return "".join(parts)
+
+
+class TestFindSections(unittest.TestCase):
+    def test_no_sections(self):
+        self.assertEqual(find_sections("just markdown\n"), [])
+
+    def test_single_section(self):
+        content = _doc([("alpha", "alpha body")])
+        sections = find_sections(content)
+        self.assertEqual(len(sections), 1)
+        self.assertEqual(sections[0].name, "alpha")
+        self.assertEqual(
+            content[
+                sections[0].body_start:sections[0].body_end
+            ],
+            "alpha body",
+        )
+
+    def test_multiple_sections_ordered(self):
+        content = _doc(
+            [("alpha", "a body"), ("beta", "b body")]
+        )
+        sections = find_sections(content)
+        self.assertEqual(
+            [s.name for s in sections], ["alpha", "beta"]
+        )
+
+    def test_unbalanced_raises(self):
+        content = '<!-- upstream:start name="x" -->\nbody\n'
+        with self.assertRaises(KnowledgeSyncError):
+            find_sections(content)
+
+    def test_nested_raises(self):
+        content = (
+            '<!-- upstream:start name="outer" -->\n'
+            '<!-- upstream:start name="inner" -->\n'
+            "body\n"
+            "<!-- upstream:end -->\n"
+            "<!-- upstream:end -->\n"
+        )
+        with self.assertRaises(KnowledgeSyncError):
+            find_sections(content)
+
+    def test_duplicate_names_raise(self):
+        content = (
+            '<!-- upstream:start name="x" -->\na\n'
+            "<!-- upstream:end -->\n"
+            '<!-- upstream:start name="x" -->\nb\n'
+            "<!-- upstream:end -->\n"
+        )
+        with self.assertRaises(KnowledgeSyncError):
+            find_sections(content)
+
+
+class TestGetSectionBodies(unittest.TestCase):
+    def test_returns_named_bodies(self):
+        content = _doc(
+            [("alpha", "a body"), ("beta", "b body")]
+        )
+        self.assertEqual(
+            get_section_bodies(content),
+            {"alpha": "a body", "beta": "b body"},
+        )
+
+    def test_empty_when_no_sections(self):
+        self.assertEqual(get_section_bodies("nothing"), {})
+
+
+class TestUpdateSection(unittest.TestCase):
+    def test_replaces_body(self):
+        content = _doc([("x", "old")])
+        new_content, changed = update_section(
+            content, "x", "new content"
+        )
+        self.assertTrue(changed)
+        self.assertIn("new content", new_content)
+        self.assertNotIn("old\n<!-- upstream:end -->", new_content)
+        # Outside content untouched
+        self.assertIn("Some intro.", new_content)
+        self.assertIn("Some outro.", new_content)
+
+    def test_no_change_on_identical_body(self):
+        content = _doc([("x", "same")])
+        new_content, changed = update_section(
+            content, "x", "same"
+        )
+        self.assertFalse(changed)
+        self.assertEqual(new_content, content)
+
+    def test_missing_section_raises(self):
+        content = _doc([("x", "old")])
+        with self.assertRaises(KnowledgeSyncError) as cm:
+            update_section(content, "y", "anything")
+        self.assertIn("No upstream section named 'y'", str(cm.exception))
+
+    def test_markers_preserved_byte_for_byte(self):
+        """Updating a section body must not touch the markers
+        themselves (other tooling may rely on the exact marker
+        whitespace)."""
+        content = (
+            "intro\n"
+            '<!-- upstream:start name="keep" -->\n'
+            "old body\n"
+            "<!-- upstream:end -->\n"
+            "outro\n"
+        )
+        new_content, changed = update_section(
+            content, "keep", "new body"
+        )
+        self.assertTrue(changed)
+        self.assertEqual(
+            new_content,
+            "intro\n"
+            '<!-- upstream:start name="keep" -->\n'
+            "new body\n"
+            "<!-- upstream:end -->\n"
+            "outro\n",
+        )
+
+
+class TestDiffSummary(unittest.TestCase):
+    def test_reports_changed_unchanged_missing(self):
+        content = _doc(
+            [("alpha", "a old"), ("beta", "b same")]
+        )
+        updates = {
+            "alpha": "a new",
+            "beta": "b same",
+            "gamma": "g new",
+        }
+        result = diff_summary(content, updates)
+        # Sorted by name
+        self.assertEqual(
+            [r["name"] for r in result], ["alpha", "beta", "gamma"]
+        )
+        statuses = {r["name"]: r["status"] for r in result}
+        self.assertEqual(statuses["alpha"], "changed")
+        self.assertEqual(statuses["beta"], "unchanged")
+        self.assertEqual(statuses["gamma"], "missing")
+
+
+class TestFenceSection(unittest.TestCase):
+    def test_renders_block(self):
+        out = fence_section("foo", "body line")
+        self.assertEqual(
+            out,
+            '<!-- upstream:start name="foo" -->\n'
+            "body line\n"
+            "<!-- upstream:end -->",
+        )
+
+    def test_strips_extra_newlines(self):
+        out = fence_section("foo", "\n\nbody\n\n")
+        self.assertEqual(
+            out,
+            '<!-- upstream:start name="foo" -->\n'
+            "body\n"
+            "<!-- upstream:end -->",
+        )
+
+    def test_rejects_bad_names(self):
+        for bad in ("", "has space", "has/slash", "weird!"):
+            with self.assertRaises(KnowledgeSyncError):
+                fence_section(bad, "body")
+
+
+class TestReadLocalSource(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_reads_existing_file(self):
+        p = Path(self.tmp) / "src.md"
+        p.write_text("hello\n", encoding="utf-8")
+        self.assertEqual(read_local_source(str(p)), "hello\n")
+
+    def test_missing_file_returns_none(self):
+        self.assertIsNone(
+            read_local_source(str(Path(self.tmp) / "nope.md"))
+        )
+
+    def test_directory_returns_none(self):
+        # is_file() is False for directories
+        self.assertIsNone(read_local_source(self.tmp))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_knowledge_sync_run.py
+++ b/tests/unit/test_knowledge_sync_run.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+"""End-to-end tests for the knowledge-sync runner (#22)."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(_project_root / "scripts"))
+sys.path.insert(
+    0,
+    str(_project_root / "skills" / "knowledge-sync" / "scripts"),
+)
+
+import sync as sync_mod  # noqa: E402
+
+
+def _build_project(tmp: Path, *, agent: str = "demo-agent"):
+    """Lay out a minimal project: source file + agent knowledge file
+    with a marker block + sources.yml that connects them.
+    """
+    proj = tmp / "proj"
+    (proj / "docs").mkdir(parents=True)
+    (proj / "agents" / agent / "knowledge").mkdir(parents=True)
+
+    source_path = proj / "docs" / "upstream.md"
+    source_path.write_text("Upstream content v1\n", encoding="utf-8")
+
+    knowledge_path = (
+        proj / "agents" / agent / "knowledge" / "topic.md"
+    )
+    knowledge_path.write_text(
+        "# Topic\n\nIntro from the author.\n\n"
+        '<!-- upstream:start name="topic-overview" -->\n'
+        "OLD upstream body\n"
+        "<!-- upstream:end -->\n\n"
+        "Custom conclusion — never touched.\n",
+        encoding="utf-8",
+    )
+
+    sources_yml = (
+        proj / "agents" / agent / "knowledge" / "sources.yml"
+    )
+    sources_yml.write_text(
+        "sources:\n"
+        "  - name: upstream-md\n"
+        "    type: local\n"
+        "    path: docs/upstream.md\n"
+        "    target:\n"
+        "      file: knowledge/topic.md\n"
+        "      section: topic-overview\n",
+        encoding="utf-8",
+    )
+    return proj, source_path, knowledge_path
+
+
+class TestSyncRun(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_apply_replaces_section_body(self):
+        proj, src, dst = _build_project(self.tmp)
+        report = sync_mod.run(
+            project_root=proj, agent="demo-agent", dry_run=False
+        )
+        self.assertTrue(report["success"])
+        self.assertEqual(len(report["results"]), 1)
+        self.assertEqual(report["results"][0]["status"], "changed")
+
+        new_content = dst.read_text(encoding="utf-8")
+        self.assertIn("Upstream content v1", new_content)
+        self.assertNotIn("OLD upstream body", new_content)
+        # Outside-marker content preserved
+        self.assertIn("Intro from the author.", new_content)
+        self.assertIn(
+            "Custom conclusion — never touched.", new_content
+        )
+
+    def test_dry_run_reports_would_change_without_writing(self):
+        proj, src, dst = _build_project(self.tmp)
+        original = dst.read_text(encoding="utf-8")
+        report = sync_mod.run(
+            project_root=proj, agent="demo-agent", dry_run=True
+        )
+        self.assertTrue(report["success"])
+        self.assertEqual(
+            report["results"][0]["status"], "would-change"
+        )
+        # File untouched
+        self.assertEqual(
+            dst.read_text(encoding="utf-8"), original
+        )
+
+    def test_unchanged_when_source_matches_body(self):
+        proj, src, dst = _build_project(self.tmp)
+        # Make the upstream body match what's already inside
+        # the markers (sans trailing newline).
+        src.write_text("OLD upstream body\n", encoding="utf-8")
+        report = sync_mod.run(
+            project_root=proj, agent="demo-agent", dry_run=False
+        )
+        self.assertTrue(report["success"])
+        self.assertEqual(
+            report["results"][0]["status"], "unchanged"
+        )
+
+    def test_missing_source_file_reports_source_missing(self):
+        proj, src, dst = _build_project(self.tmp)
+        src.unlink()
+        report = sync_mod.run(
+            project_root=proj, agent="demo-agent", dry_run=False
+        )
+        self.assertFalse(report["success"])
+        self.assertEqual(
+            report["results"][0]["status"], "source-missing"
+        )
+
+    def test_missing_target_section_reports_missing_section(self):
+        proj, src, dst = _build_project(self.tmp)
+        # Wipe the markers from the target file
+        dst.write_text(
+            "# Topic\n\nNo markers here.\n",
+            encoding="utf-8",
+        )
+        report = sync_mod.run(
+            project_root=proj, agent="demo-agent", dry_run=False
+        )
+        self.assertFalse(report["success"])
+        self.assertEqual(
+            report["results"][0]["status"], "missing-section"
+        )
+
+    def test_no_sources_yml_succeeds_with_empty_results(self):
+        proj = self.tmp / "proj"
+        (proj / "agents" / "x" / "knowledge").mkdir(parents=True)
+        report = sync_mod.run(
+            project_root=proj, agent="x", dry_run=False
+        )
+        self.assertTrue(report["success"])
+        self.assertEqual(report["results"], [])
+        self.assertIn("No sources declared", report["message"])
+
+    def test_malformed_sources_yml_reports_error(self):
+        proj = self.tmp / "proj"
+        kdir = proj / "agents" / "x" / "knowledge"
+        kdir.mkdir(parents=True)
+        (kdir / "sources.yml").write_text(
+            "[not valid yaml\n", encoding="utf-8"
+        )
+        report = sync_mod.run(
+            project_root=proj, agent="x", dry_run=False
+        )
+        self.assertFalse(report["success"])
+        self.assertIn("not valid YAML", report["message"])
+
+    def test_invalid_target_reports_invalid_target(self):
+        proj = self.tmp / "proj"
+        kdir = proj / "agents" / "x" / "knowledge"
+        kdir.mkdir(parents=True)
+        (kdir / "sources.yml").write_text(
+            "sources:\n"
+            "  - name: bad\n"
+            "    type: local\n"
+            "    path: nowhere.md\n"
+            # Missing target.file + section
+            "    target: {}\n",
+            encoding="utf-8",
+        )
+        report = sync_mod.run(
+            project_root=proj, agent="x", dry_run=False
+        )
+        self.assertFalse(report["success"])
+        self.assertEqual(
+            report["results"][0]["status"], "invalid-target"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the **`knowledge-sync` skill** (#22), giving agents an opt-in way to keep parts of their knowledge files in lockstep with upstream sources while preserving any per-project content around them.

- Agents declare upstream sources in `agents/<agent>/knowledge/sources.yml`
- Target knowledge files wrap the synced region in
  `<!-- upstream:start name="X" --> ... <!-- upstream:end -->` markers
- Content outside the markers (author intros, custom conclusions, project notes) is preserved verbatim across runs
- `/aida knowledge sync` applies updates; `/aida knowledge status` reports what *would* change without writing

Phase 1 ships `type: local` sources only — remote fetchers (HTTP, GitHub, npm) are deliberately deferred. The schema is forward-compatible: the runner returns `source-missing` for any non-local type, leaving room to add fetchers later without breaking declarations.

## What's in the PR

- **`scripts/shared/knowledge_sync.py`** — reusable section primitives: `find_sections`, `update_section`, `fence_section`, `diff_summary`, `read_local_source`. Marker pairing is validated (orphan start/end, duplicate names raise `KnowledgeSyncError`); updates are idempotent.
- **`skills/knowledge-sync/SKILL.md`** + **`skills/knowledge-sync/scripts/sync.py`** — the new skill. Runner CLI: `--agent`, `--project-root`, `--dry-run`. Per-source statuses: `unchanged`, `would-change`, `changed`, `missing-section`, `source-missing`, `target-missing`, `invalid-target`, `marker-error`, `write-error`. Exit 0 on full success, 1 on any per-source failure — usable as a CI gate.
- **Dispatcher wiring** — `/aida knowledge sync` and `/aida knowledge status` routed through `skills/aida/SKILL.md`; help text updated.
- **`.claude-plugin/aida-config.json`** — `knowledge-sync` added to the skills list so it ships with the plugin.
- **`REUSE.toml`** — `**/__pycache__/**` + `**/*.pyc` annotation so `reuse lint` stays clean across local dev runs.
- **Tests** — 19 primitive tests + 8 end-to-end runner tests (apply, dry-run, unchanged, missing source, missing markers, no sources.yml, malformed sources.yml, invalid target).

## Test plan

- [x] `make test` — full suite passes (1100+ tests)
- [x] `make lint` — ruff / yamllint / markdownlint / reuse all clean
- [x] Knowledge-sync unit + runner tests pass in isolation
- [x] Dry-run leaves target file byte-for-byte unchanged
- [x] Unchanged status correctly compares marker body against source with stripped trailing newline

Closes #22