### PR TITLE
feat(knowledge-sync): HTTP fetcher for remote sources (#143, 1.5.31)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.30",
+  "version": "1.5.31",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,93 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.31] - 2026-05-27
+
+### Added
+
+- **HTTP fetcher for knowledge-sync** (#143) — `sources.yml` now
+  supports `type: http` / `type: https` so an agent can keep its
+  knowledge files in sync with remote upstream docs (Anthropic support
+  articles, agentskills.io, project READMEs on the web, etc.). The
+  fetcher is the policy-free mechanic: it fetches a declared URL,
+  normalizes the body, and stores it in the marker-delimited section.
+  Spidering / LLM curation lives in #144
+- **`scripts/shared/http_source.py`** — `HttpFetcher`, `RateLimiter`,
+  `FetchOutcome`, `extract_content`. Pure module with no imports from
+  `bootstrap.py` or other shared modules; safe to import standalone
+- **`scripts/shared/paths.py`** — registered AIDA filesystem constants
+  (`AIDA_DIR`, `VENV_DIR`, `STAMP_FILE`, `CACHE_DIR`,
+  `KNOWLEDGE_SYNC_CACHE_DIR`). `bootstrap.py` re-exports the venv path
+  constants for backwards compatibility; new code imports from `paths`
+- **New source-result statuses:** `fetch-error` (5xx, DNS, timeout,
+  SSRF block, unsupported content-type) and `too-large` (response
+  exceeded the 2 MiB cap). `source-missing` keeps its prior meaning:
+  the upstream is definitively gone (HTTP 4xx, or local file absent)
+- **`from_cache: true` field** on per-source results when the body
+  was served entirely from the local cache without a network round
+  trip. A 304 refresh does not count as cache-only — it touched the
+  network to revalidate
+- **`/aida doctor`** now reports on the new runtime dependencies
+  (requests, beautifulsoup4, markdownify) and the
+  `~/.aida/cache/knowledge-sync/` cache directory's existence and
+  writability
+
+### Changed
+
+- `_fetch_source_body` renamed to `_dispatch_source` in
+  `skills/knowledge-sync/scripts/sync.py`. The function now returns
+  the richer `FetchOutcome` rather than `Optional[str]` so HTTP-only
+  signal (cache hit, 304, redirect-to-private, response too large,
+  etc.) isn't collapsed into a single sentinel
+- `skills/knowledge-sync/SKILL.md` description and capabilities
+  updated to reflect HTTP source support; field reference now covers
+  the new `url`, `selector`, and `cache_ttl` fields and the security
+  / caching guarantees
+
+### Security
+
+- **SSRF guard:** HTTP source URLs that resolve to private (RFC1918),
+  loopback, link-local (incl. AWS metadata at 169.254.169.254),
+  reserved, or IPv6 ULA / link-local addresses are refused before
+  connect. The check runs at every redirect hop, so a public URL that
+  302s to a private target is also blocked
+- **Redirects** follow manually (`allow_redirects=False`) and are
+  capped at 5 hops; longer chains return `fetch-error`
+- **Response size** is capped at 2 MiB via both Content-Length
+  pre-check and streamed enforcement; larger responses return
+  `too-large` without buffering the entire body
+- **Rate limit:** per-host, ≥0.5s between calls to the same hostname
+  within a sync run. Silent (no surfacing); enforced via a sliding
+  window on monotonic-clock measurements
+
+### Dependencies
+
+- `requirements.txt`: add `requests>=2.31`, `beautifulsoup4>=4.12`,
+  `markdownify>=0.11`
+- `requirements-dev.txt`: add `responses>=0.24` for HTTP mocking in
+  tests
+
+### Tests
+
+- `tests/unit/test_http_source.py` — 29 tests covering content
+  extraction (markdown / plain / HTML, selectors, fallback,
+  unsupported types), rate limiter (first-call no-wait, second-call
+  wait, per-host isolation), success paths (200 + HTML, 200 +
+  markdown, cache hit within TTL, cache_ttl=0 bypass, 304 conditional
+  refresh, redirect chain followed), failure paths (404, 503, DNS,
+  timeout, unsupported MIME), security paths (direct private IP
+  blocked, AWS metadata blocked, redirect-to-private blocked,
+  redirect chain exceeds cap, response too large via Content-Length,
+  response too large via streamed enforcement), and the FetchOutcome
+  dataclass invariants
+- `tests/unit/test_knowledge_sync_run.py` — 6 new end-to-end tests
+  for the HTTP dispatch in `run()`: happy path replaces section, 404
+  surfaces `source-missing`, 503 surfaces `fetch-error`, cache hit
+  surfaces `from_cache: true`, unknown source type surfaces
+  `fetch-error`, negative `cache_ttl` rejected
+
+---
+
 ## [1.5.30] - 2026-05-27
 
 ### Added

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@
 # Testing
 pytest>=8.0
 pytest-cov>=4.0
+responses>=0.24    # HTTP mocking for knowledge-sync HTTP fetcher tests
 
 # Linting
 ruff>=0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,8 @@ PyYAML>=6.0
 
 # JSON Schema validation for frontmatter
 jsonschema>=4.0
+
+# Knowledge-sync HTTP fetcher (#143)
+requests>=2.31
+beautifulsoup4>=4.12
+markdownify>=0.11

--- a/scripts/shared/bootstrap.py
+++ b/scripts/shared/bootstrap.py
@@ -26,9 +26,12 @@ from typing import Optional
 # Constants
 # ---------------------------------------------------------------------------
 
-AIDA_DIR = Path.home() / ".aida"
-VENV_DIR = AIDA_DIR / "venv"
-STAMP_FILE = AIDA_DIR / ".venv-stamp"
+from .paths import AIDA_DIR, STAMP_FILE, VENV_DIR  # noqa: E402
+
+# Re-exports kept for backwards compatibility with existing call sites that
+# import these names from `bootstrap`. The canonical definitions live in
+# `paths.py`.
+__all__ = ["AIDA_DIR", "STAMP_FILE", "VENV_DIR"]
 
 _IS_WINDOWS = platform.system() == "Windows"
 _BIN_DIR = "Scripts" if _IS_WINDOWS else "bin"

--- a/scripts/shared/http_source.py
+++ b/scripts/shared/http_source.py
@@ -1,0 +1,529 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+"""HTTP source fetcher for knowledge-sync (#143).
+
+The mechanic layer of knowledge-sync's remote source support. Given a
+URL declared in an agent's ``sources.yml``, returns the content suitable
+for placing inside a marker-delimited section of a knowledge file.
+
+Out of scope (tracked elsewhere): URL spidering / discovery,
+LLM-driven curation, authentication, JavaScript-rendered pages. This
+module is the policy-free mechanic. See #144 for the policy layer.
+
+The public surface is :class:`HttpFetcher`. It returns a
+:class:`FetchOutcome` that carries either successful content or one of
+three failure kinds — ``source-missing`` (definitive: HTTP 4xx),
+``fetch-error`` (transient or configuration: 5xx / DNS / timeout / SSRF
+block / unsupported content-type), or ``too-large`` (response exceeded
+size limit).
+
+Security:
+  * Pre-flight DNS resolution rejects URLs that resolve to private,
+    loopback, link-local, reserved, or other non-public addresses
+    (RFC1918, AWS metadata at 169.254.169.254, IPv6 ULA / link-local).
+  * Auto-redirects are disabled; each redirect target is re-checked
+    before connect. Redirect chain is capped.
+  * Response size is capped (Content-Length pre-check + streamed
+    enforcement).
+
+Caching:
+  * Responses are cached at
+    ``~/.aida/cache/knowledge-sync/<sha256-of-url>.json``.
+  * Within ``cache_ttl`` the cached body is returned without any
+    network call.
+  * On expiry, ETag / Last-Modified are sent as conditional headers; a
+    304 refreshes the cache timestamp and reuses the body.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import socket
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Literal, Optional
+from urllib.parse import urlparse
+
+import requests
+from bs4 import BeautifulSoup
+from markdownify import markdownify
+
+from .paths import KNOWLEDGE_SYNC_CACHE_DIR
+
+# ---------------------------------------------------------------------------
+# Constants & types
+# ---------------------------------------------------------------------------
+
+DEFAULT_CACHE_TTL = 86_400  # 24h
+DEFAULT_TIMEOUT = 30  # seconds
+MAX_REDIRECTS = 5
+MAX_BYTES = 2 * 1024 * 1024  # 2 MiB
+RATE_LIMIT_SECONDS = 0.5  # ≥0.5s between calls to same host
+
+# IP ranges blocked at every resolution + redirect hop. Anything that
+# satisfies ``ipaddress.ip_address(ip).is_reserved`` is rejected too,
+# which covers oddities like the v4 multicast and broadcast spaces.
+_BLOCKED_NETWORKS = (
+    ipaddress.ip_network("127.0.0.0/8"),       # loopback
+    ipaddress.ip_network("10.0.0.0/8"),        # RFC1918
+    ipaddress.ip_network("172.16.0.0/12"),     # RFC1918
+    ipaddress.ip_network("192.168.0.0/16"),    # RFC1918
+    ipaddress.ip_network("169.254.0.0/16"),    # link-local (AWS metadata)
+    ipaddress.ip_network("::1/128"),           # IPv6 loopback
+    ipaddress.ip_network("fc00::/7"),          # IPv6 ULA
+    ipaddress.ip_network("fe80::/10"),         # IPv6 link-local
+)
+
+FetchKind = Literal["content", "source-missing", "fetch-error", "too-large"]
+
+
+@dataclass(frozen=True)
+class FetchOutcome:
+    """Unified outcome shape for any knowledge-sync source dispatch.
+
+    Both local-file and HTTP sources return this so ``sync.py`` can map
+    consistently to per-source status in its JSON report.
+
+    ``from_cache`` is True if the HTTP outcome was served entirely from
+    the local cache without a network round-trip. False for local
+    sources, network fetches, and conditional 304 refreshes.
+    """
+
+    kind: FetchKind
+    content: Optional[str] = None
+    message: Optional[str] = None
+    from_cache: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Per-host rate limiter
+# ---------------------------------------------------------------------------
+
+
+class RateLimiter:
+    """In-process, per-host sliding-window rate limiter.
+
+    Enforces a minimum gap between calls to the same hostname. Waits
+    are silent — they don't surface as errors; the caller just spends a
+    little wall-clock time on the second call.
+
+    Single-process scope is intentional. We're not protecting upstream
+    services from a cluster; we're being polite when a knowledge sync
+    fetches several pages from the same docs site in one run.
+    """
+
+    def __init__(
+        self,
+        min_interval: float = RATE_LIMIT_SECONDS,
+        clock: Optional[callable] = None,
+        sleeper: Optional[callable] = None,
+    ) -> None:
+        self._min_interval = min_interval
+        self._last_call: Dict[str, float] = {}
+        self._clock = clock or time.monotonic
+        self._sleep = sleeper or time.sleep
+
+    def wait(self, host: str) -> None:
+        """Block until at least ``min_interval`` has passed since the
+        last call to ``host``. Records the call time on return.
+        """
+        now = self._clock()
+        last = self._last_call.get(host)
+        if last is not None:
+            elapsed = now - last
+            if elapsed < self._min_interval:
+                self._sleep(self._min_interval - elapsed)
+                now = self._clock()
+        self._last_call[host] = now
+
+
+# ---------------------------------------------------------------------------
+# SSRF guard
+# ---------------------------------------------------------------------------
+
+
+def _is_url_safe(url: str) -> bool:
+    """Resolve ``url``'s host and return False if any resolved IP is in
+    a blocked range.
+
+    NB: a small TOCTOU window exists between this DNS lookup and the
+    subsequent TCP connect. Mitigation: the same check runs at every
+    redirect hop, and the blocklists cover the high-value targets
+    (cloud metadata, RFC1918, loopback). Closing the window fully would
+    require a custom transport adapter that pins the resolved IP — out
+    of scope for this slice.
+    """
+    host = urlparse(url).hostname
+    if not host:
+        return False
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return False
+    for _, _, _, _, sockaddr in infos:
+        try:
+            ip = ipaddress.ip_address(sockaddr[0])
+        except ValueError:
+            return False
+        if ip.is_reserved:
+            return False
+        if any(ip in net for net in _BLOCKED_NETWORKS):
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Content extraction (HTML → markdown)
+# ---------------------------------------------------------------------------
+
+
+def extract_content(
+    body: str,
+    content_type: str,
+    selector: Optional[str] = None,
+) -> Optional[str]:
+    """Convert a fetched response body into markdown ready for a
+    knowledge file.
+
+    Returns None if the content type is not supported. Caller maps
+    that to ``fetch-error``.
+
+    * ``text/markdown`` and ``text/plain`` are passed through.
+    * ``text/html`` is processed: optional CSS selector picks a
+      subtree, then ``markdownify`` converts it. If the selector
+      yields no match, the full document is converted.
+    * Any other content type returns None.
+    """
+    ct = (content_type or "").split(";", 1)[0].strip().lower()
+    if ct in ("text/markdown", "text/plain", "text/x-markdown"):
+        return body
+    if ct == "text/html" or ct == "application/xhtml+xml":
+        soup = BeautifulSoup(body, "html.parser")
+        if selector:
+            chosen = soup.select_one(selector)
+            if chosen is not None:
+                return markdownify(str(chosen)).strip()
+        return markdownify(str(soup)).strip()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Cache
+# ---------------------------------------------------------------------------
+
+
+def _cache_path_for(url: str) -> Path:
+    digest = hashlib.sha256(url.encode("utf-8")).hexdigest()
+    return KNOWLEDGE_SYNC_CACHE_DIR / f"{digest}.json"
+
+
+def _load_cache(url: str) -> Optional[Dict]:
+    path = _cache_path_for(url)
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _save_cache(url: str, entry: Dict) -> None:
+    KNOWLEDGE_SYNC_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    path = _cache_path_for(url)
+    path.write_text(
+        json.dumps(entry, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _parse_iso(stamp: str) -> Optional[datetime]:
+    try:
+        return datetime.fromisoformat(stamp)
+    except (TypeError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Fetcher
+# ---------------------------------------------------------------------------
+
+
+class HttpFetcher:
+    """Synchronous HTTP fetcher with SSRF guard, caching, and rate limit.
+
+    Constructed once per sync run so the rate limiter and any shared
+    session state span all sources fetched in that run.
+    """
+
+    def __init__(
+        self,
+        rate_limiter: Optional[RateLimiter] = None,
+        session: Optional[requests.Session] = None,
+        max_redirects: int = MAX_REDIRECTS,
+        max_bytes: int = MAX_BYTES,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        self._rate_limiter = rate_limiter or RateLimiter()
+        self._session = session or requests.Session()
+        self._max_redirects = max_redirects
+        self._max_bytes = max_bytes
+        self._timeout = timeout
+
+    def fetch(
+        self,
+        url: str,
+        *,
+        selector: Optional[str] = None,
+        cache_ttl: int = DEFAULT_CACHE_TTL,
+    ) -> FetchOutcome:
+        """Fetch ``url`` and return a :class:`FetchOutcome`.
+
+        ``cache_ttl`` of ``0`` bypasses the cache entirely. Negative
+        values are rejected up-stream; this method assumes the value
+        has been validated.
+
+        Cache flow:
+          * cache_ttl > 0 and a cached entry is within TTL → return
+            cached content (``from_cache=True``)
+          * cached entry expired → conditional GET with ETag /
+            Last-Modified; 304 refreshes timestamp and reuses content
+          * no cache or 200 OK → write/replace cache entry
+        """
+        # Cache fast path
+        if cache_ttl > 0:
+            entry = _load_cache(url)
+            if entry and self._cache_is_fresh(entry, cache_ttl):
+                return FetchOutcome(
+                    kind="content",
+                    content=entry.get("content"),
+                    from_cache=True,
+                )
+
+        return self._fetch_network(url, selector, cache_ttl)
+
+    # -- internal helpers --------------------------------------------------
+
+    def _cache_is_fresh(self, entry: Dict, cache_ttl: int) -> bool:
+        fetched = _parse_iso(entry.get("fetched_at", ""))
+        if fetched is None:
+            return False
+        age = (datetime.now(timezone.utc) - fetched).total_seconds()
+        return age < cache_ttl
+
+    def _fetch_network(
+        self,
+        url: str,
+        selector: Optional[str],
+        cache_ttl: int,
+    ) -> FetchOutcome:
+        cached = _load_cache(url)
+        current_url = url
+        for hop in range(self._max_redirects + 1):
+            if not _is_url_safe(current_url):
+                return FetchOutcome(
+                    kind="fetch-error",
+                    message=(
+                        f"Refusing to fetch {current_url!r}: resolves to "
+                        "a blocked address (private / loopback / link-local "
+                        "/ reserved)."
+                    ),
+                )
+            host = urlparse(current_url).hostname or ""
+            self._rate_limiter.wait(host)
+
+            headers = self._conditional_headers(cached, current_url == url)
+
+            try:
+                response = self._session.get(
+                    current_url,
+                    headers=headers,
+                    timeout=self._timeout,
+                    stream=True,
+                    allow_redirects=False,
+                )
+            except requests.Timeout as exc:
+                return FetchOutcome(
+                    kind="fetch-error",
+                    message=f"Timeout fetching {current_url!r}: {exc}",
+                )
+            except requests.ConnectionError as exc:
+                return FetchOutcome(
+                    kind="fetch-error",
+                    message=(
+                        f"Connection error fetching {current_url!r}: {exc}"
+                    ),
+                )
+            except requests.RequestException as exc:
+                return FetchOutcome(
+                    kind="fetch-error",
+                    message=f"Request error fetching {current_url!r}: {exc}",
+                )
+
+            status = response.status_code
+
+            if status in (301, 302, 303, 307, 308):
+                next_url = response.headers.get("Location")
+                response.close()
+                if not next_url:
+                    return FetchOutcome(
+                        kind="fetch-error",
+                        message=(
+                            f"{status} redirect from {current_url!r} with "
+                            "no Location header."
+                        ),
+                    )
+                current_url = requests.compat.urljoin(current_url, next_url)
+                continue
+
+            if status == 304:
+                if cached is None:
+                    response.close()
+                    return FetchOutcome(
+                        kind="fetch-error",
+                        message=(
+                            f"304 from {current_url!r} but no cached body "
+                            "to reuse."
+                        ),
+                    )
+                response.close()
+                cached["fetched_at"] = _now_iso()
+                _save_cache(url, cached)
+                return FetchOutcome(
+                    kind="content",
+                    content=cached.get("content"),
+                    from_cache=False,
+                )
+
+            if 400 <= status < 500:
+                response.close()
+                return FetchOutcome(
+                    kind="source-missing",
+                    message=(
+                        f"HTTP {status} for {current_url!r}: the upstream "
+                        "URL is no longer available. Edit sources.yml."
+                    ),
+                )
+
+            if status >= 500:
+                response.close()
+                return FetchOutcome(
+                    kind="fetch-error",
+                    message=(
+                        f"HTTP {status} for {current_url!r}: transient "
+                        "upstream failure."
+                    ),
+                )
+
+            # 2xx — stream body with size enforcement
+            return self._consume_response(
+                url=url,
+                response=response,
+                selector=selector,
+            )
+
+        return FetchOutcome(
+            kind="fetch-error",
+            message=(
+                f"Redirect chain exceeded {self._max_redirects} hops "
+                f"starting from {url!r}."
+            ),
+        )
+
+    def _conditional_headers(
+        self,
+        cached: Optional[Dict],
+        first_hop: bool,
+    ) -> Dict[str, str]:
+        """Conditional GET headers from the cached entry (if any).
+
+        Only applied on the first hop — after a redirect, the upstream
+        URL is different so cached validators don't apply.
+        """
+        if not cached or not first_hop:
+            return {}
+        headers: Dict[str, str] = {}
+        if cached.get("etag"):
+            headers["If-None-Match"] = cached["etag"]
+        if cached.get("last_modified"):
+            headers["If-Modified-Since"] = cached["last_modified"]
+        return headers
+
+    def _consume_response(
+        self,
+        url: str,
+        response: requests.Response,
+        selector: Optional[str],
+    ) -> FetchOutcome:
+        content_length = response.headers.get("Content-Length")
+        if content_length is not None:
+            try:
+                declared = int(content_length)
+                if declared > self._max_bytes:
+                    response.close()
+                    return FetchOutcome(
+                        kind="too-large",
+                        message=(
+                            f"Content-Length {declared} exceeds limit "
+                            f"{self._max_bytes} for {url!r}."
+                        ),
+                    )
+            except ValueError:
+                pass  # malformed header — fall through to streamed check
+
+        chunks = []
+        total = 0
+        for chunk in response.iter_content(chunk_size=8192, decode_unicode=False):
+            if not chunk:
+                continue
+            total += len(chunk)
+            if total > self._max_bytes:
+                response.close()
+                return FetchOutcome(
+                    kind="too-large",
+                    message=(
+                        f"Response body exceeded {self._max_bytes} bytes "
+                        f"for {url!r}."
+                    ),
+                )
+            chunks.append(chunk)
+        response.close()
+
+        body_bytes = b"".join(chunks)
+        # NB: don't use response.apparent_encoding here — it triggers a
+        # second read of response.content, which raises because we
+        # already consumed the body via iter_content().
+        encoding = response.encoding or "utf-8"
+        try:
+            body = body_bytes.decode(encoding, errors="replace")
+        except LookupError:
+            body = body_bytes.decode("utf-8", errors="replace")
+
+        content_type = response.headers.get("Content-Type", "")
+        content = extract_content(body, content_type, selector)
+        if content is None:
+            return FetchOutcome(
+                kind="fetch-error",
+                message=(
+                    f"Unsupported Content-Type {content_type!r} for {url!r}."
+                ),
+            )
+
+        entry = {
+            "url": url,
+            "etag": response.headers.get("ETag"),
+            "last_modified": response.headers.get("Last-Modified"),
+            "fetched_at": _now_iso(),
+            "content": content,
+        }
+        _save_cache(url, entry)
+
+        return FetchOutcome(kind="content", content=content, from_cache=False)

--- a/scripts/shared/paths.py
+++ b/scripts/shared/paths.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+"""Registered AIDA path constants.
+
+Single source of truth for filesystem locations AIDA uses. Consumers
+import from here rather than building paths by string concatenation, so
+the layout can move without hunting through call sites.
+
+INVARIANT: this module imports only the stdlib. No imports from
+``bootstrap.py`` or any other ``shared/`` module — that would create
+circular initialization risk as the module graph grows.
+"""
+
+from pathlib import Path
+
+AIDA_DIR = Path.home() / ".aida"
+VENV_DIR = AIDA_DIR / "venv"
+STAMP_FILE = AIDA_DIR / ".venv-stamp"
+
+CACHE_DIR = AIDA_DIR / "cache"
+KNOWLEDGE_SYNC_CACHE_DIR = CACHE_DIR / "knowledge-sync"

--- a/skills/aida/scripts/doctor.py
+++ b/skills/aida/scripts/doctor.py
@@ -15,6 +15,7 @@ Exit codes:
     1 - Issues found
 """
 
+import os
 import sys
 import subprocess
 from pathlib import Path
@@ -155,7 +156,15 @@ def check_aida_venv():
         )
         if result.returncode == 0:
             installed = result.stdout
