### PR TITLE
feat: knowledge sync integration + audit/promote/regenerate-md (#144 Slice 2, 1.5.33)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.32",
+  "version": "1.5.33",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,77 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.33] - 2026-05-28
+
+### Added
+
+- **Knowledge sync + curator integration** (#144 Slice 2) — closes
+  the engineering loop on #144. Sync now reads both `sources.yml`
+  (hand-curated) and `decisions.json` (`status: in-use` from the
+  curator), materializing the latter into http sources at sync
+  time. Curator-decided URLs flow into knowledge files without a
+  manual `sources.yml` edit step
+- **`conflict-suppressed` per-source status** — when `sources.yml`
+  asserts a URL should sync but `decisions.json` marks it
+  `rejected`, sync emits this status with a message pointing the
+  user to `/aida knowledge review`. No silent dropping; no silent
+  syncing of rejected content
+- **`/aida knowledge promote <agent>`** — manual in-use without the
+  LLM curator. Takes `--url`, `--file`, `--section`, optional
+  `--reason`. Refuses to overwrite `locked: true` decisions
+- **`/aida knowledge audit <agent>`** — read-only health report:
+  counts by status (in-use / rejected / pending; locked subtotal),
+  stale LLM verdicts (default >90 days), in-use entries that have
+  never synced, in-use entries missing sync target metadata
+- **`/aida knowledge regenerate-md <agent>`** — repair command:
+  rebuilds `decisions.md` from `decisions.json` (the source of
+  truth) after manual edits
+
+### Changed
+
+- **`decisions.json` schema bumped to 1.1.0** — adds optional
+  `target_file` and `target_section` fields to each Decision so
+  sync's materialization can place the body into the right marker
+  block. Older 1.0.0 files load fine; in-use entries lacking the
+  new fields fall back to `informs[0]` for the file and surface as
+  `invalid-target` if no section is set
+- **Decision-log markdown rendering enriched** — per-status counts
+  in headings, locked rejections split into their own subsection
+  with explanation, sync target line per entry, "awaiting verdict"
+  note in the pending section, total count summary at the top
+- **`/aida knowledge sync` no longer fails fast on empty
+  `sources.yml`** — if `sources.yml` is missing or empty but
+  `decisions.json` has in-use entries, sync proceeds with those
+  alone
+
+### Tests
+
+- 8 tests for sync's decision-log merge behavior (in-use entries
+  flow through, pending/rejected skipped, conflict-suppressed
+  emitted on rejected URLs in sources.yml, no false conflicts when
+  in-use decisions match sources.yml entries, empty-state edge
+  cases, decisions-without-sources-yml path)
+- 12 tests for audit / promote / regenerate-md (counts by status,
+  pending URL list, stale LLM detection, never-synced flag,
+  missing-target flag, promote-new / promote-pending /
+  promote-locked-refused / promote-unlocked-rejected, regenerate
+  rebuilds md from json + handles empty-state)
+- Full suite: **1171 passing**
+
+### Notes
+
+- This closes #144. The remaining items mentioned in earlier
+  planning (project-level shared `roots:` config, JSON↔MD
+  consistency lint as a separate command, `/aida config` HTTP
+  policy block, human-string TTL formats) are out of scope and
+  will land in follow-on issues if a clear need arises
+- The "blow away `sources.yml`, decisions persist" property the
+  user wanted holds: curator-approved URLs land in
+  `decisions.json` and survive any sources.yml manipulation; sync
+  rebuilds the active set from in-use decisions on each run
+
+---
+
 ## [1.5.32] - 2026-05-28
 
 ### Added

--- a/scripts/shared/decisions_log.py
+++ b/scripts/shared/decisions_log.py
@@ -29,7 +29,12 @@ from typing import Any, Dict, List, Literal, Optional
 DECISIONS_JSON_FILENAME = "decisions.json"
 DECISIONS_MD_FILENAME = "decisions.md"
 
-SCHEMA_VERSION = "1.0.0"
+SCHEMA_VERSION = "1.1.0"
+
+# Schema versions this build accepts on read. Slice 1 shipped 1.0.0;
+# Slice 2 bumps to 1.1.0 to add target_file / target_section fields.
+# Older files load fine (the new fields just stay None).
+_ACCEPTED_VERSIONS = ("1.0.0", "1.1.0")
 
 # Two-line generated-file banner that lands at the top of every
 # regenerated decisions.md. Mirrors how AIDA already signals generated
@@ -63,6 +68,11 @@ class Decision:
     source_root: Optional[str] = None
     last_synced: Optional[str] = None
     last_etag: Optional[str] = None
+    # Schema 1.1.0+ (Slice 2): explicit sync target. When status is
+    # in-use, sync materializes an http source against these. Falls
+    # back to informs[0] (file) + url-derived slug (section) if absent.
+    target_file: Optional[str] = None
+    target_section: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Return a JSON-serializable dict, omitting None / empty defaults
@@ -116,10 +126,10 @@ def read_decisions(directory: Path) -> List[Decision]:
             f"decisions.json at {path} must be a JSON object."
         )
     version = data.get("version")
-    if version is not None and version != SCHEMA_VERSION:
+    if version is not None and version not in _ACCEPTED_VERSIONS:
         raise ValueError(
             f"decisions.json at {path} declares version={version!r}; "
-            f"this build understands {SCHEMA_VERSION!r}."
+            f"this build accepts {list(_ACCEPTED_VERSIONS)}."
         )
     raw_entries = data.get("decisions", [])
     if not isinstance(raw_entries, list):
@@ -153,6 +163,8 @@ def _decision_from_dict(raw: Dict[str, Any]) -> Decision:
         source_root=raw.get("source_root"),
         last_synced=raw.get("last_synced"),
         last_etag=raw.get("last_etag"),
+        target_file=raw.get("target_file"),
+        target_section=raw.get("target_section"),
     )
 
 
@@ -196,32 +208,62 @@ def _regenerate_decisions_md(
 ) -> None:
     """Render decisions.md from the JSON state.
 
-    Plain-dump format for Slice 1 — sections grouped by status, with
-    one entry per URL carrying its metadata line and reason prose if
-    present. Slice 2 may invest in richer formatting.
+    Sections grouped by status; counts in headings; locked entries
+    grouped within rejected (since locked rejections are the "do not
+    re-suggest" set). Each entry shows URL, metadata, target, reason.
     """
     in_use = [d for d in decisions if d.status == "in-use"]
-    rejected = [d for d in decisions if d.status == "rejected"]
+    rejected_locked = [
+        d for d in decisions if d.status == "rejected" and d.locked
+    ]
+    rejected_unlocked = [
+        d for d in decisions if d.status == "rejected" and not d.locked
+    ]
     pending = [d for d in decisions if d.status == "pending"]
 
     out = [_GENERATED_BANNER, "\n# Curator Decisions\n"]
+    out.append(
+        f"\n*Total: {len(decisions)} "
+        f"({len(in_use)} in-use, "
+        f"{len(rejected_locked) + len(rejected_unlocked)} rejected, "
+        f"{len(pending)} pending)*\n"
+    )
 
