### PR TITLE
fix(skills): scope AIDA sub-skills behind /aida, stop /permissions shadowing (1.5.35)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aida-core",
   "description": "Foundation plugin for building your custom Claude Code experience. Extension scaffolding, multi-level configuration, and structured session context.",
-  "version": "1.5.34",
+  "version": "1.5.35",
   "author": {
     "name": "oakensoul",
     "email": "github@oakensoul.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,43 @@ All notable changes to AIDA Core Plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.35] - 2026-06-13
+
+### Fixed
+
+- **AIDA skills no longer shadow Claude Code's built-in slash
+  commands** — every sub-skill was registered as its own
+  top-level slash command (the `user-invocable` field defaults to
+  `true`), so the skill literally named `permissions` collided
+  with the built-in `/permissions` command and intermittently
+  intercepted it instead of letting the native command fire
+  (reported by Mark via Slack). All 10 sub-skills now set
+  `user-invocable: false`, leaving `/aida` as the single
+  user-facing entry point. The sub-skills remain reachable through
+  `/aida <thing>` routing because `user-invocable: false` only
+  hides a skill from the `/` menu — it does not block Skill-tool
+  invocation by the `aida` router
+- **`plugin-manager` frontmatter** — corrected `argument_hint`
+  (underscore) to the canonical `argument-hint` (hyphen) so the
+  field is actually recognized
+
+### Changed
+
+- **Sub-skill descriptions rewritten for routing precision** —
+  each description now leads with the concrete AIDA-scoped action,
+  anchors invocation to `/aida`, and adds an explicit negative
+  boundary so the model stops auto-routing generic requests into
+  AIDA skills (e.g. the `permissions` description now explicitly
+  defers ad-hoc permission edits and the built-in `/permissions`
+  command to native Claude Code). Applies to `permissions`,
+  `agent-manager`, `skill-manager`, `plugin-manager`,
+  `hook-manager`, `claude-md-manager`, `memento`, and
+  `expert-registry`
+- **`aida` skill description** — now enumerates all routed
+  sub-skills (added `permissions`, `expert-registry`,
+  `knowledge-sync`, `knowledge-curator`) and states that it is the
+  single entry point and the sub-skills are not directly invocable
+
 ## [1.5.34] - 2026-05-28
 
 ### Added

--- a/skills/agent-manager/SKILL.md
+++ b/skills/agent-manager/SKILL.md
@@ -3,10 +3,13 @@ type: skill
 name: agent-manager
 title: Agent Manager
 description: >-
-  Manages Claude Code agent (subagent) definitions including
-  create, validate, version, and list operations using a
-  two-phase API.
+  Create, validate, version, and list AIDA-managed Claude Code
+  subagent definition files (two-phase API). Use for CRUD on agent
+  .md definitions, routed through /aida extension management. Do
+  NOT use to run, dispatch, or consult a subagent — this only
+  authors and maintains the definition files.
 version: 0.1.0
+user-invocable: false
 tags:
   - core
   - management

--- a/skills/aida/SKILL.md
+++ b/skills/aida/SKILL.md
@@ -3,8 +3,11 @@ type: skill
 name: aida
 description: This skill routes /aida commands to appropriate handlers - configuration,
   diagnostics, feedback, extension management (agent-manager, skill-manager,
-  plugin-manager, hook-manager, claude-md-manager), and session persistence
-  (memento).
+  plugin-manager, hook-manager, claude-md-manager, permissions), expert and
+  panel configuration (expert-registry), agent knowledge management
+  (knowledge-sync, knowledge-curator), and session persistence (memento). This
+  is the single entry point for all AIDA operations - the sub-skills are not
+  directly invocable.
 version: 0.9.0
 tags:
   - core

--- a/skills/claude-md-manager/SKILL.md
+++ b/skills/claude-md-manager/SKILL.md
@@ -3,10 +3,13 @@ type: skill
 name: claude-md-manager
 title: CLAUDE.md Manager
 description: >-
-  Manages CLAUDE.md configuration files across project, user, and
-  plugin scopes using a two-phase API for create, optimize,
-  validate, and list operations.
+  Create, optimize, validate, and list CLAUDE.md memory files
+  across project, user, and plugin scopes (two-phase API), routed
+  through /aida. Use for structured CLAUDE.md management. Do NOT
+  use for a one-off manual edit to a single CLAUDE.md — edit that
+  file directly.
 version: 0.1.0