-            required = ["jinja2", "pyyaml", "jsonschema"]
+            required = [
+                "jinja2",
+                "pyyaml",
+                "jsonschema",
+                # knowledge-sync HTTP fetcher (#143)
+                "requests",
+                "beautifulsoup4",
+                "markdownify",
+            ]
             for pkg in required:
                 if pkg.lower() in installed.lower():
                     print(f"  ✓ {pkg}: installed")
@@ -163,6 +172,27 @@ def check_aida_venv():
                     print(f"  ✗ {pkg}: missing")
     except (subprocess.TimeoutExpired, subprocess.SubprocessError):
         print("  ⚠ Could not verify installed packages")
+
+    # knowledge-sync cache directory health
+    from shared.paths import KNOWLEDGE_SYNC_CACHE_DIR
+
+    if KNOWLEDGE_SYNC_CACHE_DIR.exists():
+        if os.access(KNOWLEDGE_SYNC_CACHE_DIR, os.W_OK):
+            print(
+                f"✓ Knowledge-sync cache: {KNOWLEDGE_SYNC_CACHE_DIR} "
+                "(writable)"
+            )
+        else:
+            print(
+                f"⚠ Knowledge-sync cache: {KNOWLEDGE_SYNC_CACHE_DIR} "
+                "exists but is not writable"
+            )
+    else:
+        # Not an error — created lazily on first HTTP source fetch.
+        print(
+            f"  ℹ Knowledge-sync cache will be created at "
+            f"{KNOWLEDGE_SYNC_CACHE_DIR} on first HTTP source sync"
+        )
 
     return True
 