-    out.append("\n## In-use\n")
+    out.append(f"\n## In-use ({len(in_use)})\n")
     if in_use:
         for d in in_use:
             out.append(_render_decision(d))
     else:
         out.append("\n*No in-use decisions.*\n")
 
-    out.append("\n## Rejected\n")
-    if rejected:
-        for d in rejected:
+    out.append(
+        f"\n## Rejected ({len(rejected_locked) + len(rejected_unlocked)})\n"
+    )
+    if rejected_locked:
+        out.append(
+            f"\n### Locked rejections ({len(rejected_locked)})\n"
+        )
+        out.append(
+            "\n*These have been human-confirmed; the curator skips "
+            "them on subsequent runs.*\n"
+        )
+        for d in rejected_locked:
             out.append(_render_decision(d))
-    else:
+    if rejected_unlocked:
+        out.append(
+            f"\n### Unlocked rejections ({len(rejected_unlocked)})\n"
+        )
+        for d in rejected_unlocked:
+            out.append(_render_decision(d))
+    if not rejected_locked and not rejected_unlocked:
         out.append("\n*No rejected decisions.*\n")
 
-    out.append("\n## Pending\n")
+    out.append(f"\n## Pending ({len(pending)})\n")
     if pending:
+        out.append(
+            "\n*Awaiting verdict — run `/aida knowledge curate "
+            "<agent>` to decide.*\n"
+        )
         for d in pending:
             out.append(_render_decision(d))
     else:
