### PR TITLE
chore(claude-code-expert): refresh knowledge to cover agentskills.io patterns (#145, 1.5.34)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.33",
+  "version": "1.5.34",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,70 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.34] - 2026-05-28
+
+### Added
+
+- **`claude-code-expert` knowledge refresh** (#145) — closes the
+  agentskills.io coverage gap identified during review-skill
+  planning. The agent's knowledge now teaches the iteration loop
+  and authoring patterns the community treats as standard, plus
+  the rubric guidance the review skill's Phase 2 LLM grading will
+  consume
+- **`agents/claude-code-expert/knowledge/skill-authoring-patterns.md`**
+  — gotchas sections, calibrated control (freedom vs. prescription),
+  defaults-not-menus, procedures-over-declarations, output
+  templates, checklists, validation loops, plan-validate-execute,
+  bundling reusable scripts. AIDA-specific patterns (two-phase API,
+  atomic primitives, knowledge-with-the-agent) included at the end
+- **`agents/claude-code-expert/knowledge/skill-iteration.md`** —
+  start from real expertise (extract from a task or synthesize
+  from artifacts), refine with real execution (read execution
+  traces, not just outputs), when evals pay off, the iteration
+  loop in compressed form
+- **`agents/claude-code-expert/knowledge/evaluating-extensions.md`**
+  — narrative rubric guidance for the review skill's Phase 2 LLM
+  grading (#146). Per-type "excellent" criteria, cross-cutting
+  failure modes (semantic mismatch, overlapping knowledge, missing
+  gotchas, iteration debt), calibration notes for the A–F scale,
+  anti-patterns the LLM reviewer should avoid
+- **`agents/claude-code-expert/knowledge/sources.yml`** — `roots:`
+  configured for the agentskills.io and support.claude.com docs.
+  The agent is now a working consumer of #144's discovery +
+  curator pipeline; future refreshes can run
+  `/aida knowledge discover claude-code-expert` followed by
+  `/aida knowledge curate claude-code-expert`
+
+### Changed
+
+- **`agents/claude-code-expert/knowledge/skills.md`** — added a
+  cross-link to the new authoring-patterns and iteration files at
+  the top of the Best Practices section
+- **`agents/claude-code-expert/knowledge/framework-design-principles.md`**
+  — added an explicit note on our divergence from agentskills.io on
+  "quality belongs in agents, not skills" (we keep the line bright;
+  they don't)
+- **`agents/claude-code-expert/knowledge/index.md`** — three new
+  files registered with "when to use" entries; Quick Reference
+  table expanded with 14 new question→file mappings
+
+### Notes
+
+- The three new knowledge files are **synthesized prose**, not
+  verbatim upstream content. They adapt agentskills.io concepts to
+  AIDA's WHO/HOW/CONTEXT framework, note divergences explicitly,
+  and cross-link to existing knowledge. This is the intended shape
+  for our knowledge files — vendored upstream content with marker
+  blocks is for the rare cases where exact quotes are warranted
+- The `sources.yml` `roots:` config dogfoods #144 — the
+  claude-code-expert agent is the first consumer of the
+  discover/curate workflow. The next round of refreshes can be
+  driven by the spider rather than hand-authored
+- Unblocks #146 (review skill); the Phase 2 LLM grading now has the
+  reasoning context it needs
+
+---
+
 ## [1.5.33] - 2026-05-28
 
 ### Added

--- a/agents/claude-code-expert/knowledge/evaluating-extensions.md
+++ b/agents/claude-code-expert/knowledge/evaluating-extensions.md
@@ -1,0 +1,261 @@
+---
+type: reference
+name: evaluating-extensions
+title: Evaluating Extensions — Rubric Guidance for the Review Skill
+description: Narrative rubric for grading agents, skills, and plugins. What "excellent" looks like per extension type, what to flag, and how to score sub-rationally when the structural rules don't catch what matters.
+version: "1.0.0"
+---
+
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# Evaluating Extensions
+
+This file is the reasoning context for the **Phase 2 (LLM expert
+review)** layer of the review skill design tracked in
+`docs/proposals/review-skill.md`. The deterministic rubric scores
+the structural properties of an extension; the LLM expert reads
+this file to score the *qualitative* properties — description
+clarity, knowledge depth, expertise authenticity, semantic match
+between an extension's stated purpose and its actual content.
+
+**When to use this file:** the review skill's Phase 2 invokes
+`claude-code-expert` to render a narrative critique on top of the
+rubric findings. The agent loads this file then walks the artifact
+under review.
+
+## The three-phase review model (recap)
+
+| Phase | Owner | What it grades | Reproducible? |
+|---|---|---|---|
+| 1. Deterministic rubric | Python | Structural properties (frontmatter complete, knowledge index exists, tool scope, etc.) | Yes — CI-gateable |
+| 2. LLM expert review | `claude-code-expert` (this agent) | Qualitative properties (description quality, semantic mismatch, redundancy) | No — advisory |
+| 3. Behavioral evals | `evals/evals.json` runner | The extension's actual outputs against assertions | Yes (with caveats) |
+
+The canonical grade for CI is **Phase 1**. The expert score in
+Phase 2 is **advisory**. Both ship in the report; only one gates
+merges.
+
+## What excellence looks like — agents
+
+An excellent agent has:
+
+- **A description that names concrete activation triggers.** Not
+  "helps with frontend code" but "expert on React component
+  architecture and accessibility patterns; reviews component
+  hierarchies and recommends ARIA patterns". Generic descriptions
+  produce generic activations.
+- **One coherent area of expertise**, not a kitchen sink. The
+  agent's knowledge files should cluster around one domain. If
+  reading the knowledge dir feels like reading three different
+  agents stapled together, the agent is over-scoped.
+- **Knowledge files organized for progressive disclosure.** The
+  always-loaded `agent.md` is lean — it has the persona,
+  judgment frameworks, and pointers. The deep content lives in
+  `knowledge/*.md` files, each focused on a single topic, each
+  named so the agent can reason about when to load it. An
+  `index.md` lists the files with one-line "when to use" entries.
+- **Tool scope matched to the work.** `allowed-tools` lists the
+  specific tools the agent needs. A wildcard `*` is acceptable
+  only when the agent genuinely needs the full toolset; "I
+  couldn't be bothered to narrow it" is not.
+- **An honest description.** If the agent description claims
+  expertise the knowledge files don't back up, that's a Phase 2
+  red flag — the structural rubric won't catch it, but a human
+  reading the description and then the knowledge will.
+
+## What excellence looks like — skills
+
+An excellent skill has:
+
+- **A lean shell.** `SKILL.md` is the always-loaded entry point.
+  Anything that doesn't need to be in context on every activation
+  belongs in `references/`, `scripts/`, or `templates/`. The
+  hard ceiling is ~500 lines; below that, less is usually better.
+- **Activation criteria stated explicitly.** "This skill
+  activates when…" or equivalent in the body. Helps the model
+  know whether to route here AND helps the human reviewer
+  understand the skill's scope.
+- **Progressive disclosure with explicit triggers.** Not "see
+  `references/` for details" but "if the API returns a non-200
+  status, read `references/api-errors.md`". The agent needs to
+  know *when* to load each deeper file.
+- **Process, not expertise.** Skills define HOW. Domain judgment
+  ("which approach is better for our codebase?") belongs in an
+  agent the skill can spawn. A skill that prescribes "this is
+  the right way to architect X" is doing an agent's job.
+- **The two-phase API where it applies.** For skills with side
+  effects, get-questions / execute keeps the user in the loop
+  about what's about to happen. Side effects in the questions
+  phase is a serious bug — see `agent-manager`, `memento`, and
+  `plugin-manager` for the pattern done right.
+- **Scripts that earn their place.** Bundled scripts should
+  encapsulate repeated logic; a script with one caller and no
+  reuse story is suspect. Scripts must carry SPDX headers, type
+  hints on public functions, and the `if __name__ == "__main__"`
+  pattern.
+
+### What to flag on skills
+
+- **Quality judgments inline.** A skill that says "look for SQL
+  injection, verify authentication checks" is putting expertise
+  where process should be. The fix is to spawn a security-review
+  agent whose knowledge covers those heuristics.
+- **Menus instead of defaults.** "You can use pypdf, pdfplumber,
+  PyMuPDF, or pdf2image" pushes decisions onto the agent and
+  produces inconsistent runs. Pick one.
+- **Specifics instead of procedures.** "Join orders to customers
+  on customer_id" only works for one task. "Find the relevant
+  tables in the schema, join on the `_id` foreign-key
+  convention" works for any analytical query.
+- **Missing gotchas.** If the skill operates against a system
+  with non-obvious behavior (soft deletes, ambiguous IDs,
+  health-vs-ready endpoints) and the gotchas aren't enumerated,
+  the agent will make those mistakes. Every correction that
+  comes back during dogfooding is a candidate gotcha.
+
+## What excellence looks like — plugins
+
+An excellent plugin has:
+
+- **Complete metadata.** `plugin.json` has `name`, `description`
+  (substantive, not a single phrase), `version`, `author`,
+  `repository`. `LICENSE`, `AUTHORS`, and `REUSE.toml` exist.
+  CI workflow + version-check workflow + CHANGELOG following
+  Keep-a-Changelog.
+- **Agents and skills that themselves score well.** A plugin's
+  grade is partly a roll-up of its parts. A plugin shipping three
+  agents and four skills where one agent is excellent and the
+  rest are C-grade isn't excellent overall.
+- **No name collisions.** Agents and skills inside the plugin
+  don't conflict with anything else commonly installed.
+- **Plugin-level docs follow the progressive-disclosure pattern.**
+  README and CLAUDE.md route to deeper docs rather than inlining
+  them.
+
+## Cross-cutting failure modes the LLM should catch
+
+These are the kinds of issues the structural rubric tends to miss
+but that significantly degrade extension quality:
+
+### Semantic mismatch
+
+The description claims one thing; the content does another. An
+agent described as "frontend architecture expert" with knowledge
+files about backend API patterns. A skill described as "PR review"
+that's actually a deploy workflow. The structural rubric can't
+catch this; reading the artifact does.
+
+When you see this, score it harshly. Misleading descriptions
+cause activation failures in production.
+
+### Knowledge that overlaps without acknowledging the overlap
+
+Two knowledge files in the same agent that cover the same topic
+from slightly different angles. The agent probably built them
+incrementally and never reconciled. The fix is consolidation, not
+cross-references — cross-references multiply the load cost. Flag
+overlap and recommend consolidating, naming the specific files.
+
+### Activation triggers that don't trigger
+
+The description says "activates when reviewing PRs" but uses
+phrasing that doesn't match how users actually ask for PR
+reviews. Look at the description with a user's hat on: would
+someone naturally produce a sentence that matches these
+keywords?
+
+### Tool scope that doesn't fit the work
+
+An agent with `allowed-tools: *` whose knowledge only covers
+read-only research. An agent with narrowly scoped tools whose
+SKILL.md prescribes operations the tools can't perform. The
+mismatch produces silent failures.
+
+### Iteration debt
+
+A knowledge file with a "TODO: expand this section" comment from
+six months ago. A skill with a half-implemented feature. A
+gotchas list with one entry, suggesting the author started the
+list and walked away. These don't fail the rubric, but they
+signal that the author lost interest before the extension was
+done. Score them down and note specifically what looks
+unfinished.
+
+## How to write the review
+
+The deterministic rubric gives you a score, findings (severity +
+file:line + rule), and a letter grade. Your job is the *narrative
+critique* on top. Write 2–4 paragraphs that:
+
+1. **Reinforce or push back on the deterministic score.** If the
+   rubric gave it an A but the description is a generic phrase,
+   say so. The structural score is canonical for CI; your job is
+   to be the second pair of eyes for the human reviewer.
+2. **Cluster the findings.** If three rubric findings all point
+   at one root cause, name it. "All three findings about the
+   knowledge directory cluster around the fact that
+   `knowledge/index.md` doesn't actually index the new files."
+3. **Surface what the rubric can't see.** Semantic mismatch,
+   overlap, iteration debt, misleading descriptions.
+4. **Recommend a concrete next action** — "consolidate X and Y",
+   "rewrite the description to name the actual activation
+   scenarios", "drop the menu and pick a default" — not generic
+   advice.
+
+Cite `file:line` whenever possible. Avoid "this could be better"
+verdicts; say what specifically is wrong and what good would look
+like.
+
+### Tone
+
+Be honest. The structural rubric is forgiving by design; your job
+is to be the more candid reviewer. But honesty isn't cruelty —
+the goal is to make the extension better, not to demoralize the
+author. A useful critique always points at the fix.
+
+## Anti-patterns specific to LLM-grading
+
+When the LLM does Phase 2 review, common failure modes to avoid:
+
+- **Grading on prose quality of the SKILL.md.** Skills aren't
+  essays. Choppy, terse instructions often work better than
+  flowing prose. Don't penalize directness.
+- **Penalizing brevity.** A 200-line SKILL.md that does its job
+  cleanly is excellent. Don't recommend padding.
+- **Recommending more options.** Defaults beat menus. If the
+  skill picks one approach, that's usually correct — don't
+  suggest "you could also support X, Y, Z."
+- **Conflating structural rules with quality.** The Phase 1
+  rubric handles "has SPDX header", "has frontmatter", etc. Your
+  Phase 2 review should focus on things Phase 1 can't measure.
+
+## Calibration notes
+
+When grading on the 0–100 scale:
+
+- **90–100 (A):** This is what you'd point to as an example of
+  how to write the extension type. Few or no findings; what
+  findings exist are minor polish.
+- **80–89 (B):** Solid work. A few real issues that warrant
+  fixing but the extension is usable as-is.
+- **70–79 (C):** Adequate. Multiple real issues; the extension
+  works but a reviewer would push back on shipping it.
+- **60–69 (D):** Needs work. Structural or qualitative issues
+  serious enough that a user trying to learn from this extension
+  would learn the wrong lessons.
+- **<60 (F):** Recommend rewrite. The artifact isn't doing what
+  it claims, or the architecture is fundamentally wrong.
+
+Don't grade-inflate. A C is fine — most extensions are C-grade
+when first reviewed. The review skill exists to help authors get
+to B.
+
+## Source materials
+
+This rubric draws on principles from
+<https://agentskills.io/skill-creation/best-practices>,
+<https://agentskills.io/skill-creation/evaluating-skills>, and our
+own `framework-design-principles.md`. See
+`agents/claude-code-expert/knowledge/external-references.md` for
+the full upstream source list.

--- a/agents/claude-code-expert/knowledge/framework-design-principles.md
+++ b/agents/claude-code-expert/knowledge/framework-design-principles.md
@@ -79,6 +79,16 @@ workflows with Python scripts, Jinja2 templates, and reference documentation.
 - Domain expertise ("why X is better than Y")
 - Quality judgments (that belongs in Agents)
 
+**On divergence with agentskills.io:** the broader Agent Skills
+ecosystem is looser about this line — community examples often put
+quality heuristics directly in skills (e.g., a code-review skill
+that prescribes "check for SQL injection"). We keep the line bright
+because the AIDA framework scales better when skills are reusable
+process and agents carry the domain expertise. A code-review *skill*
+should spawn a code-review *agent* whose knowledge enumerates the
+heuristics. This means our skills are more portable across domains;
+their skills are more self-contained but less composable.
+
 **Analogy:** A recipe combined with kitchen tools. The skill defines the process
 ("mix ingredients, bake at 350") and provides the automation to execute it.
 

--- a/agents/claude-code-expert/knowledge/index.md
+++ b/agents/claude-code-expert/knowledge/index.md
@@ -135,6 +135,56 @@ Contains:
 - Security considerations
 - Common patterns (formatting, logging, blocking, quality gates)
 
+### skill-authoring-patterns.md
+
+**When to use:** Writing a new skill body, reviewing an existing
+skill for quality, deciding how loose vs. how prescriptive a
+workflow should be
+
+Contains:
+
+- Spend the agent's context wisely (add what it lacks, omit what it
+  knows)
+- Calibrate control to task fragility (freedom vs. prescriptive)
+- Provide defaults, not menus
+- Favor procedures over declarations
+- Gotchas sections — the highest-value content in many skills
+- Output templates, checklists, validation loops, plan-validate-execute
+- Bundling reusable scripts
+- AIDA-specific patterns (two-phase API, atomic primitives, knowledge
+  with the agent)
+
+### skill-iteration.md
+
+**When to use:** Authoring a new skill, troubleshooting a skill that
+fails inconsistently, deciding whether a skill needs evals
+
+Contains:
+
+- Start from real expertise (extract from a hands-on task or
+  synthesize from project artifacts)
+- Refine with real execution (read execution traces, not just
+  outputs)
+- When evals pay off and when they're overkill
+- The iteration loop in compressed form
+- How to prompt an LLM to propose revisions
+
+### evaluating-extensions.md
+
+**When to use:** When the review skill's Phase 2 LLM grading runs;
+this is the reasoning context that informs the narrative critique
+
+Contains:
+
+- The three-phase review model (deterministic / LLM / behavioral)
+- What "excellent" looks like per extension type (agents, skills,
+  plugins)
+- Cross-cutting failure modes the LLM should catch (semantic
+  mismatch, overlapping knowledge, missing gotchas, iteration debt)
+- How to write the narrative review
+- Anti-patterns specific to LLM grading
+- Calibration notes for the A–F scale
+
 ### external-references.md
 
 **When to use:** When rebuilding or refreshing this agent's knowledge
@@ -184,6 +234,19 @@ Contains:
 | "How do I auto-format code?"                    | hooks.md                        |
 | "How do I block dangerous operations?"          | hooks.md                        |
 | "What lifecycle events exist?"                  | hooks.md                        |
+| "How do I write a good skill body?"             | skill-authoring-patterns.md     |
+| "When should the agent have freedom vs. prescription?" | skill-authoring-patterns.md |
+| "What's a gotchas section?"                     | skill-authoring-patterns.md     |
+| "Defaults vs menus?"                            | skill-authoring-patterns.md     |
+| "Procedures vs declarations?"                   | skill-authoring-patterns.md     |
+| "Plan-validate-execute pattern?"                | skill-authoring-patterns.md     |
+| "How do skills get good?"                       | skill-iteration.md              |
+| "How do I iterate on a skill?"                  | skill-iteration.md              |
+| "When should I add evals?"                      | skill-iteration.md              |
+| "How do I read execution traces?"               | skill-iteration.md              |
+| "How does the review skill grade extensions?"   | evaluating-extensions.md        |
+| "What does 'excellent' look like for X?"        | evaluating-extensions.md, framework-design-principles.md |
+| "What should the LLM reviewer catch?"           | evaluating-extensions.md        |
 
 ## External Resources
 

--- a/agents/claude-code-expert/knowledge/skill-authoring-patterns.md
+++ b/agents/claude-code-expert/knowledge/skill-authoring-patterns.md
@@ -1,0 +1,302 @@
+---
+type: reference
+name: skill-authoring-patterns
+title: Skill Authoring Patterns
+description: Reusable patterns for writing skills that calibrate control to task fragility, include gotchas, and use templates / checklists / validation loops where they actually pay off.
+version: "1.0.0"
+---
+
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# Skill Authoring Patterns
+
+How to write skill bodies that get the agent to do useful work
+reliably. These patterns come from the agentskills.io community
+documentation, framed against our WHO/HOW/CONTEXT architecture and
+the lessons baked into the existing knowledge files.
+
+**When to use this file:** authoring a new skill, reviewing an
+existing one for quality, deciding whether a workflow needs explicit
+structure or can stay loose.
+
+## Spend the agent's context wisely
+
+Once a skill activates, its full SKILL.md body lands in the agent's
+context window alongside conversation history, system context, and
+every other active skill. Every token competes for the agent's
+attention.
+
+**Add what the agent lacks; omit what it knows.** Project-specific
+conventions, domain-specific procedures, the particular tools or
+APIs to use — these are signal. General programming knowledge ("PDFs
+are a common file format", "HTTP requests can fail") is noise. Cut
+anything that wouldn't change the agent's behavior if removed.
+
+For each piece of content, ask: *Would the agent get this wrong
+without this instruction?* If the answer is no, cut it. If unsure,
+test it.
+
+Skills that don't change the agent's behavior aren't pulling their
+weight. If the agent already does the task well without the skill,
+the skill isn't earning its tokens.
+
+## Calibrate control to task fragility
+
+Not every part of a skill needs the same level of prescriptiveness.
+Match specificity to fragility.
+
+**Give the agent freedom** when multiple approaches are valid and
+the task tolerates variation. Explaining *why* tends to work better
+than rigid directives — an agent that understands the purpose makes
+better context-dependent decisions. A code-review skill can describe
+what to look for without prescribing exact steps:
+
+```markdown
+Check all database queries for SQL injection (use parameterized queries).
+Verify authentication checks on every endpoint.
+Look for race conditions in concurrent code paths.
+```
+
+**Be prescriptive** when operations are fragile, consistency
+matters, or a specific sequence must be followed:
+
+````markdown
+## Database migration
+
+Run exactly this sequence:
+
+```bash
+python scripts/migrate.py --verify --backup
+```
+
+Do not modify the command or add additional flags.
+````
+
+Most skills have a mix. Calibrate each part independently.
+
+## Provide defaults, not menus
+
+When multiple tools or approaches could work, pick a default and
+mention alternatives briefly. Don't present them as equal options.
+
+```markdown
+<!-- Too many options — agent has to choose, often gets it wrong -->
+You can use pypdf, pdfplumber, PyMuPDF, or pdf2image...
+
+<!-- Clear default with an escape hatch -->
+Use pdfplumber for text extraction. For scanned PDFs requiring OCR,
+use pdf2image with pytesseract instead.
+```
+
+A menu of equally-weighted options shifts the decision burden onto
+the agent and produces inconsistent results across runs. Pick the
+right call once, in the skill, where reviewers can argue about it.
+
+## Favor procedures over declarations
+
+A skill should teach the agent *how to approach* a class of problems,
+not *what to produce* for a specific instance.
+
+```markdown
+<!-- Specific answer — only useful for this exact task -->
+Join the `orders` table to `customers` on `customer_id`, filter
+where `region = 'EMEA'`, and sum the `amount` column.
+
+<!-- Reusable method — works for any analytical query -->
+1. Read the schema from `references/schema.yaml` to find relevant tables
+2. Join tables using the `_id` foreign key convention
+3. Apply any filters from the user's request as WHERE clauses
+4. Aggregate numeric columns as needed and format as a markdown table
+```
+
+This doesn't mean skills can't include specifics — output format
+templates, hard constraints ("never log PII"), and tool-specific
+instructions all belong. The point is that the *approach* should
+generalize even when individual details are pinned down.
+
+## Gotchas sections
+
+The highest-value content in many skills is a list of gotchas —
+environment-specific facts that defy reasonable assumptions. These
+aren't general advice ("handle errors appropriately"); they're
+concrete corrections to mistakes the agent will make without being
+told otherwise:
+
+```markdown
+## Gotchas
+
+- The `users` table uses soft deletes. Queries must include
+  `WHERE deleted_at IS NULL` or results will include deactivated
+  accounts.
+- The user ID is `user_id` in the database, `uid` in the auth
+  service, and `accountId` in the billing API. All three refer to
+  the same value.
+- The `/health` endpoint returns 200 as long as the web server is
+  running, even if the database connection is down. Use `/ready`
+  to check full service health.
+```
+
+Keep gotchas in SKILL.md, not in a `references/` file. The agent
+needs to read them *before* encountering the situation. A separate
+file works only if the SKILL.md tells the agent precisely when to
+load it — and for surprises, the agent often won't recognize the
+trigger until it has already gone wrong.
+
+**When the agent makes a mistake you have to correct, that's a new
+gotcha.** This is the most direct way to improve a skill: every
+correction is a candidate for the gotchas list.
+
+## Output templates
+
+When the agent needs to produce output in a specific format, provide
+a template. Agents pattern-match against concrete structures much
+more reliably than they follow prose descriptions of structure.
+
+Short templates inline:
+
+````markdown
+## Report structure
+
+Use this template, adapting sections as needed:
+
+```markdown
+# [Analysis Title]
+
+## Executive summary
+[One-paragraph overview of key findings]
+
+## Key findings
+- Finding 1 with supporting data
+
+## Recommendations
+1. Specific actionable recommendation
+```
+````
+
+Long templates in `assets/` or `templates/`, referenced from
+SKILL.md so they only load when needed.
+
+## Checklists for multi-step workflows
+
+An explicit checklist helps the agent track progress and avoid
+skipping steps, especially when steps have dependencies or
+validation gates:
+
+```markdown
+## Form processing workflow
+
+Progress:
+- [ ] Step 1: Analyze the form (run `scripts/analyze_form.py`)
+- [ ] Step 2: Create field mapping (edit `fields.json`)
+- [ ] Step 3: Validate mapping (run `scripts/validate_fields.py`)
+- [ ] Step 4: Fill the form (run `scripts/fill_form.py`)
+- [ ] Step 5: Verify output (run `scripts/verify_output.py`)
+```
+
+The checkbox syntax invites the agent to walk through the steps in
+order and report status, rather than jumping ahead.
+
+## Validation loops
+
+Instruct the agent to validate its own work before moving on.
+Pattern: do the work, run a validator (script, reference checklist,
+or self-check), fix any issues, and repeat until validation passes.
+
+```markdown
+## Editing workflow
+
+1. Make your edits
+2. Run validation: `python scripts/validate.py output/`
+3. If validation fails:
+   - Review the error message
+   - Fix the issues
+   - Run validation again
+4. Only proceed when validation passes
+```
+
+A reference document can serve as the "validator" — instruct the
+agent to check its work against the reference before finalizing.
+
+## Plan-validate-execute
+
+For batch or destructive operations, have the agent create an
+intermediate plan in a structured format, validate it against a
+source of truth, and only then execute.
+
+```markdown
+## PDF form filling
+
+1. Extract form fields: `python scripts/analyze_form.py input.pdf`
+   → `form_fields.json` (lists every field name, type, required-ness)
+2. Create `field_values.json` mapping each field name to its
+   intended value
+3. Validate: `python scripts/validate_fields.py form_fields.json
+   field_values.json` (checks every field name exists, types match,
+   required fields aren't missing)
+4. If validation fails, revise `field_values.json` and re-validate
+5. Fill the form: `python scripts/fill_form.py input.pdf
+   field_values.json output.pdf`
+```
+
+The load-bearing step is step 3: a validator that checks the plan
+against the source of truth. Errors like *"Field 'signature_date'
+not found — available fields: customer_name, order_total,
+signature_date_signed"* give the agent enough information to
+self-correct without guessing.
+
+This is similar to the **get-questions / execute** two-phase
+pattern AIDA uses for skills like `agent-manager` and `memento`,
+but with three phases: gather inputs → validate against source of
+truth → execute. Use plan-validate-execute when the cost of an
+error is high enough to justify the validation overhead.
+
+## Bundling reusable scripts
+
+If you find the agent independently reinventing the same logic each
+run — building a chart, parsing a specific format, validating output
+— bundle the script into the skill's `scripts/` directory once and
+have the SKILL.md reference it.
+
+Heuristic: if it appears in three skill runs in roughly the same
+form, it should be a script. Two is a coincidence; three is a
+pattern; four is wasted tokens.
+
+## Patterns we use here
+
+Beyond the agentskills.io patterns, the existing AIDA skills lean
+heavily on:
+
+- **Two-phase API** — get-questions then execute. The skill asks
+  any clarifying questions first (returns them as a structured
+  list), then executes once the answers are in. Side-effects only
+  ever happen in execute. See `agent-manager`, `memento`,
+  `plugin-manager`.
+- **Atomic primitives** — when a skill writes multiple related
+  files, the I/O primitive enforces atomicity rather than relying
+  on the skill body to remember the right order. See
+  `decisions_log.write_decisions` (#144) for the canonical
+  example: writes JSON and regenerates Markdown in one call; no
+  exported way to write one without the other.
+- **Knowledge with the agent, process with the skill** — when an
+  LLM workflow needs reasoning context, the skill loads it from
+  the relevant agent's knowledge directory rather than embedding
+  the context in the skill. Lets the agent be refreshed without
+  rebuilding the skill.
+
+## What this doesn't replace
+
+The architectural decisions about *which* extension type to create,
+*what* should live in a skill vs. an agent vs. knowledge, and *how*
+to organize a plugin remain in `framework-design-principles.md` and
+`extension-types.md`. This file is about how to write the body of a
+skill once you know that a skill is the right tool.
+
+## Source materials
+
+These patterns are synthesized from
+<https://agentskills.io/skill-creation/best-practices> and adapted
+to the AIDA framework. See
+`agents/claude-code-expert/knowledge/external-references.md` for
+the full list of upstream sources informing this agent's
+knowledge.

--- a/agents/claude-code-expert/knowledge/skill-iteration.md
+++ b/agents/claude-code-expert/knowledge/skill-iteration.md
@@ -1,0 +1,198 @@
+---
+type: reference
+name: skill-iteration
+title: How Skills Get Good
+description: The iteration loop that produces quality skills — start from real expertise, refine with real execution, read traces not just outputs. Where evals fit and what they're for.
+version: "1.0.0"
+---
+
+<!-- SPDX-FileCopyrightText: 2026 The AIDA Core Authors -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# How Skills Get Good
+
+A skill that just works on the first try is rare. The skills that
+work *reliably* — across varied prompts, in edge cases, better than
+no skill at all — got there through iteration.
+
+**When to use this file:** authoring a new skill, troubleshooting a
+skill that fails inconsistently, deciding whether to add evals,
+reviewing whether a skill is ready to ship.
+
+## Start from real expertise
+
+The common pitfall in skill creation is asking an LLM to generate a
+skill from a one-line description, relying on its training-data
+generalities. The result is vague, generic procedures ("handle
+errors appropriately", "follow best practices") rather than the
+specific API patterns, edge cases, and project conventions that
+make a skill actually useful.
+
+Effective skills are grounded in real, hands-on, project-specific
+expertise. Two ways to ground them:
+
+### Extract from a hands-on task
+
+Do the task with an agent in conversation, providing context,
+corrections, and preferences as you go. When the task succeeds,
+extract the reusable pattern into a skill. Pay attention to:
+
+- **Steps that worked** — the sequence of actions that led to success
+- **Corrections you made** — places where you steered the agent away
+  from a wrong approach. Each correction is a candidate gotcha.
+- **Input/output formats** — what the data looked like going in and
+  coming out
+- **Project-specific context you provided** — facts, conventions,
+  or constraints the agent didn't already know
+
+A skill written from one successful run usually beats one written
+from "what skills like this typically look like".
+
+### Synthesize from existing project artifacts
+
+When the project already has accumulated knowledge — runbooks,
+incident reports, code review comments, style guides, schemas — feed
+those into the synthesis instead of relying on generic references.
+
+Good source material includes:
+
+- Internal documentation, runbooks, and style guides
+- API specifications, schemas, and configuration files
+- Code review comments and issue trackers (captures recurring
+  concerns and reviewer expectations)
+- Version control history, especially patches and fixes — reveals
+  patterns through what actually changed
+- Real-world failure cases and their resolutions
+
+A data-pipeline skill synthesized from your team's actual incident
+reports will outperform one synthesized from a generic "data
+engineering best practices" article, because it captures *your*
+schemas, failure modes, and recovery procedures.
+
+## Refine with real execution
+
+The first draft of a skill usually needs refinement. Run the skill
+against real tasks, then feed the results — all of them, not just
+failures — back into the next revision. Ask:
+
+- What triggered false positives?
+- What was missed?
+- What could be cut?
+
+Even one pass of execute-then-revise noticeably improves quality.
+Complex domains often benefit from several.
+
+### Read execution traces, not just final outputs
+
+The final output tells you whether the skill produced something
+acceptable. The execution trace tells you *why*. Common signals in
+traces:
+
+- **Agent tries several approaches before finding one that works**
+  — instructions are too vague; pick a default
+- **Agent follows an instruction that doesn't apply to the current
+  task** — instructions are over-eager; scope them or remove them
+- **Agent waffles between options presented in the skill** — too
+  many options, not enough opinion
+- **Agent independently re-implements the same logic across runs**
+  — that logic should be a bundled script
+
+Traces are where the real iteration happens. Look at them.
+
+## Evals — when and what for
+
+Evals are how you stop relying on vibes for "is this skill good?"
+The agentskills.io community has a working methodology that's
+documented in our planning at `docs/proposals/review-skill.md`
+under Phase 3. The pattern:
+
+1. Write 2–3 test cases as realistic user prompts in
+   `evals/evals.json` inside the skill directory. Each test case
+   has a prompt, an expected-output description, and optional input
+   files.
+2. Run each prompt twice — once **with the skill** and once
+   **without it** (or with the previous version). The delta is
+   what tells you the skill is contributing.
+3. After the first run, write assertions. Good assertions are
+   verifiable ("the output is valid JSON", "the chart has labeled
+   axes"). Bad assertions are vague ("the output is good") or
+   brittle ("uses exactly the phrase 'Total Revenue'").
+4. Grade each assertion against actual outputs, requiring evidence
+   for a PASS. A section titled "Summary" with one vague sentence
+   is not a PASS for "includes a summary" — the label is there but
+   the substance isn't.
+5. Aggregate pass-rate, timing, and tokens across runs. The delta
+   between with-skill and without-skill tells you the cost and
+   value.
+
+### When evals pay off
+
+- **The skill is shipped to other users** — you can't rely on
+  catching regressions during dogfooding
+- **The skill has subtle output requirements** — what counts as
+  "good" varies enough that assertions help you stay honest
+- **You're iterating on the skill** — evals let you compare
+  versions empirically instead of reasoning about which one feels
+  better
+
+### When evals are overkill
+
+- **The skill is a thin wrapper around a script that already has
+  unit tests** — the script's tests cover the behavior; an
+  end-to-end eval adds little
+- **The skill is a one-off internal workflow** — the cost of
+  setting up evals exceeds the value of the marginal quality
+  improvement
+- **The output is so structured that diffing it across versions
+  is enough** — assertions duplicate effort
+
+The review skill (`#146`) is meant to incorporate behavioral evals
+as Phase 3 of its scoring, so when it lands, the question becomes
+"do you ship evals?" rather than "do you write them by hand?".
+
+## The iteration loop in compressed form
+
+```text
+1. Draft the skill from real expertise (extract from a task or
+   synthesize from artifacts)
+2. Run it on a few prompts and read the traces
+3. Note what went wrong + what was wasted effort
+4. Revise: add a gotcha, tighten an instruction, bundle a script,
+   pick a default instead of a menu
+5. Re-run. Did the trace get cleaner?
+6. Repeat until traces are boring and outputs are consistent.
+```
+
+Stop when you're satisfied with results, feedback is consistently
+empty, or you're no longer seeing meaningful improvement between
+iterations. Over-iterating produces skills that are over-constrained
+and brittle.
+
+## A note on prompting an LLM to revise the skill
+
+If you ask an LLM to propose revisions based on failed assertions
+and execution traces, prime it with these guidelines:
+
+- **Generalize from feedback.** A skill will be used across many
+  prompts, not just the test cases. Fixes should address
+  underlying issues broadly, not patch each example individually.
+- **Keep the skill lean.** Fewer, better instructions often
+  outperform exhaustive rules. If transcripts show wasted work,
+  remove instructions, not add them.
+- **Explain the why.** Reasoning-based instructions ("Do X
+  because Y tends to cause Z") work better than rigid directives
+  ("ALWAYS do X, NEVER do Y"). Models follow instructions more
+  reliably when they understand the purpose.
+
+## Source materials
+
+The structured approach in this file is synthesized from
+<https://agentskills.io/skill-creation/evaluating-skills> and
+<https://agentskills.io/skill-creation/best-practices>, adapted to
+the AIDA framework. The detailed eval methodology — including the
+`evals/evals.json` schema, with/without baseline runs, assertion
+grading, and benchmark aggregation — lives upstream and is
+mirrored into the review skill design in
+`docs/proposals/review-skill.md`. See
+`agents/claude-code-expert/knowledge/external-references.md` for
+the full upstream source list.

--- a/agents/claude-code-expert/knowledge/skills.md
+++ b/agents/claude-code-expert/knowledge/skills.md
@@ -532,6 +532,12 @@ modifying any files.
 
 ## Best Practices
 
+> **See also:** `skill-authoring-patterns.md` for deeper authoring
+> patterns — gotchas sections, calibrated control, defaults vs.
+> menus, plan-validate-execute, output templates, validation
+> loops. And `skill-iteration.md` for the iteration loop that
+> takes a skill from "works once" to "works reliably".
+
 ### Naming
 
 - Use lowercase kebab-case: `fix-issue`, `deploy-staging`

--- a/agents/claude-code-expert/knowledge/sources.yml
+++ b/agents/claude-code-expert/knowledge/sources.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2026 The AIDA Core Authors
+# SPDX-License-Identifier: MPL-2.0
+#
+# Knowledge sources for the claude-code-expert agent.
+#
+# Two top-level blocks:
+#   - roots:   Spider starting points for `/aida knowledge discover`.
+#              Walked sitemap-first; URLs that aren't already in
+#              decisions.json get added there as `status: pending`
+#              for the curator workflow.
+#   - sources: Explicit sync targets. Hand-curated entries (local
+#              files, hand-picked URLs). Sync also reads in-use
+#              entries from decisions.json and merges them with this
+#              list.
+#
+# Initial population: external-references.md lists the upstream URLs
+# the agent's knowledge derives from. The three URLs below seed the
+# spider for ongoing refreshes; once Anthropic's docs gain a sitemap
+# the recursive crawl will pull only what robots.txt permits.
+---
+version: "1.0.0"
+
+roots:
+  - url: https://agentskills.io/
+    name: agentskills
+    max_depth: 2
+    max_urls: 50
+
+  # support.claude.com is a help-center route; the spider tries the
+  # site's sitemap first. Limited depth so we don't pull marketing
+  # pages.
+  - url: https://support.claude.com/
+    name: claude-support
+    max_depth: 1
+    max_urls: 30
+
+sources: []


### PR DESCRIPTION
## Summary

Closes #145. Brings the `claude-code-expert` agent's knowledge up to date with the agentskills.io best-practices coverage identified during review-skill planning. Three new knowledge files synthesize the upstream concepts and adapt them to AIDA's WHO/HOW/CONTEXT framework. Plus a `sources.yml` configuration that makes the agent the first working consumer of #144's discover/curate pipeline.

## What's in the PR

### Three new knowledge files (synthesized prose)

- **`skill-authoring-patterns.md`** — gotchas, calibrated control (freedom vs. prescription), defaults-not-menus, procedures-over-declarations, output templates, checklists, validation loops, plan-validate-execute, bundling reusable scripts. Closes with AIDA-specific patterns (two-phase API, atomic primitives, knowledge-with-the-agent).
- **`skill-iteration.md`** — start from real expertise (extract from a hands-on task, synthesize from project artifacts), refine with real execution (read traces, not just outputs), when evals pay off, the iteration loop in compressed form.
- **`evaluating-extensions.md`** — reasoning context for the review skill's Phase 2 LLM grading (#146). Per-type excellence criteria, cross-cutting failure modes (semantic mismatch, overlapping knowledge, missing gotchas, iteration debt), calibration notes for the A–F scale, anti-patterns for the LLM reviewer.

These are **synthesized** — not vendored upstream content. They adapt agentskills.io concepts to our framework, note divergences explicitly, and cross-link to existing knowledge.

### Existing-file refresh (light touches)

- **`framework-design-principles.md`** — explicit note on our divergence from agentskills.io on \"quality belongs in agents, not skills\" (we keep the line bright; they don't)
- **`skills.md`** — cross-link to the new authoring-patterns and iteration files at the top of Best Practices
- **`index.md`** — three new files registered with \"when to use\" entries; Quick Reference table expanded with 14 new question→file mappings

### `sources.yml` for future automated refreshes

- **`roots:` configured** for agentskills.io and support.claude.com. Running `/aida knowledge discover claude-code-expert` (after this lands) walks those sitemaps and writes candidate URLs as pending decisions for the curator. The agent becomes the first working consumer of the #144 pipeline.

## Why this matters for the chain

- **Unblocks #146 (review skill)** — Phase 2 LLM grading now has the reasoning context it needs
- **Dogfoods #144** — discover/curate workflow has a real downstream user; the next refresh can be driven by the spider rather than hand-authored
- **Notes the divergence inline** — future contributors see the AIDA-vs-agentskills.io rationale rather than silently inheriting either school's conventions

## Test plan

- [x] All three new files have valid frontmatter, SPDX headers
- [x] `sources.yml` parses cleanly through `spider.parse_roots(...)` (verified locally)
- [x] Existing knowledge files preserved verbatim outside the two small edits called out above
- [x] Full suite: 1171 passing locally
- [x] ruff / yamllint / frontmatter / REUSE all clean locally

Closes #145