--- a/skills/knowledge-sync/SKILL.md
+++ b/skills/knowledge-sync/SKILL.md
@@ -5,8 +5,8 @@ description: >-
   Keep agent knowledge files current with their declared upstream
   sources. Reads agents/<name>/knowledge/sources.yml, fetches
   each source, and updates marker-delimited sections in target
-  knowledge files. Local-file sources only in Phase 1.
-version: 0.1.0
+  knowledge files. Supports local files and HTTP/HTTPS URLs.
+version: 0.2.0
 user-invocable: true
 argument-hint: "[sync <agent>|status <agent>|status --all]"
 tags:
@@ -49,29 +49,79 @@ This skill activates when:
 
 ## Source declaration (`sources.yml`)
 
-Lives at `agents/<agent>/knowledge/sources.yml`:
+Lives at `agents/<agent>/knowledge/sources.yml`. A source is either a
+local file or a remote URL:
 
 ```yaml
 sources:
+  # Local file relative to the project root
   - name: project-adrs-extension-types
     type: local
     path: docs/architecture/adr/001-skills-first-architecture.md
     target:
       file: knowledge/extension-types.md
       section: extension-types-overview
+
+  # Remote HTTP/HTTPS source
+  - name: claude-skills-overview
+    type: http
+    url: https://support.claude.com/en/articles/12512176-what-are-skills
+    selector: "main article"      # optional CSS selector
+    cache_ttl: 86400              # optional, seconds
+    target:
+      file: knowledge/skills.md
+      section: claude-skills-upstream
 ```
 