+user-invocable: false
 tags:
   - core
   - configuration

--- a/skills/expert-registry/SKILL.md
+++ b/skills/expert-registry/SKILL.md
@@ -2,12 +2,13 @@
 type: skill
 name: expert-registry
 description: >-
-  Manage expert agent activation and panel composition for
-  project and global scopes. Provides list, configure, and
-  panel operations for expert-based workflows like code review
-  and plan grading.
+  Configure AIDA expert-agent activation and panel composition for
+  project and global scopes (list, configure, panel operations),
+  routed through /aida. Use to set which experts/panels are active
+  for workflows like code review and plan grading. Do NOT use to
+  run a review or grading — this only manages the registry.
 version: 0.1.0
-user-invocable: true
+user-invocable: false
 argument-hint: "[list|list configure|panel list|panel create|panel remove]"
 tags:
   - core

--- a/skills/hook-manager/SKILL.md
+++ b/skills/hook-manager/SKILL.md
@@ -3,10 +3,13 @@ type: skill
 name: hook-manager
 title: Hook Manager
 description: >-
-  Manages Claude Code hook configurations in
-  settings.json files. Supports listing, adding,
-  removing, and validating lifecycle hooks.
+  List, add, remove, and validate Claude Code lifecycle hook
+  entries in settings.json, routed through /aida extension
+  management. Use for structured CRUD on the hooks block. For
+  general settings.json edits or other harness behavior changes,
+  use the native settings/config flow instead.
 version: 0.1.0
+user-invocable: false
 tags:
   - core
   - hooks

--- a/skills/knowledge-curator/SKILL.md
+++ b/skills/knowledge-curator/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   in-use or rejected based on the agent's purpose, or walks them
   interactively with a human for override.
 version: 0.1.0
-user-invocable: true
+user-invocable: false
 argument-hint: "[curate <agent>|review <agent>]"
 tags:
   - core

--- a/skills/knowledge-sync/SKILL.md
+++ b/skills/knowledge-sync/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   files. Supports local files and HTTP/HTTPS URLs, plus URL
   discovery via the sitemap-first spider.
 version: 0.3.0
-user-invocable: true
+user-invocable: false
 argument-hint: "[sync <agent>|status <agent>|discover <agent>]"
 tags:
   - core

--- a/skills/memento/SKILL.md
+++ b/skills/memento/SKILL.md
@@ -1,8 +1,13 @@
 ---
 type: skill
 name: memento
-description: Manages mementos for session persistence - save and restore context across /clear and /compact
+description: >-
+  Save and restore AIDA session mementos — structured context
+  snapshots that persist across /clear and /compact. Use when the
+  user runs /aida memento to capture or restore session state. Not
+  a general note-taking tool or long-term memory store.
 version: 0.1.0
+user-invocable: false
 tags:
   - core
   - memory

--- a/skills/permissions/SKILL.md
+++ b/skills/permissions/SKILL.md
@@ -2,10 +2,15 @@
 type: skill
 name: permissions
 description: >-
-  Interactive Claude Code permissions management - scans plugin
-  recommendations, presents categorized setup, and writes to
-  settings.json
+  Set up Claude Code permission rules from AIDA plugin
+  recommendations. Scans installed plugins' recommendedPermissions
+  and writes categorized allow/ask/deny rules to settings.json. Use
+  ONLY when the user runs /aida config permissions (setup or
+  --audit). Do NOT use for ad-hoc permission edits, allowing or
+  denying a single tool, or the built-in /permissions command —
+  those are handled natively by Claude Code, not by AIDA.
 version: 0.1.0
+user-invocable: false
 tags:
   - core
   - permissions

--- a/skills/plugin-manager/SKILL.md
+++ b/skills/plugin-manager/SKILL.md
@@ -3,10 +3,14 @@ type: skill
 name: plugin-manager
 title: Plugin Manager
 description: >-