@@ -233,7 +275,7 @@ def _regenerate_decisions_md(
 
 
 def _render_decision(d: Decision) -> str:
-    lines = [f"\n### {d.url}\n"]
+    lines = [f"\n#### {d.url}\n"]
     meta_bits: List[str] = []
     if d.decided_at:
         meta_bits.append(f"Decided {d.decided_at}")
@@ -243,12 +285,25 @@ def _render_decision(d: Decision) -> str:
         meta_bits.append(f"by {d.decided_by}")
     if d.locked:
         meta_bits.append("**locked**")
-    if d.informs:
-        meta_bits.append(f"Informs: {', '.join(d.informs)}")
     if d.source_root:
         meta_bits.append(f"Source root: {d.source_root}")
+    if d.last_synced:
+        meta_bits.append(f"Last synced: {d.last_synced}")
     if meta_bits:
         lines.append(f"\n*{' · '.join(meta_bits)}*\n")
+    if d.target_file or d.target_section:
+        target_file = d.target_file or (
+            d.informs[0] if d.informs else "<unset>"
+        )
+        target_section = d.target_section or "<unset>"
+        lines.append(
+            f"\n**Sync target:** "
+            f"`{target_file}` → section `{target_section}`\n"
+        )
+    elif d.informs:
+        lines.append(
+            f"\n**Informs:** {', '.join(d.informs)}\n"
+        )
     if d.reason:
         lines.append(f"\n{d.reason}\n")
     return "".join(lines)

--- a/skills/aida/SKILL.md
+++ b/skills/aida/SKILL.md
@@ -279,6 +279,9 @@ For `expert` commands:
 | `sync <agent>` | knowledge-sync | `sync.py --agent <name>` |
 | `status <agent>` | knowledge-sync | `sync.py --agent <name> --dry-run` |
 | `discover <agent>` | knowledge-sync | `discover.py --agent <name>` |
+| `audit <agent>` | knowledge-sync | `audit.py --agent <name>` |
+| `promote <agent> --url X --file F --section S` | knowledge-sync | `promote.py --agent <name> --url X --file F --section S` |
+| `regenerate-md <agent>` | knowledge-sync | `regenerate_md.py --agent <name>` |
 | `curate <agent>` | knowledge-curator | follow SKILL.md workflow |
 | `review <agent>` | knowledge-curator | follow SKILL.md workflow |
 
@@ -288,11 +291,14 @@ Script paths are resolved as
 **Examples:**
 
 ```text
-/aida knowledge sync <agent>          → knowledge-sync (sync.py)
-/aida knowledge status <agent>        → knowledge-sync (--dry-run)
-/aida knowledge discover <agent>      → knowledge-sync (discover.py)
-/aida knowledge curate <agent>        → knowledge-curator (workflow)
-/aida knowledge review <agent>        → knowledge-curator (workflow)
+/aida knowledge sync <agent>           → knowledge-sync (sync.py)
+/aida knowledge status <agent>         → knowledge-sync (--dry-run)
+/aida knowledge discover <agent>       → knowledge-sync (discover.py)
+/aida knowledge audit <agent>          → knowledge-sync (audit.py)
+/aida knowledge promote <agent> ...    → knowledge-sync (promote.py)
+/aida knowledge regenerate-md <agent>  → knowledge-sync (regenerate_md.py)
+/aida knowledge curate <agent>         → knowledge-curator (workflow)
+/aida knowledge review <agent>         → knowledge-curator (workflow)
 ```
 
 ### Memento Commands
@@ -415,9 +421,12 @@ When displaying help (for `help` command or no arguments), show:
 - `/aida expert panel remove <name>` - Remove a named panel
 
 ### Knowledge
-- `/aida knowledge sync <agent>` - Sync an agent's knowledge from declared upstream sources
+- `/aida knowledge sync <agent>` - Sync an agent's knowledge from declared sources + in-use decisions
 - `/aida knowledge status <agent>` - Dry-run; report what would change
 - `/aida knowledge discover <agent>` - Spider configured roots; record new URLs as pending decisions
+- `/aida knowledge audit <agent>` - Drift report (pending count, stale verdicts, never-synced URLs)
+- `/aida knowledge promote <agent> --url X --file F --section S` - Manually mark a URL in-use (skip the LLM curator)
+- `/aida knowledge regenerate-md <agent>` - Repair: rebuild decisions.md from decisions.json
 - `/aida knowledge curate <agent>` - LLM workflow: decide pending URLs into in-use or rejected
 - `/aida knowledge review <agent>` - Interactive: human confirms or overrides curator decisions
 

--- a/skills/knowledge-sync/SKILL.md
+++ b/skills/knowledge-sync/SKILL.md
@@ -43,16 +43,39 @@ This skill activates when:
 
 ## Operations
 
-| Operation  | Mode    | Description                                              |
-| ---------- | ------- | -------------------------------------------------------- |
-| `sync`     | Apply   | Read sources.yml, fetch, replace targeted sections       |
-| `status`   | Inspect | Dry-run the sync; report changed/unchanged/missing       |
-| `discover` | Spider  | Walk configured roots; add new URLs to decisions.json    |
+| Operation       | Mode    | Description                                                            |
+| --------------- | ------- | ---------------------------------------------------------------------- |
+| `sync`          | Apply   | Read sources.yml + in-use decisions, fetch, replace targeted sections  |
+| `status`        | Inspect | Dry-run the sync; report changed/unchanged/missing/conflict-suppressed |
+| `discover`      | Spider  | Walk configured roots; add new URLs to decisions.json                  |
+| `audit`         | Inspect | Report pending count, stale verdicts, never-synced URLs                |
+| `promote`       | Apply   | Manually mark a URL in-use (skip the LLM curator)                      |
+| `regenerate-md` | Repair  | Rebuild decisions.md from decisions.json                               |
 
 `discover` is the deterministic spider half of the curator workflow
 (#144). It walks `roots:` declared in `sources.yml`, finds candidate
 URLs, and writes them as `status: pending` into `decisions.json` for
 the `knowledge-curator` skill to verdict.
+
+`sync` reads both `sources.yml` (hand-curated entries) and
+`decisions.json` (`status: in-use` entries from the curator workflow).
+A URL listed in both `sources.yml` AND marked `rejected` in
+`decisions.json` produces a `conflict-suppressed` result so the user
+can reconcile rather than silently sync a rejected source.
+
+`audit` is a read-only report — pending count, stale LLM verdicts
+(default: older than 90 days), in-use entries that have never been
+synced, in-use entries missing `target_file` / `target_section`.
+
+`promote` is a manual override for the LLM curator. Useful when you
+already know a URL belongs in an agent's corpus — provide
+`--url <X> --file <F> --section <S>` and it lands directly as
+in-use with `decided_by: human`. Refuses to overwrite locked
+decisions.
+
+`regenerate-md` is a repair command. If a user has hand-edited
+`decisions.md` (despite the generated-file banner), this rebuilds
+it from `decisions.json` (the source of truth).
 
 ## Source declaration (`sources.yml`)
 

--- a/skills/knowledge-sync/scripts/audit.py
+++ b/skills/knowledge-sync/scripts/audit.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+"""Knowledge audit report (#144 Slice 2).
+
+Reads `agents/<agent>/knowledge/decisions.json` and reports:
+  - count by status (pending / in-use / rejected, locked subtotal)
+  - oldest / newest decided_at among LLM verdicts (signal that a
+    re-curate pass may be due)
+  - URLs with last_synced older than a threshold (stale syncs)
+  - URLs that are in-use but missing target_file / target_section
+    (would fail to materialize during sync)
+
+Doctor's job stays "is the local environment healthy?" Audit's job
+is "is this agent's curated knowledge healthy?" — different scopes,
+different commands.
+
+Output is JSON on stdout; exit 0 always (audit reports state; it
+doesn't fail).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+SCRIPT_DIR = Path(__file__).parent
+SHARED = SCRIPT_DIR.parent.parent.parent / "scripts"
+sys.path.insert(0, str(SHARED))
+
+from shared.decisions_log import (  # noqa: E402
+    Decision,
+    read_decisions,
+)
+
+# Decisions older than this without re-review are flagged as stale.
+DEFAULT_STALE_AFTER_DAYS = 90
+
+
+def _parse_iso(stamp: Optional[str]) -> Optional[datetime]:
+    if not stamp:
+        return None
+    try:
+        return datetime.fromisoformat(stamp)
+    except ValueError:
+        return None
+
+
+def _age_days(stamp: Optional[str], now: datetime) -> Optional[float]:
+    parsed = _parse_iso(stamp)
+    if parsed is None:
+        return None
+    return (now - parsed).total_seconds() / 86_400
+
+
+def _missing_target(d: Decision) -> bool:
+    """In-use decision lacks the metadata sync needs to materialize."""
+    if d.status != "in-use":
+        return False
+    target_file = d.target_file or (
+        d.informs[0] if d.informs else None
+    )
+    return not target_file or not d.target_section
+
+
+def run(
+    project_root: Path,
+    agent: str,
+    stale_after_days: int = DEFAULT_STALE_AFTER_DAYS,
+) -> Dict[str, Any]:
+    knowledge_dir = project_root / "agents" / agent / "knowledge"
+    try:
+        decisions = read_decisions(knowledge_dir)
+    except ValueError as exc:
+        return {
+            "success": False,
+            "agent": agent,
+            "message": str(exc),
+        }
+
+    now = datetime.now(timezone.utc)
+
+    in_use = [d for d in decisions if d.status == "in-use"]
+    rejected = [d for d in decisions if d.status == "rejected"]
+    pending = [d for d in decisions if d.status == "pending"]
+    locked_rejected = [d for d in rejected if d.locked]
+
+    # Decisions LLM made — flag stale ones that may benefit from a
+    # human review.
+    llm_decisions = [d for d in decisions if d.decided_by == "llm"]
+    stale_llm_decisions: List[Dict[str, Any]] = []
+    for d in llm_decisions:
+        if d.locked:
+            continue
+        age = _age_days(d.decided_at, now)
+        if age is not None and age > stale_after_days:
+            stale_llm_decisions.append(
+                {
+                    "url": d.url,
+                    "decided_at": d.decided_at,
+                    "age_days": round(age, 1),
+                    "status": d.status,
+                }
+            )
+
+    # In-use entries that haven't been synced recently (using
+    # last_synced field, which sync populates).
+    never_synced = [
+        d.url for d in in_use if not d.last_synced
+    ]
+
+    # In-use entries missing the metadata sync needs.
+    missing_target = [
+        d.url for d in decisions if _missing_target(d)
+    ]
+
+    return {
+        "success": True,
+        "agent": agent,
+        "totals": {
+            "all": len(decisions),
+            "in_use": len(in_use),
+            "rejected": len(rejected),
+            "rejected_locked": len(locked_rejected),
+            "pending": len(pending),
+        },
+        "pending_urls": [d.url for d in pending],
+        "stale_llm_decisions": stale_llm_decisions,
+        "stale_after_days": stale_after_days,
+        "never_synced": never_synced,
+        "missing_target": missing_target,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="audit.py",
+        description=(
+            "Audit an agent's decision log — pending count, stale "
+            "LLM verdicts, never-synced in-use entries, and in-use "
+            "entries missing sync metadata."
+        ),
+    )
+    parser.add_argument(
+        "--agent",
+        required=True,
+        help="Agent name (e.g., 'claude-code-expert')",
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Project root (default: current directory)",
+    )
+    parser.add_argument(
+        "--stale-after-days",
+        type=int,
+        default=DEFAULT_STALE_AFTER_DAYS,
+        help=(
+            "Flag LLM verdicts older than this many days as stale "
+            f"(default: {DEFAULT_STALE_AFTER_DAYS})."
+        ),
+    )
+    args = parser.parse_args()
+
+    report = run(
+        project_root=args.project_root.resolve(),
+        agent=args.agent,
+        stale_after_days=args.stale_after_days,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/knowledge-sync/scripts/promote.py
+++ b/skills/knowledge-sync/scripts/promote.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+"""Manually mark a URL in-use without going through the LLM curator
+(#144 Slice 2).
+
+Useful for URLs you already know belong in an agent's corpus — you
+can skip the discover → curate cycle and promote directly.
+
+Behavior:
+  - If the URL is new (no existing decision), creates an in-use
+    entry from --url, --file, --section
+  - If the URL exists as pending or rejected (and not locked), flips
+    it to in-use with the given target metadata
+  - Refuses to overwrite a locked entry — the user must run
+    /aida knowledge review to flip a lock
+
+decided_by is recorded as "human" and decided_at gets a fresh
+timestamp.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+SCRIPT_DIR = Path(__file__).parent
+SHARED = SCRIPT_DIR.parent.parent.parent / "scripts"
+sys.path.insert(0, str(SHARED))
+
+from shared.decisions_log import (  # noqa: E402
+    Decision,
+    find_by_url,
+    now_iso,
+    read_decisions,
+    upsert_decision,
+    write_decisions,
+)
+
+
+def run(
+    project_root: Path,
+    agent: str,
+    url: str,
+    target_file: str,
+    target_section: str,
+    reason: str = "",
+) -> Dict[str, Any]:
+    knowledge_dir = project_root / "agents" / agent / "knowledge"
+
+    try:
+        existing = read_decisions(knowledge_dir)
+    except ValueError as exc:
+        return {
+            "success": False,
+            "agent": agent,
+            "message": str(exc),
+        }
+
+    current = find_by_url(existing, url)
+    if current is not None and current.locked:
+        return {
+            "success": False,
+            "agent": agent,
+            "message": (
+                f"Decision for {url!r} is locked ({current.status}). "
+                "Run `/aida knowledge review` to flip the lock."
+            ),
+        }
+
+    promoted = Decision(
+        url=url,
+        status="in-use",
+        decided_at=now_iso(),
+        decided_by="human",
+        reason=reason or "Manually promoted via /aida knowledge promote.",
+        target_file=target_file,
+        target_section=target_section,
+        # Preserve the discovery metadata if it existed
+        discovered_at=current.discovered_at if current else None,
+        source_root=current.source_root if current else None,
+        informs=current.informs if current else [],
+    )
+    next_decisions = upsert_decision(existing, promoted)
+    try:
+        write_decisions(knowledge_dir, next_decisions)
+    except OSError as exc:
+        return {
+            "success": False,
+            "agent": agent,
+            "message": f"Could not write decisions log: {exc}",
+        }
+    return {
+        "success": True,
+        "agent": agent,
+        "url": url,
+        "previous_status": current.status if current else None,
+        "new_status": "in-use",
+        "target_file": target_file,
+        "target_section": target_section,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="promote.py",
+        description=(
+            "Manually mark a URL in-use, bypassing the LLM curator."
+        ),
+    )
+    parser.add_argument(
+        "--agent",
+        required=True,
+        help="Agent name (e.g., 'claude-code-expert')",
+    )
+    parser.add_argument(
+        "--url",
+        required=True,
+        help="The URL to promote.",
+    )
+    parser.add_argument(
+        "--file",
+        dest="target_file",
+        required=True,
+        help=(
+            "The knowledge file this URL syncs into "
+            "(e.g., 'skills.md')."
+        ),
+    )
+    parser.add_argument(
+        "--section",
+        dest="target_section",
+        required=True,
+        help=(
+            "The marker-block section name within the knowledge "
+            "file (e.g., 'claude-skills-upstream')."
+        ),
+    )
+    parser.add_argument(
+        "--reason",
+        default="",
+        help=(
+            "Optional reason recorded with the decision. Falls "
+            "back to a generic 'manually promoted' note if empty."
+        ),
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Project root (default: current directory)",
+    )
+    args = parser.parse_args()
+
+    report = run(
+        project_root=args.project_root.resolve(),
+        agent=args.agent,
+        url=args.url,
+        target_file=args.target_file,
+        target_section=args.target_section,
+        reason=args.reason,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/knowledge-sync/scripts/regenerate_md.py
+++ b/skills/knowledge-sync/scripts/regenerate_md.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+"""Regenerate decisions.md from decisions.json (#144 Slice 2).
+
+Repair command: if a user has hand-edited decisions.md (despite the
+generated-file banner), this rebuilds it from the JSON state. The
+JSON is the source of truth; markdown is derivative.
+
+Implementation is trivial — just round-trip the JSON through
+write_decisions, which regenerates the markdown atomically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+SCRIPT_DIR = Path(__file__).parent
+SHARED = SCRIPT_DIR.parent.parent.parent / "scripts"
+sys.path.insert(0, str(SHARED))
+
+from shared.decisions_log import (  # noqa: E402
+    read_decisions,
+    write_decisions,
+)
+
+
+def run(
+    project_root: Path,
+    agent: str,
+) -> Dict[str, Any]:
+    knowledge_dir = project_root / "agents" / agent / "knowledge"
+    try:
+        decisions = read_decisions(knowledge_dir)
+    except ValueError as exc:
+        return {
+            "success": False,
+            "agent": agent,
+            "message": str(exc),
+        }
+    try:
+        write_decisions(knowledge_dir, decisions)
+    except OSError as exc:
+        return {
+            "success": False,
+            "agent": agent,
+            "message": f"Could not write decisions log: {exc}",
+        }
+    return {
+        "success": True,
+        "agent": agent,
+        "regenerated": str(
+            knowledge_dir / "decisions.md"
+        ),
+        "decisions_count": len(decisions),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="regenerate_md.py",
+        description=(
+            "Repair: regenerate decisions.md from decisions.json."
+        ),
+    )
+    parser.add_argument(
+        "--agent",
+        required=True,
+        help="Agent name (e.g., 'claude-code-expert')",
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Project root (default: current directory)",
+    )
+    args = parser.parse_args()
+
+    report = run(
+        project_root=args.project_root.resolve(),
+        agent=args.agent,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/knowledge-sync/scripts/sync.py
+++ b/skills/knowledge-sync/scripts/sync.py
@@ -33,6 +33,10 @@ SCRIPT_DIR = Path(__file__).parent
 SHARED = SCRIPT_DIR.parent.parent.parent / "scripts"
 sys.path.insert(0, str(SHARED))
 
+from shared.decisions_log import (  # noqa: E402
+    Decision,
+    read_decisions,
+)
 from shared.http_source import (  # noqa: E402
     DEFAULT_CACHE_TTL,
     FetchOutcome,
@@ -201,6 +205,69 @@ def _dispatch_source(
     )
 
 
+def _materialize_decision(decision: Decision) -> Optional[Dict[str, Any]]:
+    """Turn an in-use Decision into a source-shaped dict that sync's
+    existing dispatch path can consume.
+
+    ``target_file`` is interpreted as relative to the agent's
+    ``knowledge/`` directory (matching the convention curator authors
+    use). The materialized source uses the full
+    ``knowledge/<file>`` path expected by ``_resolve_target``.
+
+    Returns None if the decision lacks the target metadata needed to
+    sync it (no target_file and no informs[0] fallback, or no
+    target_section). Callers surface those as ``invalid-target``.
+    """
+    target_file = decision.target_file or (
+        decision.informs[0] if decision.informs else None
+    )
+    if not target_file or not decision.target_section:
+        return None
+    if not target_file.startswith("knowledge/"):
+        target_file = f"knowledge/{target_file}"
+    return {
+        "name": f"decision:{decision.url}",
+        "type": "http",
+        "url": decision.url,
+        "target": {
+            "file": target_file,
+            "section": decision.target_section,
+        },
+    }
+
+
+def _detect_conflicts(
+    sources: List[Dict[str, Any]],
+    decisions: List[Decision],
+) -> Dict[str, str]:
+    """Map sources.yml URLs that conflict with the decision log to a
+    human-readable reason.
+
+    A conflict exists when sources.yml asserts a URL should be synced
+    but the decision log marks that URL ``rejected``. The user is
+    silently editing past a curator verdict; sync surfaces it so they
+    can run ``/aida knowledge review`` to override.
+    """
+    conflicts: Dict[str, str] = {}
+    by_url = {d.url: d for d in decisions}
+    for source in sources:
+        if source.get("type") not in ("http", "https"):
+            continue
+        url = source.get("url")
+        if not isinstance(url, str):
+            continue
+        decision = by_url.get(url)
+        if decision and decision.status == "rejected":
+            locked_note = " (locked)" if decision.locked else ""
+            conflicts[url] = (
+                f"URL is listed in sources.yml but decisions.json "
+                f"marks it rejected{locked_note}. Run "
+                "`/aida knowledge review <agent>` to override, or "
+                "remove the entry from sources.yml."
+            )
+    return conflicts
+
+
 def run(
     project_root: Path,
     agent: str,
@@ -208,8 +275,21 @@ def run(
 ) -> Dict[str, Any]:
     """Walk sources for ``agent`` and sync (or report) each.
 
+    Sources come from two places:
+
+      1. ``sources.yml`` — hand-curated entries (existing behavior)
+      2. ``decisions.json`` — every ``status: in-use`` decision is
+         materialized into an http source and processed alongside
+         the rest. Re-runs are idempotent because the http fetcher's
+         cache deduplicates network calls.
+
+    Conflicts (a URL listed in sources.yml that's marked ``rejected``
+    in decisions.json) surface as ``conflict-suppressed`` per-source
+    results so the user can run ``/aida knowledge review`` to
+    reconcile.
+
     Returns a structured report; never raises for per-source
-    failures — those go in the per-source `status` field.
+    failures — those go in the per-source ``status`` field.
     """
     try:
         sources = _load_sources(project_root, agent)
@@ -221,20 +301,83 @@ def run(
             "results": [],
         }
 
-    if not sources:
+    knowledge_dir = _agent_root(project_root, agent) / "knowledge"
+    try:
+        decisions = read_decisions(knowledge_dir)
+    except ValueError as exc:
+        return {
+            "success": False,
+            "agent": agent,
+            "message": (
+                f"Could not read decisions.json: {exc}"
+            ),
+            "results": [],
+        }
+
+    # Merge in-use decisions as additional http sources, skipping any
+    # URLs the user has already declared by hand in sources.yml.
+    yml_urls = {
+        s.get("url")
+        for s in sources
+        if s.get("type") in ("http", "https")
+    }
+    for decision in decisions:
+        if decision.status != "in-use":
+            continue
+        if decision.url in yml_urls:
+            continue  # sources.yml wins; explicit declaration trumps materialized
+        materialized = _materialize_decision(decision)
+        if materialized is None:
+            sources.append(
+                {
+                    "name": f"decision:{decision.url}",
+                    "type": "http",
+                    "url": decision.url,
+                    # No target — will be caught as invalid-target
+                    "_decision_missing_target": True,
+                }
+            )
+        else:
+            sources.append(materialized)
+
+    if not sources and not decisions:
         return {
             "success": True,
             "agent": agent,
             "message": (
                 f"No sources declared for agent {agent!r} "
-                "(sources.yml missing or empty)."
+                "(sources.yml missing or empty, no in-use decisions)."
             ),
             "results": [],
         }
 
+    conflicts = _detect_conflicts(sources, decisions)
+
     results: List[Dict[str, Any]] = []
     overall_ok = True
     fetcher = HttpFetcher()
+
+    # Emit conflict-suppressed entries first so they appear at the
+    # top of the report and can't be missed.
+    for url, message in conflicts.items():
+        results.append(
+            {
+                "name": f"conflict:{url}",
+                "status": "conflict-suppressed",
+                "target": None,
+                "message": message,
+            }
+        )
+        overall_ok = False
+
+    # Drop the conflicting URLs from the source list before
+    # dispatching, so we don't actually sync rejected content into
+    # the knowledge files.
+    sources = [
+        s
+        for s in sources
+        if s.get("url") not in conflicts
+    ]
 
     for source in sources:
         name = source.get("name") or source.get("type") or "<unnamed>"

--- a/tests/unit/test_audit_promote_regen.py
+++ b/tests/unit/test_audit_promote_regen.py
@@ -1,0 +1,357 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+"""Tests for audit / promote / regenerate-md (#144 Slice 2)."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(_project_root / "scripts"))
+sys.path.insert(
+    0,
+    str(_project_root / "skills" / "knowledge-sync" / "scripts"),
+)
+
+from shared.decisions_log import (  # noqa: E402
+    DECISIONS_MD_FILENAME,
+    Decision,
+    read_decisions,
+    write_decisions,
+)
+
+import audit as audit_mod  # noqa: E402
+import promote as promote_mod  # noqa: E402
+import regenerate_md as regen_mod  # noqa: E402
+
+
+def _build_agent(tmp: Path, agent: str = "demo-agent") -> Path:
+    knowledge = tmp / "proj" / "agents" / agent / "knowledge"
+    knowledge.mkdir(parents=True)
+    return knowledge
+
+
+def _days_ago(days: float) -> str:
+    return (
+        datetime.now(timezone.utc) - timedelta(days=days)
+    ).isoformat(timespec="seconds")
+
+
+class _Fixture(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+
+# ----------------------------------------------------------------------
+# audit
+# ----------------------------------------------------------------------
+
+
+class TestAuditRunner(_Fixture):
+    def test_counts_by_status(self):
+        knowledge = _build_agent(self.tmp)
+        write_decisions(
+            knowledge,
+            [
+                Decision(url="https://x.test/in1", status="in-use"),
+                Decision(url="https://x.test/in2", status="in-use"),
+                Decision(url="https://x.test/rej", status="rejected", locked=True),
+                Decision(url="https://x.test/pen", status="pending"),
+            ],
+        )
+        report = audit_mod.run(
+            project_root=self.tmp / "proj", agent="demo-agent"
+        )
+        self.assertTrue(report["success"])
+        self.assertEqual(report["totals"]["in_use"], 2)
+        self.assertEqual(report["totals"]["rejected"], 1)
+        self.assertEqual(report["totals"]["rejected_locked"], 1)
+        self.assertEqual(report["totals"]["pending"], 1)
+        self.assertEqual(report["totals"]["all"], 4)
+
+    def test_lists_pending_urls(self):
+        knowledge = _build_agent(self.tmp)
+        write_decisions(
+            knowledge,
+            [
+                Decision(url="https://x.test/a", status="pending"),
+                Decision(url="https://x.test/b", status="pending"),
+                Decision(url="https://x.test/c", status="in-use"),
+            ],
+        )
+        report = audit_mod.run(
+            project_root=self.tmp / "proj", agent="demo-agent"
+        )
+        self.assertEqual(
+            sorted(report["pending_urls"]),
+            ["https://x.test/a", "https://x.test/b"],
+        )
+
+    def test_stale_llm_decisions_flagged(self):
+        knowledge = _build_agent(self.tmp)
+        write_decisions(
+            knowledge,
+            [
+                Decision(
+                    url="https://x.test/old",
+                    status="in-use",
+                    decided_at=_days_ago(120),
+                    decided_by="llm",
+                ),
+                Decision(
+                    url="https://x.test/recent",
+                    status="in-use",
+                    decided_at=_days_ago(10),
+                    decided_by="llm",
+                ),
+                Decision(
+                    url="https://x.test/locked-old",
+                    status="rejected",
+                    decided_at=_days_ago(200),
+                    decided_by="llm",
+                    locked=True,
+                ),
+            ],
+        )
+        report = audit_mod.run(
+            project_root=self.tmp / "proj",
+            agent="demo-agent",
+            stale_after_days=90,
+        )
+        stale_urls = {
+            entry["url"] for entry in report["stale_llm_decisions"]
+        }
+        # Old LLM decision is stale; recent isn't; locked is exempt
+        self.assertIn("https://x.test/old", stale_urls)
+        self.assertNotIn("https://x.test/recent", stale_urls)
+        self.assertNotIn("https://x.test/locked-old", stale_urls)
+
+    def test_never_synced_flagged(self):
+        knowledge = _build_agent(self.tmp)
+        write_decisions(
+            knowledge,
+            [
+                Decision(
+                    url="https://x.test/never",
+                    status="in-use",
+                ),
+                Decision(
+                    url="https://x.test/done",
+                    status="in-use",
+                    last_synced=_days_ago(1),
+                ),
+            ],
+        )
+        report = audit_mod.run(
+            project_root=self.tmp / "proj", agent="demo-agent"
+        )
+        self.assertEqual(
+            report["never_synced"], ["https://x.test/never"]
+        )
+
+    def test_missing_target_flagged(self):
+        knowledge = _build_agent(self.tmp)
+        write_decisions(
+            knowledge,
+            [
+                Decision(
+                    url="https://x.test/bad",
+                    status="in-use",
+                    # No target_file or informs, no target_section
+                ),
+                Decision(
+                    url="https://x.test/ok",
+                    status="in-use",
+                    target_file="skills.md",
+                    target_section="upstream",
+                ),
+            ],
+        )
+        report = audit_mod.run(
+            project_root=self.tmp / "proj", agent="demo-agent"
+        )
+        self.assertIn(
+            "https://x.test/bad", report["missing_target"]
+        )
+        self.assertNotIn(
+            "https://x.test/ok", report["missing_target"]
+        )
+
+    def test_empty_state(self):
+        _build_agent(self.tmp)
+        report = audit_mod.run(
+            project_root=self.tmp / "proj", agent="demo-agent"
+        )
+        self.assertTrue(report["success"])
+        self.assertEqual(report["totals"]["all"], 0)
+
+
+# ----------------------------------------------------------------------
+# promote
+# ----------------------------------------------------------------------
+
+
+class TestPromoteRunner(_Fixture):
+    def test_promote_new_url(self):
+        _build_agent(self.tmp)
+        report = promote_mod.run(
+            project_root=self.tmp / "proj",
+            agent="demo-agent",
+            url="https://x.test/page",
+            target_file="skills.md",
+            target_section="upstream",
+            reason="needed by skills.md upstream block",
+        )
+        self.assertTrue(report["success"])
+        self.assertIsNone(report["previous_status"])
+        self.assertEqual(report["new_status"], "in-use")
+        decisions = read_decisions(
+            self.tmp / "proj" / "agents" / "demo-agent" / "knowledge"
+        )
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].status, "in-use")
+        self.assertEqual(decisions[0].decided_by, "human")
+        self.assertEqual(decisions[0].target_file, "skills.md")
+        self.assertEqual(decisions[0].target_section, "upstream")
+
+    def test_promote_pending_url(self):
+        knowledge = _build_agent(self.tmp)
+        write_decisions(
+            knowledge,
+            [
+                Decision(
+                    url="https://x.test/page",
+                    status="pending",
+                    discovered_at="2026-05-28T00:00:00+00:00",
+                    source_root="agentskills",
+                ),
+            ],
+        )
+        report = promote_mod.run(
+            project_root=self.tmp / "proj",
+            agent="demo-agent",
+            url="https://x.test/page",
+            target_file="skills.md",
+            target_section="upstream",
+        )
+        self.assertTrue(report["success"])
+        self.assertEqual(report["previous_status"], "pending")
+        decisions = read_decisions(knowledge)
+        self.assertEqual(decisions[0].status, "in-use")
+        # Discovery metadata preserved
+        self.assertEqual(
+            decisions[0].discovered_at,
+            "2026-05-28T00:00:00+00:00",
+        )
+        self.assertEqual(decisions[0].source_root, "agentskills")
+
+    def test_promote_locked_refused(self):
+        knowledge = _build_agent(self.tmp)
+        write_decisions(
+            knowledge,
+            [
+                Decision(
+                    url="https://x.test/page",
+                    status="rejected",
+                    locked=True,
+                    decided_at="2026-05-28T00:00:00+00:00",
+                    decided_by="human",
+                ),
+            ],
+        )
+        report = promote_mod.run(
+            project_root=self.tmp / "proj",
+            agent="demo-agent",
+            url="https://x.test/page",
+            target_file="skills.md",
+            target_section="upstream",
+        )
+        self.assertFalse(report["success"])
+        self.assertIn("locked", report["message"])
+        # Decision unchanged
+        decisions = read_decisions(knowledge)
+        self.assertEqual(decisions[0].status, "rejected")
+
+    def test_promote_unlocked_rejected_flips_to_in_use(self):
+        knowledge = _build_agent(self.tmp)
+        write_decisions(
+            knowledge,
+            [
+                Decision(
+                    url="https://x.test/page",
+                    status="rejected",
+                    locked=False,
+                    decided_at="2026-05-28T00:00:00+00:00",
+                    decided_by="llm",
+                ),
+            ],
+        )
+        report = promote_mod.run(
+            project_root=self.tmp / "proj",
+            agent="demo-agent",
+            url="https://x.test/page",
+            target_file="skills.md",
+            target_section="upstream",
+        )
+        self.assertTrue(report["success"])
+        self.assertEqual(report["previous_status"], "rejected")
+        decisions = read_decisions(knowledge)
+        self.assertEqual(decisions[0].status, "in-use")
+        self.assertEqual(decisions[0].decided_by, "human")
+
+
+# ----------------------------------------------------------------------
+# regenerate-md
+# ----------------------------------------------------------------------
+
+
+class TestRegenerateMd(_Fixture):
+    def test_rebuilds_md_from_json(self):
+        knowledge = _build_agent(self.tmp)
+        write_decisions(
+            knowledge,
+            [
+                Decision(
+                    url="https://x.test/page",
+                    status="in-use",
+                    decided_at="2026-05-28T00:00:00+00:00",
+                    decided_by="llm",
+                    reason="useful",
+                ),
+            ],
+        )
+        # Corrupt the markdown by hand
+        md_path = knowledge / DECISIONS_MD_FILENAME
+        md_path.write_text("# Garbage\n", encoding="utf-8")
+
+        report = regen_mod.run(
+            project_root=self.tmp / "proj", agent="demo-agent"
+        )
+        self.assertTrue(report["success"])
+        self.assertEqual(report["decisions_count"], 1)
+        rebuilt = md_path.read_text(encoding="utf-8")
+        self.assertTrue(rebuilt.startswith("<!-- GENERATED"))
+        self.assertIn("https://x.test/page", rebuilt)
+        # Garbage gone
+        self.assertNotIn("# Garbage", rebuilt)
+
+    def test_no_decisions_still_rewrites_md(self):
+        _build_agent(self.tmp)
+        report = regen_mod.run(
+            project_root=self.tmp / "proj", agent="demo-agent"
+        )
+        self.assertTrue(report["success"])
+        self.assertEqual(report["decisions_count"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_sync_decision_merge.py
+++ b/tests/unit/test_sync_decision_merge.py
@@ -1,0 +1,345 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+
+"""Tests for sync's decision-log merge behavior (#144 Slice 2)."""
+
+from __future__ import annotations
+
+import shutil
+import socket
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import responses
+
+_project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(_project_root / "scripts"))
+sys.path.insert(
+    0,
+    str(_project_root / "skills" / "knowledge-sync" / "scripts"),
+)
+
+from shared import http_source  # noqa: E402
+from shared.decisions_log import (  # noqa: E402
+    Decision,
+    write_decisions,
+)
+
+import sync as sync_mod  # noqa: E402
+
+
+def _public_getaddrinfo(host, *_a, **_kw):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("203.0.113.10", 0))]
+
+
+def _build_project(
+    tmp: Path,
+    *,
+    agent: str = "demo-agent",
+    sources_yml: str = "sources: []\n",
+):
+    proj = tmp / "proj"
+    knowledge = proj / "agents" / agent / "knowledge"
+    knowledge.mkdir(parents=True)
+    (knowledge / "sources.yml").write_text(
+        sources_yml, encoding="utf-8"
+    )
+    return proj, knowledge
+
+
+def _seed_target_file(knowledge: Path, section: str = "remote") -> Path:
+    target = knowledge / "topic.md"
+    target.write_text(
+        "# Topic\n\n"
+        f'<!-- upstream:start name="{section}" -->\n'
+        "OLD body\n"
+        "<!-- upstream:end -->\n",
+        encoding="utf-8",
+    )
+    return target
+
+
+class _MergeFixture(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.cache_dir = self.tmp / "cache"
+        self._cache_patch = mock.patch.object(
+            http_source, "KNOWLEDGE_SYNC_CACHE_DIR", self.cache_dir
+        )
+        self._cache_patch.start()
+
+    def tearDown(self):
+        self._cache_patch.stop()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+
+class TestInUseMergedIntoSync(_MergeFixture):
+    @responses.activate
+    def test_in_use_decision_synced_alongside_sources_yml(self):
+        responses.get(
+            "https://x.test/page",
+            body="# Fresh body",
+            content_type="text/markdown",
+        )
+        proj, knowledge = _build_project(self.tmp)
+        _seed_target_file(knowledge, section="remote")
+        write_decisions(
+            knowledge,
+            [
+                Decision(
+                    url="https://x.test/page",
+                    status="in-use",
+                    decided_at="2026-05-28T00:00:00+00:00",
+                    decided_by="llm",
+                    target_file="topic.md",
+                    target_section="remote",
+                )
+            ],
+        )
+        with mock.patch.object(socket, "getaddrinfo", _public_getaddrinfo):
+            report = sync_mod.run(
+                project_root=proj, agent="demo-agent"
+            )
+        self.assertTrue(report["success"])
+        # Find the result for our decision-materialized source
+        result = next(
+            r
+            for r in report["results"]
+            if r["name"].startswith("decision:")
+        )
+        self.assertEqual(result["status"], "changed")
+        new_content = (knowledge / "topic.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("Fresh body", new_content)
+        self.assertNotIn("OLD body", new_content)
+
+    def test_pending_decisions_not_synced(self):
+        # No HTTP mock — sync shouldn't even try to fetch a pending URL
+        proj, knowledge = _build_project(self.tmp)
+        _seed_target_file(knowledge, section="remote")
+        write_decisions(
+            knowledge,
+            [
+                Decision(
+                    url="https://x.test/page",
+                    status="pending",
+                    discovered_at="2026-05-28T00:00:00+00:00",
+                    target_file="topic.md",
+                    target_section="remote",
+                )
+            ],
+        )
+        report = sync_mod.run(
+            project_root=proj, agent="demo-agent"
+        )
+        self.assertTrue(report["success"])
+        # No materialized result; sources.yml is empty
+        self.assertNotIn(
+            "decision:https://x.test/page",
+            [r["name"] for r in report["results"]],
+        )
+
+    def test_rejected_decisions_not_synced(self):
+        proj, knowledge = _build_project(self.tmp)
+        _seed_target_file(knowledge, section="remote")
+        write_decisions(
+            knowledge,
+            [
+                Decision(
+                    url="https://x.test/page",
+                    status="rejected",
+                    decided_at="2026-05-28T00:00:00+00:00",
+                    decided_by="llm",
+                    target_file="topic.md",
+                    target_section="remote",
+                )
+            ],
+        )
+        report = sync_mod.run(
+            project_root=proj, agent="demo-agent"
+        )
+        self.assertTrue(report["success"])
+        self.assertEqual(report["results"], [])
+
+    def test_in_use_without_target_metadata_falls_back_to_informs(self):
+        # No target_file/target_section, but informs gives us a file —
+        # falls back to informs[0]. But target_section is still
+        # required, so this should report invalid-target.
+        proj, knowledge = _build_project(self.tmp)
+        _seed_target_file(knowledge, section="remote")
+        write_decisions(
+            knowledge,
+            [
+                Decision(
+                    url="https://x.test/page",
+                    status="in-use",
+                    decided_at="2026-05-28T00:00:00+00:00",
+                    decided_by="llm",
+                    informs=["topic.md"],
+                    # target_section missing
+                )
+            ],
+        )
+        report = sync_mod.run(
+            project_root=proj, agent="demo-agent"
+        )
+        # The materialized source lacks section → invalid-target
+        result = next(
+            r
+            for r in report["results"]
+            if r["name"].startswith("decision:")
+        )
+        self.assertEqual(result["status"], "invalid-target")
+        self.assertFalse(report["success"])
+
+
+class TestConflictSuppressed(_MergeFixture):
+    def test_sources_yml_url_rejected_by_decision_emits_conflict(self):
+        proj, knowledge = _build_project(
+            self.tmp,
+            sources_yml=(
+                "sources:\n"
+                "  - name: hand-picked\n"
+                "    type: http\n"
+                "    url: https://x.test/page\n"
+                "    target:\n"
+                "      file: knowledge/topic.md\n"
+                "      section: remote\n"
+            ),
+        )
+        _seed_target_file(knowledge, section="remote")
+        write_decisions(
+            knowledge,
+            [
+                Decision(
+                    url="https://x.test/page",
+                    status="rejected",
+                    decided_at="2026-05-28T00:00:00+00:00",
+                    decided_by="llm",
+                    locked=True,
+                    reason="out of scope",
+                )
+            ],
+        )
+        report = sync_mod.run(
+            project_root=proj, agent="demo-agent"
+        )
+        self.assertFalse(report["success"])
+        conflicts = [
+            r
+            for r in report["results"]
+            if r["status"] == "conflict-suppressed"
+        ]
+        self.assertEqual(len(conflicts), 1)
+        self.assertIn(
+            "rejected (locked)", conflicts[0]["message"]
+        )
+        # The conflicting source was suppressed — no actual sync
+        # against the rejected URL.
+        non_conflict_results = [
+            r
+            for r in report["results"]
+            if r["status"] != "conflict-suppressed"
+        ]
+        self.assertEqual(non_conflict_results, [])
+
+    def test_sources_yml_url_matches_in_use_decision_no_conflict(self):
+        # Same URL in both places, but decision says in-use →
+        # sources.yml entry wins (explicit declaration trumps
+        # materialized), no conflict.
+        proj, knowledge = _build_project(
+            self.tmp,
+            sources_yml=(
+                "sources:\n"
+                "  - name: hand-picked\n"
+                "    type: http\n"
+                "    url: https://x.test/page\n"
+                "    target:\n"
+                "      file: knowledge/topic.md\n"
+                "      section: remote\n"
+            ),
+        )
+        _seed_target_file(knowledge, section="remote")
+        write_decisions(
+            knowledge,
+            [
+                Decision(
+                    url="https://x.test/page",
+                    status="in-use",
+                    decided_at="2026-05-28T00:00:00+00:00",
+                    decided_by="llm",
+                    target_file="topic.md",
+                    target_section="remote",
+                )
+            ],
+        )
+        # No HTTP mock → fetch fails, but that's fine for this test.
+        # We're checking the absence of conflict-suppressed.
+        report = sync_mod.run(
+            project_root=proj, agent="demo-agent"
+        )
+        statuses = {r["status"] for r in report["results"]}
+        self.assertNotIn("conflict-suppressed", statuses)
+        # Should not double-process the URL
+        url_count = sum(
+            1
+            for r in report["results"]
+            if "x.test/page" in (r.get("name") or "")
+        )
+        self.assertLessEqual(url_count, 1)
+
+
+class TestEmptyState(_MergeFixture):
+    def test_empty_sources_and_no_decisions(self):
+        proj = self.tmp / "proj"
+        (proj / "agents" / "demo-agent" / "knowledge").mkdir(parents=True)
+        report = sync_mod.run(
+            project_root=proj, agent="demo-agent"
+        )
+        self.assertTrue(report["success"])
+        self.assertIn("No sources declared", report["message"])
+
+    def test_decisions_present_but_no_sources_yml(self):
+        proj = self.tmp / "proj"
+        knowledge = proj / "agents" / "demo-agent" / "knowledge"
+        knowledge.mkdir(parents=True)
+        # No sources.yml at all — sync still picks up in-use decisions
+        _seed_target_file(knowledge, section="remote")
+        write_decisions(
+            knowledge,
+            [
+                Decision(
+                    url="https://x.test/page",
+                    status="in-use",
+                    decided_at="2026-05-28T00:00:00+00:00",
+                    decided_by="llm",
+                    target_file="topic.md",
+                    target_section="remote",
+                )
+            ],
+        )
+        # Without sources.yml, _load_sources should still succeed
+        # (returns []). The decision becomes the only source.
+        # No HTTP mock — fetch will fail but that's fine for this
+        # test's scope.
+        report = sync_mod.run(
+            project_root=proj, agent="demo-agent"
+        )
+        # The materialized decision is the only result; status is
+        # fetch-error or similar (no mock), but the IMPORTANT thing
+        # is that sync didn't return "no sources" — it actually
+        # processed the decision.
+        self.assertTrue(
+            any(
+                r["name"].startswith("decision:")
+                for r in report["results"]
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #144. Slice 2 finishes the chain by wiring `decisions.json` into `/aida knowledge sync` and adding the remaining policy commands (audit, promote, regenerate-md). Curator-decided URLs now flow into knowledge files without a manual `sources.yml` edit step.

## What's in the PR

### Sync integration

`/aida knowledge sync` now reads both `sources.yml` (hand-curated) AND `decisions.json` (status: in-use entries from the curator). It materializes the in-use decisions into http sources at sync time. Dedup: URLs explicitly listed in `sources.yml` win over the materialized form.

### `conflict-suppressed` status

When `sources.yml` asserts a URL should sync but `decisions.json` marks that URL `rejected`, sync emits a `conflict-suppressed` per-source result with a message pointing the user to `/aida knowledge review`. No silent dropping; no silent syncing of rejected content.

### Schema bump — `decisions.json` 1.1.0

- New optional `target_file` and `target_section` fields per Decision so sync's materialization knows which marker block to update
- `target_file` is relative to the agent's `knowledge/` directory (the curator can write just `topic.md`; the prefix is added automatically)
- Falls back to `informs[0]` when `target_file` absent
- Older 1.0.0 files load fine; in-use entries missing target metadata surface as `invalid-target`

### New commands

- **`/aida knowledge audit <agent>`** — read-only health report: status counts (including locked rejection subtotal), stale LLM verdicts (default >90 days), never-synced in-use entries, in-use entries missing sync metadata
- **`/aida knowledge promote <agent> --url X --file F --section S`** — manual in-use override. Records `decided_by: human` + fresh timestamp. Refuses to overwrite `locked: true` decisions
- **`/aida knowledge regenerate-md <agent>`** — repair after manual `decisions.md` edits. JSON is source of truth; markdown is derivative

### Rich `decisions.md` formatting

- Per-status counts in headings (`## In-use (3)`)
- Locked rejections split into their own subsection with note
- Sync target line per entry (`file → section`)
- "Awaiting verdict" note in pending section
- Total count summary at the top

## Test plan

- [x] 8 tests for sync's decision-log merge behavior
- [x] 12 tests for audit / promote / regenerate-md
- [x] Full suite: **1171 passing**
- [x] ruff / yamllint / frontmatter / REUSE all clean locally

## What's left vs the original #144 scope

This closes #144 from the user's perspective — the full discover → curate → review → sync loop ships. Items that were on the wishlist but deliberately deferred (project-level shared `roots:`, `/aida config` HTTP policy block, human-string TTL formats, JSON↔MD consistency lint as a separate command) will land in follow-on issues if a clear need arises.

The "blow away `sources.yml`, decisions persist" property the user wanted holds: curator-approved URLs in `decisions.json` survive any sources.yml manipulation; sync rebuilds the active set from in-use decisions on each run.

Closes #144