-Field reference:
+### Common fields
 
 - `name`: identifier for the source (logs / error messages use this)
-- `type`: currently only `local` — fetches a file from disk relative
-  to the project root. Future types (`web`, `command`, `api`) are on
-  the roadmap (Phase 2 of #22)
-- `path`: path to the upstream file (relative to project root)
+- `type`: `local`, `http`, or `https`
 - `target.file`: path to the knowledge file to update (relative to
   the agent's knowledge directory)
 - `target.section`: section name. The knowledge file must already
   contain `<!-- upstream:start name="<section>" -->` ... markers
+
+### `type: local`
+
+- `path`: path to the upstream file (relative to project root)
+
+### `type: http` / `type: https`
+
+- `url` (required): full URL to fetch
+- `selector` (optional): CSS selector to extract a subtree before
+  conversion. Defaults to the full document. If the selector matches
+  nothing the fetcher falls back to the full document
+- `cache_ttl` (optional): seconds before re-fetching. Default `86400`
+  (24h). `0` bypasses the cache entirely (always fetches). Negative
+  values are rejected at source load time
+
+#### Content handling
+
+- `text/markdown` and `text/plain` are passed through verbatim
+- `text/html` and `application/xhtml+xml` are converted to markdown
+  via BeautifulSoup + markdownify; the optional `selector` picks a
+  subtree first
+- Any other Content-Type is rejected as `fetch-error`
+
+#### Networking guarantees
+
+- **SSRF guard:** URLs that resolve to private (RFC1918), loopback,
+  link-local (incl. AWS metadata at 169.254.169.254), reserved, or
+  IPv6 ULA / link-local addresses are refused. The check runs at
+  every redirect hop, so a public URL that 302s to a private target
+  is also blocked
+- **Redirects** are followed manually and capped at 5 hops; chains
+  longer than that report `fetch-error`
+- **Rate limiting:** silent, in-process, per-host. Minimum 0.5s
+  between calls to the same hostname during a single sync run
+- **Response size:** capped at 2 MiB. Larger responses (declared via
+  `Content-Length` or measured during streaming) return `too-large`
+- **Cache:** responses are stored at
+  `~/.aida/cache/knowledge-sync/<sha256(url)>.json` with the fetched
+  body, ETag, and Last-Modified header. On expiry, the next fetch
+  sends conditional GET headers; a 304 refreshes the cache timestamp
+  and reuses the cached body
 
 The section markers are the single source of truth for "this content
 is replaceable by sync". Knowledge file authors decide which parts
@@ -90,24 +140,47 @@ to surface for syncing; everything else they wrote stays.
 ```
 
 Returns a JSON report (one entry per source) with each target's
-status: `unchanged` / `changed` / `missing-section` / `source-missing`.
+status:
 
-## Phase 1 scope (this release)
+| Status            | Meaning                                                     |
+| ----------------- | ----------------------------------------------------------- |
+| `unchanged`       | Section already matches the upstream body                   |
+| `changed`         | Section updated (apply mode)                                |
+| `would-change`    | Section would update (dry-run / status mode)                |
+| `source-missing`  | HTTP 4xx, or a local file that no longer exists             |
+| `fetch-error`     | HTTP 5xx, DNS / timeout / SSRF block, unsupported MIME type |
+| `too-large`       | Response body exceeded the 2 MiB cap                        |
+| `missing-section` | Knowledge file lacks the named marker block                 |
+| `target-missing`  | Knowledge file does not exist                               |
+| `invalid-target`  | Source declaration is malformed                             |
+| `marker-error`    | Markers are unbalanced inside the knowledge file            |
+| `write-error`     | Failed to write the updated knowledge file                  |
 
-- Local-file sources only (`type: local`)
+HTTP sources also include a `from_cache: true` field on the per-source
+result when the body was served entirely from cache without a network
+round-trip (a 304 refresh does not count as cache-only — it touched the
+network to revalidate).
+
+## Capabilities (this release)
+
+- Local-file sources (`type: local`)
+- HTTP / HTTPS sources (`type: http` / `https`) with SSRF guard,
+  per-host rate limit, redirect cap, response-size cap, and
+  ETag/Last-Modified caching
 - Marker-based section replacement
 - Dry-run + apply modes
-- Per-source error reporting (a missing source file doesn't crash
-  the whole sync — that source just reports `source-missing` and the
-  others continue)
+- Per-source error reporting (one bad source doesn't fail the whole
+  sync — the others continue)
 
 ## Out of scope (deferred)
 
-- Web sources (`type: web`) — fetch from URL, extract content.
-  Adding the dispatch hook for these is straightforward; the actual
-  fetcher is a follow-up
+- Spidering / URL discovery — tracked in #144
+- LLM-driven curation (decide which discovered URLs are worth using)
+  with a persisted decision log — tracked in #144
 - Command sources (`type: command`) — run a command, use stdout
 - API sources (`type: api`) — query a JSON endpoint
+- Authentication (cookies, OAuth, API keys)
+- JavaScript-rendered pages (headless browser)
 - Interactive review UX — current sync is "show diff via status,
   then apply via sync". A keep/reject-per-change wizard is a future
   enhancement

--- a/skills/knowledge-sync/scripts/sync.py
+++ b/skills/knowledge-sync/scripts/sync.py
@@ -33,6 +33,11 @@ SCRIPT_DIR = Path(__file__).parent
 SHARED = SCRIPT_DIR.parent.parent.parent / "scripts"
 sys.path.insert(0, str(SHARED))
 
+from shared.http_source import (  # noqa: E402
+    DEFAULT_CACHE_TTL,
+    FetchOutcome,
+    HttpFetcher,
+)
 from shared.knowledge_sync import (  # noqa: E402
     KnowledgeSyncError,
     diff_summary,
@@ -88,33 +93,112 @@ def _resolve_target(
     return _agent_root(project_root, agent) / rel
 
 
-def _fetch_source_body(
-    project_root: Path, source: Dict[str, Any]
-) -> Optional[str]:
-    """Fetch the upstream content for ``source``.
-
-    Currently only handles ``type: local``. Returns None for other
-    types or read failures — callers report ``source-missing`` for
-    those.
-
-    Normalizes the body by stripping the single trailing newline
-    that POSIX file convention adds. Without this, every sync
-    would report ``changed`` because the marker-block body has its
-    trailing newline stripped by the parser (so the body never
-    matches a file ending in \\n).
+def _normalize_body(text: Optional[str]) -> Optional[str]:
+    """Strip a single trailing newline so source-with-final-LF compares
+    equal to the LF-stripped marker body. Without this, every sync
+    would report ``changed`` because the marker-block parser strips
+    the trailing newline from its body.
     """
-    if source.get("type") != "local":
-        return None
-    path = source.get("path")
-    if not isinstance(path, str):
-        return None
-    full = project_root / path
-    text = read_local_source(str(full))
     if text is None:
         return None
-    # Strip a single trailing newline so source-with-final-LF
-    # compares equal to the LF-stripped marker body.
     return text[:-1] if text.endswith("\n") else text
+
+
+def _validate_cache_ttl(source: Dict[str, Any]) -> Optional[FetchOutcome]:
+    """Reject negative ``cache_ttl`` values at source-loading time."""
+    ttl = source.get("cache_ttl")
+    if ttl is None:
+        return None
+    if not isinstance(ttl, int) or isinstance(ttl, bool):
+        return FetchOutcome(
+            kind="fetch-error",
+            message=(
+                f"`cache_ttl` must be a non-negative integer, got "
+                f"{ttl!r}."
+            ),
+        )
+    if ttl < 0:
+        return FetchOutcome(
+            kind="fetch-error",
+            message=(
+                f"`cache_ttl` must be a non-negative integer, got {ttl}."
+            ),
+        )
+    return None
+
+
+def _dispatch_source(
+    project_root: Path,
+    source: Dict[str, Any],
+    fetcher: HttpFetcher,
+) -> FetchOutcome:
+    """Dispatch a source declaration to its fetcher and return a
+    :class:`FetchOutcome` describing the result.
+
+    Body normalization (trailing-newline strip) is applied here so
+    every dispatch path returns content shaped to compare cleanly
+    against marker-block bodies.
+    """
+    typ = source.get("type")
+
+    if typ == "local":
+        path = source.get("path")
+        if not isinstance(path, str):
+            return FetchOutcome(
+                kind="source-missing",
+                message=(
+                    "Local source missing a string `path` field."
+                ),
+            )
+        text = read_local_source(str(project_root / path))
+        if text is None:
+            return FetchOutcome(
+                kind="source-missing",
+                message=(
+                    f"Could not read local source at {path!r}."
+                ),
+            )
+        return FetchOutcome(
+            kind="content", content=_normalize_body(text)
+        )
+
+    if typ in ("http", "https"):
+        url = source.get("url")
+        if not isinstance(url, str) or not url:
+            return FetchOutcome(
+                kind="fetch-error",
+                message="HTTP source requires a string `url` field.",
+            )
+        bad_ttl = _validate_cache_ttl(source)
+        if bad_ttl is not None:
+            return bad_ttl
+        selector = source.get("selector")
+        if selector is not None and not isinstance(selector, str):
+            return FetchOutcome(
+                kind="fetch-error",
+                message="`selector` must be a string CSS selector.",
+            )
+        cache_ttl = source.get("cache_ttl")
+        if cache_ttl is None:
+            cache_ttl = DEFAULT_CACHE_TTL
+        outcome = fetcher.fetch(
+            url, selector=selector, cache_ttl=cache_ttl
+        )
+        if outcome.kind == "content":
+            return FetchOutcome(
+                kind="content",
+                content=_normalize_body(outcome.content),
+                from_cache=outcome.from_cache,
+            )
+        return outcome
+
+    return FetchOutcome(
+        kind="fetch-error",
+        message=(
+            f"Unsupported source type: {typ!r}. Supported types: "
+            "local, http, https."
+        ),
+    )
 
 
 def run(
@@ -150,6 +234,7 @@ def run(
 
     results: List[Dict[str, Any]] = []
     overall_ok = True
+    fetcher = HttpFetcher()
 
     for source in sources:
         name = source.get("name") or source.get("type") or "<unnamed>"
@@ -180,17 +265,17 @@ def run(
             results.append(result)
             continue
 
-        body = _fetch_source_body(project_root, source)
-        if body is None:
-            result["status"] = "source-missing"
-            result["message"] = (
-                f"Couldn't read upstream source for {name!r}. "
-                f"Source type: {source.get('type', '?')}, "
-                f"path: {source.get('path', '?')}"
-            )
+        outcome = _dispatch_source(project_root, source, fetcher)
+        if outcome.kind != "content":
+            result["status"] = outcome.kind
+            if outcome.message is not None:
+                result["message"] = outcome.message
             overall_ok = False
             results.append(result)
             continue
+        body = outcome.content
+        if outcome.from_cache:
+            result["from_cache"] = True
 
         if not target.is_file():
             result["status"] = "target-missing"

--- a/tests/unit/test_http_source.py
+++ b/tests/unit/test_http_source.py
@@ -1,0 +1,439 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+"""Tests for the knowledge-sync HTTP fetcher (#143)."""
+
+from __future__ import annotations
+
+import json
+import socket
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import responses
+
+_project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(_project_root / "scripts"))
+
+# Import after path setup so the shared package resolves.
+from shared import http_source  # noqa: E402
+from shared.http_source import (  # noqa: E402
+    FetchOutcome,
+    HttpFetcher,
+    RateLimiter,
+    extract_content,
+)
+
+
+# Stub DNS to always say "this IP is fine" so the SSRF guard doesn't
+# block us during normal success-path tests. Specific SSRF tests
+# patch this with private IPs.
+def _public_getaddrinfo(host, *_a, **_kw):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("203.0.113.10", 0))]
+
+
+def _private_getaddrinfo(host, *_a, **_kw):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))]
+
+
+def _link_local_getaddrinfo(host, *_a, **_kw):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 0))]
+
+
+class TestExtractContent(unittest.TestCase):
+    def test_text_markdown_passthrough(self):
+        self.assertEqual(
+            extract_content("# Hi", "text/markdown"), "# Hi"
+        )
+
+    def test_text_plain_passthrough(self):
+        self.assertEqual(
+            extract_content("plain text", "text/plain"), "plain text"
+        )
+
+    def test_html_no_selector_converts_to_markdown(self):
+        html = "<h1>Title</h1><p>Body</p>"
+        result = extract_content(html, "text/html")
+        self.assertIn("Title", result)
+        self.assertIn("Body", result)
+
+    def test_html_with_selector_extracts_subtree(self):
+        html = (
+            "<html><body>"
+            "<nav>Nav stuff</nav>"
+            "<main><h1>Wanted</h1></main>"
+            "</body></html>"
+        )
+        result = extract_content(html, "text/html", selector="main")
+        self.assertIn("Wanted", result)
+        self.assertNotIn("Nav stuff", result)
+
+    def test_html_selector_no_match_falls_back_to_full(self):
+        html = "<p>Hello</p>"
+        result = extract_content(html, "text/html", selector=".missing")
+        self.assertIn("Hello", result)
+
+    def test_unsupported_content_type_returns_none(self):
+        self.assertIsNone(
+            extract_content("blob", "application/octet-stream")
+        )
+
+    def test_content_type_with_charset(self):
+        self.assertEqual(
+            extract_content(
+                "raw", "text/markdown; charset=utf-8"
+            ),
+            "raw",
+        )
+
+
+class TestRateLimiter(unittest.TestCase):
+    def test_first_call_does_not_wait(self):
+        clock = mock.Mock(return_value=100.0)
+        sleeper = mock.Mock()
+        rl = RateLimiter(min_interval=0.5, clock=clock, sleeper=sleeper)
+        rl.wait("example.com")
+        sleeper.assert_not_called()
+
+    def test_second_call_to_same_host_waits(self):
+        times = iter([100.0, 100.2, 100.5])
+        clock = mock.Mock(side_effect=lambda: next(times))
+        sleeper = mock.Mock()
+        rl = RateLimiter(min_interval=0.5, clock=clock, sleeper=sleeper)
+        rl.wait("example.com")
+        rl.wait("example.com")
+        sleeper.assert_called_once()
+        # Sleep for the remaining interval: 0.5 - (100.2 - 100.0) = 0.3
+        self.assertAlmostEqual(sleeper.call_args[0][0], 0.3, places=5)
+
+    def test_different_hosts_do_not_wait(self):
+        clock = mock.Mock(side_effect=[100.0, 100.1])
+        sleeper = mock.Mock()
+        rl = RateLimiter(min_interval=0.5, clock=clock, sleeper=sleeper)
+        rl.wait("a.example.com")
+        rl.wait("b.example.com")
+        sleeper.assert_not_called()
+
+
+class _FetcherFixture(unittest.TestCase):
+    """Shared setup: a temp cache dir + an HttpFetcher with stubbed
+    rate limiting (so tests don't sleep)."""
+
+    def setUp(self):
+        import tempfile
+
+        self._tmp = Path(tempfile.mkdtemp())
+        # Redirect the cache dir to the temp location for the duration
+        self._cache_patch = mock.patch.object(
+            http_source, "KNOWLEDGE_SYNC_CACHE_DIR", self._tmp
+        )
+        self._cache_patch.start()
+        # Stub the rate limiter so wait() never sleeps
+        self.rl = RateLimiter(
+            min_interval=0.5,
+            clock=lambda: 0.0,
+            sleeper=mock.Mock(),
+        )
+        self.fetcher = HttpFetcher(rate_limiter=self.rl)
+
+    def tearDown(self):
+        self._cache_patch.stop()
+        import shutil
+
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+
+class TestHttpFetcherSuccess(_FetcherFixture):
+    @responses.activate
+    def test_200_html_converts_and_caches(self):
+        responses.get(
+            "https://docs.example.com/page",
+            body="<h1>Hello</h1>",
+            content_type="text/html",
+            headers={"ETag": 'W/"abc"'},
+        )
+        with mock.patch.object(socket, "getaddrinfo", _public_getaddrinfo):
+            outcome = self.fetcher.fetch("https://docs.example.com/page")
+        self.assertEqual(outcome.kind, "content")
+        self.assertIn("Hello", outcome.content)
+        self.assertFalse(outcome.from_cache)
+        # Cache entry written
+        cache_files = list(self._tmp.glob("*.json"))
+        self.assertEqual(len(cache_files), 1)
+        entry = json.loads(cache_files[0].read_text())
+        self.assertEqual(entry["etag"], 'W/"abc"')
+
+    @responses.activate
+    def test_200_markdown_passthrough(self):
+        responses.get(
+            "https://docs.example.com/raw",
+            body="# Title\n\nBody",
+            content_type="text/markdown",
+        )
+        with mock.patch.object(socket, "getaddrinfo", _public_getaddrinfo):
+            outcome = self.fetcher.fetch("https://docs.example.com/raw")
+        self.assertEqual(outcome.kind, "content")
+        self.assertEqual(outcome.content, "# Title\n\nBody")
+
+    @responses.activate
+    def test_cache_hit_within_ttl_skips_network(self):
+        responses.get(
+            "https://docs.example.com/cached",
+            body="<p>One</p>",
+            content_type="text/html",
+        )
+        with mock.patch.object(socket, "getaddrinfo", _public_getaddrinfo):
+            first = self.fetcher.fetch("https://docs.example.com/cached")
+            second = self.fetcher.fetch("https://docs.example.com/cached")
+        self.assertEqual(first.kind, "content")
+        self.assertFalse(first.from_cache)
+        self.assertEqual(second.kind, "content")
+        self.assertTrue(second.from_cache)
+        # Only the first call hit the network
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_cache_ttl_zero_always_fetches(self):
+        responses.get(
+            "https://docs.example.com/no-cache",
+            body="<p>One</p>",
+            content_type="text/html",
+        )
+        responses.get(
+            "https://docs.example.com/no-cache",
+            body="<p>Two</p>",
+            content_type="text/html",
+        )
+        with mock.patch.object(socket, "getaddrinfo", _public_getaddrinfo):
+            first = self.fetcher.fetch(
+                "https://docs.example.com/no-cache", cache_ttl=0
+            )
+            second = self.fetcher.fetch(
+                "https://docs.example.com/no-cache", cache_ttl=0
+            )
+        self.assertFalse(first.from_cache)
+        self.assertFalse(second.from_cache)
+        self.assertEqual(len(responses.calls), 2)
+
+    @responses.activate
+    def test_304_refreshes_cache_and_reuses_body(self):
+        # First call: 200 with ETag
+        responses.get(
+            "https://docs.example.com/cond",
+            body="<p>v1</p>",
+            content_type="text/html",
+            headers={"ETag": 'W/"v1"'},
+        )
+        # Second call: 304 — server says nothing changed
+        responses.get(
+            "https://docs.example.com/cond",
+            status=304,
+        )
+        with mock.patch.object(socket, "getaddrinfo", _public_getaddrinfo):
+            first = self.fetcher.fetch(
+                "https://docs.example.com/cond", cache_ttl=0
+            )
+            second = self.fetcher.fetch(
+                "https://docs.example.com/cond", cache_ttl=0
+            )
+        self.assertEqual(first.kind, "content")
+        self.assertEqual(second.kind, "content")
+        self.assertIn("v1", second.content)
+        self.assertFalse(second.from_cache)  # 304 is not a cache-fast-path
+        # Both calls hit the network; second sent If-None-Match
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(
+            responses.calls[1].request.headers.get("If-None-Match"),
+            'W/"v1"',
+        )
+
+    @responses.activate
+    def test_redirect_chain_followed(self):
+        responses.get(
+            "https://docs.example.com/old",
+            status=301,
+            headers={"Location": "https://docs.example.com/new"},
+        )
+        responses.get(
+            "https://docs.example.com/new",
+            body="<p>moved</p>",
+            content_type="text/html",
+        )
+        with mock.patch.object(socket, "getaddrinfo", _public_getaddrinfo):
+            outcome = self.fetcher.fetch("https://docs.example.com/old")
+        self.assertEqual(outcome.kind, "content")
+        self.assertIn("moved", outcome.content)
+
+
+class TestHttpFetcherFailures(_FetcherFixture):
+    @responses.activate
+    def test_404_is_source_missing(self):
+        responses.get("https://docs.example.com/gone", status=404)
+        with mock.patch.object(socket, "getaddrinfo", _public_getaddrinfo):
+            outcome = self.fetcher.fetch("https://docs.example.com/gone")
+        self.assertEqual(outcome.kind, "source-missing")
+        self.assertIn("404", outcome.message)
+
+    @responses.activate
+    def test_503_is_fetch_error(self):
+        responses.get("https://docs.example.com/down", status=503)
+        with mock.patch.object(socket, "getaddrinfo", _public_getaddrinfo):
+            outcome = self.fetcher.fetch("https://docs.example.com/down")
+        self.assertEqual(outcome.kind, "fetch-error")
+        self.assertIn("503", outcome.message)
+
+    def test_dns_failure_is_fetch_error(self):
+        def _gaierror(*_a, **_kw):
+            raise socket.gaierror("nope")
+
+        with mock.patch.object(socket, "getaddrinfo", _gaierror):
+            outcome = self.fetcher.fetch(
+                "https://nx.example.com/anything"
+            )
+        # Failed name resolution → _is_url_safe returns False →
+        # fetch-error (we couldn't confirm the IP was safe).
+        self.assertEqual(outcome.kind, "fetch-error")
+
+    @responses.activate
+    def test_timeout_is_fetch_error(self):
+        import requests as _r
+
+        responses.get(
+            "https://docs.example.com/slow",
+            body=_r.Timeout("read timed out"),
+        )
+        with mock.patch.object(socket, "getaddrinfo", _public_getaddrinfo):
+            outcome = self.fetcher.fetch(
+                "https://docs.example.com/slow"
+            )
+        self.assertEqual(outcome.kind, "fetch-error")
+
+    @responses.activate
+    def test_unsupported_content_type_is_fetch_error(self):
+        responses.get(
+            "https://docs.example.com/binary",
+            body=b"\x00\x01\x02",
+            content_type="application/octet-stream",
+        )
+        with mock.patch.object(socket, "getaddrinfo", _public_getaddrinfo):
+            outcome = self.fetcher.fetch(
+                "https://docs.example.com/binary"
+            )
+        self.assertEqual(outcome.kind, "fetch-error")
+        self.assertIn("Content-Type", outcome.message)
+
+
+class TestHttpFetcherSecurity(_FetcherFixture):
+    def test_direct_private_ip_blocked(self):
+        with mock.patch.object(
+            socket, "getaddrinfo", _private_getaddrinfo
+        ):
+            outcome = self.fetcher.fetch(
+                "https://internal.example.com/foo"
+            )
+        self.assertEqual(outcome.kind, "fetch-error")
+        self.assertIn("blocked address", outcome.message)
+
+    def test_aws_metadata_address_blocked(self):
+        with mock.patch.object(
+            socket, "getaddrinfo", _link_local_getaddrinfo
+        ):
+            outcome = self.fetcher.fetch(
+                "http://169.254.169.254/latest/meta-data/"
+            )
+        self.assertEqual(outcome.kind, "fetch-error")
+
+    @responses.activate
+    def test_redirect_to_private_blocked(self):
+        # Public → redirect → private. SSRF guard must re-check the
+        # redirect target before connecting.
+        responses.get(
+            "https://docs.example.com/redirect",
+            status=302,
+            headers={"Location": "https://internal.example.com/secret"},
+        )
+        responses.get(
+            "https://internal.example.com/secret",
+            body="secret content",
+            content_type="text/html",
+        )
+
+        # First hop resolves public; redirect target resolves private.
+        host_to_ip = {
+            "docs.example.com": "203.0.113.10",
+            "internal.example.com": "127.0.0.1",
+        }
+
+        def fake_getaddrinfo(host, *_a, **_kw):
+            ip = host_to_ip.get(host, "203.0.113.10")
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0))]
+
+        with mock.patch.object(socket, "getaddrinfo", fake_getaddrinfo):
+            outcome = self.fetcher.fetch(
+                "https://docs.example.com/redirect"
+            )
+        self.assertEqual(outcome.kind, "fetch-error")
+        self.assertIn("blocked address", outcome.message)
+
+    @responses.activate
+    def test_redirect_chain_exceeds_cap(self):
+        # 6 hops: original + 5 redirects that all redirect again
+        for i in range(7):
+            responses.get(
+                f"https://docs.example.com/r{i}",
+                status=302,
+                headers={"Location": f"https://docs.example.com/r{i + 1}"},
+            )
+        # A short-circuit fetcher with MAX_REDIRECTS=5
+        fetcher = HttpFetcher(rate_limiter=self.rl, max_redirects=5)
+        with mock.patch.object(socket, "getaddrinfo", _public_getaddrinfo):
+            outcome = fetcher.fetch("https://docs.example.com/r0")
+        self.assertEqual(outcome.kind, "fetch-error")
+        self.assertIn("Redirect chain exceeded", outcome.message)
+
+    @responses.activate
+    def test_response_too_large_via_content_length(self):
+        responses.get(
+            "https://docs.example.com/big",
+            body="<p>x</p>",
+            content_type="text/html",
+            headers={"Content-Length": str(10 * 1024 * 1024)},
+        )
+        fetcher = HttpFetcher(rate_limiter=self.rl, max_bytes=1024)
+        with mock.patch.object(socket, "getaddrinfo", _public_getaddrinfo):
+            outcome = fetcher.fetch("https://docs.example.com/big")
+        self.assertEqual(outcome.kind, "too-large")
+
+    @responses.activate
+    def test_response_too_large_streamed(self):
+        # Server lies / doesn't send Content-Length; we still abort
+        # mid-stream when the byte count exceeds the cap.
+        big_body = "<p>" + ("x" * 5000) + "</p>"
+        responses.get(
+            "https://docs.example.com/sneaky",
+            body=big_body,
+            content_type="text/html",
+        )
+        fetcher = HttpFetcher(rate_limiter=self.rl, max_bytes=1024)
+        with mock.patch.object(socket, "getaddrinfo", _public_getaddrinfo):
+            outcome = fetcher.fetch("https://docs.example.com/sneaky")
+        self.assertEqual(outcome.kind, "too-large")
+
+
+class TestFetchOutcome(unittest.TestCase):
+    def test_frozen_dataclass(self):
+        outcome = FetchOutcome(kind="content", content="x")
+        with self.assertRaises(Exception):
+            outcome.kind = "fetch-error"  # type: ignore[misc]
+
+    def test_defaults(self):
+        outcome = FetchOutcome(kind="fetch-error")
+        self.assertIsNone(outcome.content)
+        self.assertIsNone(outcome.message)
+        self.assertFalse(outcome.from_cache)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_knowledge_sync_run.py
+++ b/tests/unit/test_knowledge_sync_run.py
@@ -6,10 +6,14 @@
 from __future__ import annotations
 
 import shutil
+import socket
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
+
+import responses
 
 _project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(_project_root / "scripts"))
@@ -18,7 +22,13 @@ sys.path.insert(
     str(_project_root / "skills" / "knowledge-sync" / "scripts"),
 )
 
+from shared import http_source  # noqa: E402
+
 import sync as sync_mod  # noqa: E402
+
+
+def _public_getaddrinfo(host, *_a, **_kw):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("203.0.113.10", 0))]
 
 
 def _build_project(tmp: Path, *, agent: str = "demo-agent"):
@@ -182,6 +192,181 @@ class TestSyncRun(unittest.TestCase):
         self.assertEqual(
             report["results"][0]["status"], "invalid-target"
         )
+
+
+def _build_http_project(tmp: Path, *, agent: str = "http-agent"):
+    """Layout for HTTP source tests: knowledge file with marker + a
+    sources.yml pointing at a URL."""
+    proj = tmp / "proj"
+    (proj / "agents" / agent / "knowledge").mkdir(parents=True)
+
+    knowledge_path = (
+        proj / "agents" / agent / "knowledge" / "topic.md"
+    )
+    knowledge_path.write_text(
+        "# Topic\n\n"
+        '<!-- upstream:start name="remote-overview" -->\n'
+        "OLD body\n"
+        "<!-- upstream:end -->\n",
+        encoding="utf-8",
+    )
+
+    sources_yml = (
+        proj / "agents" / agent / "knowledge" / "sources.yml"
+    )
+    sources_yml.write_text(
+        "sources:\n"
+        "  - name: remote-page\n"
+        "    type: http\n"
+        "    url: https://docs.example.com/page\n"
+        "    target:\n"
+        "      file: knowledge/topic.md\n"
+        "      section: remote-overview\n",
+        encoding="utf-8",
+    )
+    return proj, knowledge_path
+
+
+class TestHttpSourceDispatch(unittest.TestCase):
+    """End-to-end coverage of the new http-type dispatch in run()."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.cache_dir = self.tmp / "cache"
+        self._cache_patch = mock.patch.object(
+            http_source, "KNOWLEDGE_SYNC_CACHE_DIR", self.cache_dir
+        )
+        self._cache_patch.start()
+
+    def tearDown(self):
+        self._cache_patch.stop()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    @responses.activate
+    def test_http_source_happy_path_replaces_section(self):
+        responses.get(
+            "https://docs.example.com/page",
+            body="# Fresh\n\nNew upstream body",
+            content_type="text/markdown",
+        )
+        proj, knowledge_path = _build_http_project(self.tmp)
+        with mock.patch.object(socket, "getaddrinfo", _public_getaddrinfo):
+            report = sync_mod.run(
+                project_root=proj, agent="http-agent", dry_run=False
+            )
+        self.assertTrue(report["success"])
+        result = report["results"][0]
+        self.assertEqual(result["status"], "changed")
+        new_content = knowledge_path.read_text(encoding="utf-8")
+        self.assertIn("Fresh", new_content)
+        self.assertNotIn("OLD body", new_content)
+
+    @responses.activate
+    def test_http_404_reports_source_missing(self):
+        responses.get("https://docs.example.com/page", status=404)
+        proj, _ = _build_http_project(self.tmp)
+        with mock.patch.object(socket, "getaddrinfo", _public_getaddrinfo):
+            report = sync_mod.run(
+                project_root=proj, agent="http-agent", dry_run=False
+            )
+        self.assertFalse(report["success"])
+        result = report["results"][0]
+        self.assertEqual(result["status"], "source-missing")
+        self.assertIn("404", result["message"])
+
+    @responses.activate
+    def test_http_500_reports_fetch_error(self):
+        responses.get("https://docs.example.com/page", status=503)
+        proj, _ = _build_http_project(self.tmp)
+        with mock.patch.object(socket, "getaddrinfo", _public_getaddrinfo):
+            report = sync_mod.run(
+                project_root=proj, agent="http-agent", dry_run=False
+            )
+        self.assertFalse(report["success"])
+        result = report["results"][0]
+        self.assertEqual(result["status"], "fetch-error")
+
+    @responses.activate
+    def test_http_cache_hit_surfaces_from_cache_flag(self):
+        responses.get(
+            "https://docs.example.com/page",
+            body="cached body",
+            content_type="text/markdown",
+        )
+        proj, _ = _build_http_project(self.tmp)
+        with mock.patch.object(socket, "getaddrinfo", _public_getaddrinfo):
+            # First run: writes cache, no from_cache flag (network)
+            first = sync_mod.run(
+                project_root=proj, agent="http-agent", dry_run=False
+            )
+            # Second run: cache hit
+            second = sync_mod.run(
+                project_root=proj, agent="http-agent", dry_run=False
+            )
+        self.assertNotIn("from_cache", first["results"][0])
+        self.assertTrue(second["results"][0].get("from_cache"))
+        # Only one network call
+        self.assertEqual(len(responses.calls), 1)
+
+    def test_unknown_source_type_reports_fetch_error(self):
+        proj = self.tmp / "proj"
+        kdir = proj / "agents" / "x" / "knowledge"
+        kdir.mkdir(parents=True)
+        (kdir / "topic.md").write_text(
+            "# T\n"
+            '<!-- upstream:start name="s" -->\n'
+            "old\n"
+            "<!-- upstream:end -->\n",
+            encoding="utf-8",
+        )
+        (kdir / "sources.yml").write_text(
+            "sources:\n"
+            "  - name: weird\n"
+            "    type: ftp\n"
+            "    target:\n"
+            "      file: knowledge/topic.md\n"
+            "      section: s\n",
+            encoding="utf-8",
+        )
+        report = sync_mod.run(
+            project_root=proj, agent="x", dry_run=False
+        )
+        self.assertFalse(report["success"])
+        self.assertEqual(
+            report["results"][0]["status"], "fetch-error"
+        )
+        self.assertIn("Unsupported source type", report["results"][0]["message"])
+
+    def test_negative_cache_ttl_rejected(self):
+        proj = self.tmp / "proj"
+        kdir = proj / "agents" / "x" / "knowledge"
+        kdir.mkdir(parents=True)
+        (kdir / "topic.md").write_text(
+            "# T\n"
+            '<!-- upstream:start name="s" -->\n'
+            "old\n"
+            "<!-- upstream:end -->\n",
+            encoding="utf-8",
+        )
+        (kdir / "sources.yml").write_text(
+            "sources:\n"
+            "  - name: bad-ttl\n"
+            "    type: http\n"
+            "    url: https://docs.example.com/page\n"
+            "    cache_ttl: -1\n"
+            "    target:\n"
+            "      file: knowledge/topic.md\n"
+            "      section: s\n",
+            encoding="utf-8",
+        )
+        report = sync_mod.run(
+            project_root=proj, agent="x", dry_run=False
+        )
+        self.assertFalse(report["success"])
+        self.assertEqual(
+            report["results"][0]["status"], "fetch-error"
+        )
+        self.assertIn("cache_ttl", report["results"][0]["message"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #143. Adds HTTP / HTTPS source support to the `knowledge-sync` skill so agents can refresh their knowledge files from remote upstream docs (Anthropic support articles, agentskills.io, project READMEs on the web, etc.).

**Mechanic only** — no spidering, no LLM curation, no persisted decision log. Those are the policy layer and live in #144.

## What's in the PR

### New modules

- **`scripts/shared/http_source.py`** — `HttpFetcher`, `RateLimiter`, `FetchOutcome`, `extract_content`
- **`scripts/shared/paths.py`** — registered AIDA filesystem constants (`AIDA_DIR`, `VENV_DIR`, `STAMP_FILE`, `CACHE_DIR`, `KNOWLEDGE_SYNC_CACHE_DIR`). Single source of truth so call sites stop string-concatenating paths. `bootstrap.py` re-exports the venv constants for backwards compatibility

### Refactored

- **`skills/knowledge-sync/scripts/sync.py`** — `_fetch_source_body` → `_dispatch_source`. Returns `FetchOutcome` (rich) rather than `Optional[str]` so HTTP-only signal (cache hit, 304 refresh, redirect-to-private, response too large, etc.) isn't collapsed into a single sentinel
- **`skills/knowledge-sync/SKILL.md`** — description and capabilities updated; full field reference for `url`, `selector`, `cache_ttl`; status vocabulary table with the new codes
- **`skills/aida/scripts/doctor.py`** — import checks for `requests` / `beautifulsoup4` / `markdownify`; cache directory existence + writability probe

### Status vocabulary additions

| New status | When |
|---|---|
| `fetch-error` | 5xx, DNS failure, timeout, SSRF block, unsupported MIME type |
| `too-large` | Response exceeded the 2 MiB cap |

`source-missing` keeps its existing meaning: HTTP 4xx or local file absent (definitive absence — edit `sources.yml`).

Per-source results gain `from_cache: true` when the body was served entirely from the local cache. A 304 refresh does not count as cache-only — it touched the network to revalidate.

## Security guarantees (in this slice, per review)

- **SSRF guard** rejects URLs resolving to private (RFC1918), loopback, link-local (incl. AWS metadata at 169.254.169.254), reserved, or IPv6 ULA / link-local addresses. Check re-runs at every redirect hop, so a public URL that 302s to a private target is also blocked
- **Redirects** are followed manually (`allow_redirects=False`) and capped at 5 hops
- **Response size** capped at 2 MiB via Content-Length pre-check + streamed enforcement
- **Per-host rate limit** at ≥0.5s between calls within a sync run (silent; sliding window on monotonic clock)

## Caching

- `~/.aida/cache/knowledge-sync/<sha256(url)>.json` stores body, ETag, Last-Modified, fetched_at
- Within `cache_ttl`, no network call
- On expiry, conditional GET sends `If-None-Match` / `If-Modified-Since`; 304 refreshes the timestamp and reuses the cached body
- `cache_ttl: 0` bypasses cache entirely (always fetches); negative rejected at source load time

## Dependencies

Runtime: `requests>=2.31`, `beautifulsoup4>=4.12`, `markdownify>=0.11`
Dev: `responses>=0.24` (HTTP mocking)

## Test plan

- [x] 29 new tests in `test_http_source.py` covering content extraction, rate limiter, success paths, failure paths, security paths, and `FetchOutcome` invariants
- [x] 6 new end-to-end tests in `test_knowledge_sync_run.py` covering HTTP dispatch in `run()` (happy path, 404, 503, cache-hit, unknown type, negative `cache_ttl`)
- [x] Full local suite passes: **1108 / 1108**
- [x] ruff, yamllint, frontmatter, REUSE all clean locally

## Reviews

Two rounds of expert review (claude-code-expert + aida) drove the design. Key items incorporated:

- `fetch-error` / `too-large` status codes (vs. overloading `source-missing`)
- `FetchOutcome` dataclass return shape (vs. `Optional[str]`)
- SSRF + size guards in this slice (not deferred)
- `paths.py` extraction with explicit "no imports from `bootstrap.py`" constraint
- `_fetch_source_body` → `_dispatch_source` rename
- `from_cache: true` field for cache-hit visibility
- Doctor checks for new deps + cache dir writability
- SKILL.md updated in place (stale "Phase 1 local only" / `type: web` lines removed)