-  Unified plugin management combining extension CRUD operations
-  (create, validate, version, list) with project scaffolding
+  Create, validate, version, list, and scaffold AIDA/Claude Code
+  plugin projects (two-phase API). Use for plugin authoring and
+  project scaffolding, routed through /aida extension management.
+  Do NOT use to install or enable a plugin in the user's Claude
+  Code session — this only authors plugin project files.
 version: 0.1.0
-argument_hint: "[operation] [args]"
+user-invocable: false
+argument-hint: "[operation] [args]"
 tags:
   - core
   - management

--- a/skills/skill-manager/SKILL.md
+++ b/skills/skill-manager/SKILL.md
@@ -2,8 +2,14 @@
 type: skill
 name: skill-manager
 title: Skill Manager
-description: Manages Claude Code skill definitions - create, validate, version, and list skills following the Agent Skills open standard.
+description: >-
+  Create, validate, version, and list Claude Code skill definition
+  files following the Agent Skills open standard (two-phase API).
+  Use for CRUD on skill files, routed through /aida extension
+  management. Do NOT use to execute a skill's behavior — this only
+  authors and maintains skill definitions.
 version: 0.1.0
+user-invocable: false
 tags:
   - core
   - management


### PR DESCRIPTION
## Problem

Mark flagged in Slack that AIDA core had a permissions bug that "blocks the actual permissions command from firing 100% of the time."

Root cause: every AIDA sub-skill was registered as its own top-level slash command (the `user-invocable` frontmatter field defaults to `true`). The skill literally named `permissions` therefore collided with Claude Code's built-in `/permissions` command and intermittently intercepted it instead of letting the native command fire. This was a whole *class* of exposure — all 11 skills were standalone `/` commands — `permissions` just happened to shadow a built-in.

## Change

Principle: **nothing in AIDA is a direct slash command except the single `/aida` entry point.**

- **`user-invocable: false`** on all 10 sub-skills (`permissions`, `agent-manager`, `skill-manager`, `plugin-manager`, `hook-manager`, `claude-md-manager`, `memento`, `expert-registry`, `knowledge-sync`, `knowledge-curator`). `aida` stays `user-invocable: true`.
  - This only hides them from the `/` menu; it does **not** block Skill-tool invocation, so `/aida <thing>` routing still reaches them. (Distinct from `disable-model-invocation`, which we deliberately did **not** set.)
- **Rewrote every sub-skill description** to lead with the concrete AIDA-scoped action, anchor invocation to `/aida`, and add an explicit negative boundary — so the model stops auto-routing generic requests (e.g. any "permissions" mention) into AIDA. The `permissions` description now explicitly defers ad-hoc edits and the built-in `/permissions` to native Claude Code.
- **`aida` description** updated to enumerate all routed sub-skills (it was missing `permissions`, `expert-registry`, `knowledge-sync`, `knowledge-curator`) and to state it is the single entry point.
- **Drive-by fix:** `plugin-manager` had `argument_hint` (underscore) instead of the canonical `argument-hint` (hyphen).

Version bumped `1.5.34 → 1.5.35`; CHANGELOG updated.

## Review

Reviewed by the `claude-code-expert` agent: **PASS** on the `user-invocable` semantics and description quality. The `aida`-description gap and the `argument_hint` typo it surfaced are folded into this PR. Two body-level nice-to-haves were noted and deferred:
- Some sub-skills have vague catch-all bullets in their `## Activation` sections (body-level, low risk — they load only after invocation is already decided).
- `memento` retains its intentional post-`/clear` suggestion behavior. That's model-invocation, not a slash command, so it's consistent with the single-`/aida`-entry-point goal; left as-is.

## Verification

- YAML frontmatter validated against the repo's yamllint config (line-length max 120; `truthy` allows `false`).
- Confirmed scope is frontmatter/docs only — no Python touched, so the test suite is unaffected. (Local `make lint`/`make test` need `make install` first; the venv isn't provisioned in this environment.)

## Also checked (no change needed)

Per a related ask, confirmed AIDA's scaffolding/config does **not** blanket-ignore `.claude/`: the scaffold templates ignore only `.claude/settings.local.json`, the extension template has no `.claude/` entry, and `/aida config`'s `ensure_gitignore_entry` adds only `.claude/aida-project-context.local.yml` (and won't create a `.gitignore` if one is absent). A regression test (`test_gitignore_does_not_blanket_ignore_claude_dir`) already locks this in.
